### PR TITLE
Let helpers answer requests, and authors choose

### DIFF
--- a/apps/api/src/konnekt/api/schemas.py
+++ b/apps/api/src/konnekt/api/schemas.py
@@ -16,7 +16,7 @@ Two conventions worth stating once:
 from datetime import date, datetime
 from typing import Annotated
 
-from pydantic import BaseModel, Field, StringConstraints
+from pydantic import BaseModel, Field, StringConstraints, field_validator
 
 from konnekt.db.models.enums import PriceUnit, UiLang, WorkFormat
 
@@ -337,7 +337,9 @@ class RequestCreate(BaseModel):
     langs: list[LangCode] = Field(default_factory=list, max_length=12)
 
 
-class RequestOut(BaseModel):
+class RequestBase(BaseModel):
+    """What a request is, to anyone looking at it."""
+
     id: int
     text: str
     subject: str | None = None
@@ -345,6 +347,62 @@ class RequestOut(BaseModel):
     service_type: str | None = None
     deadline_on: date | None = None
     status: str
+    created_at: datetime
+
+
+class RequestOut(RequestBase):
+    """Your own request. Who answered is the whole point of the screen."""
+
     responses_count: int = 0
     responders: list[Avatar] = Field(default_factory=list)
+
+
+class FeedRequestOut(RequestBase):
+    """A request as a helper sees it.
+
+    Deliberately not a subclass of RequestOut: how many people have already
+    answered, and who they are, is the competition's business and not this
+    reader's. A helper who can see "3 answers already" simply skips those,
+    which is the opposite of what the feed is for — and inheriting the fields
+    to blank them would still leave them in the schema.
+    """
+
+    author: Avatar
+    author_name: str
+    budget: Price | None = None
+    langs: list[str] = Field(default_factory=list)
+    # Why this request surfaced: the same subject you teach, your faculty, or
+    # simply that it is new. Rendered by the client, like every other Phrase.
+    reason: Phrase | None = None
+
+
+class ResponseCreate(BaseModel):
+    # Validated after stripping, below: min_length alone sees the raw string,
+    # so "   " passes it and lands in the database as "".
+    message: str = Field(max_length=1000)
+    price_amount: float | None = Field(default=None, ge=0, le=1_000_000)
+    price_unit: PriceUnit | None = None
+
+    @field_validator("message")
+    @classmethod
+    def _not_blank(cls, value: str) -> str:
+        stripped = value.strip()
+        if len(stripped) < 3:
+            raise ValueError("write at least a few words")
+        return stripped
+
+
+class ResponseOut(BaseModel):
+    id: int
+    request_id: int
+    helper_id: int
+    name: str
+    avatar: Avatar
+    username: str | None = None
+    affiliation: str | None = None
+    rating: float | None = None
+    deals_count: int = 0
+    message: str
+    price: Price | None = None
+    status: str
     created_at: datetime

--- a/apps/api/src/konnekt/api/v1/routes.py
+++ b/apps/api/src/konnekt/api/v1/routes.py
@@ -1,7 +1,8 @@
 from datetime import UTC, datetime, time, timedelta
 
-from fastapi import APIRouter, HTTPException, Query, Request, status
-from sqlalchemy import delete, func, select
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query, Request, status
+from sqlalchemy import delete, false, func, or_, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import selectinload
 
 from konnekt.api.deps import LangDep, SessionDep, UserDep
@@ -10,6 +11,7 @@ from konnekt.api.schemas import (
     Clarify,
     ClarifyOption,
     ContactOut,
+    FeedRequestOut,
     HelperDetailOut,
     HelperUpsert,
     HomeOut,
@@ -26,10 +28,20 @@ from konnekt.api.schemas import (
     Price,
     RequestCreate,
     RequestOut,
+    ResponseCreate,
+    ResponseOut,
     SearchFilters,
     SearchOut,
     ServiceTypeOut,
     SubjectOut,
+)
+from konnekt.bot.texts import (
+    FOR_PRICE,
+    NEW_RESPONSE,
+    RESPONSE_ACCEPTED,
+    WAIT_FOR_MESSAGE,
+    WRITE_TO,
+    pick,
 )
 from konnekt.db.models import (
     Contact,
@@ -51,11 +63,13 @@ from konnekt.db.models.enums import (
     PriceUnit,
     PublishStatus,
     RequestStatus,
+    ResponseStatus,
     UserEventKind,
     WorkFormat,
 )
-from konnekt.services import catalog, parser, placements
+from konnekt.services import catalog, notify, parser, placements
 from konnekt.services.catalog import _localised, avatar_for
+from konnekt.services.notify import quote
 from konnekt.services.people import log_event
 
 router = APIRouter(prefix="/api/v1")
@@ -827,6 +841,517 @@ async def my_requests(
         )
     ).all()
     return await _requests_out(session, list(rows), lang)
+
+
+@router.get("/requests/feed", response_model=list[FeedRequestOut], tags=["requests"])
+async def request_feed(
+    session: SessionDep,
+    lang: LangDep,
+    user: UserDep,
+    limit: int = Query(20, ge=1, le=50),
+) -> list[FeedRequestOut]:
+    """Open requests, for someone who could answer them.
+
+    Visible to any helper profile including a draft one: seeing that four
+    people want help with the thing you teach is the argument for finishing
+    the profile, and withholding it until published gets that backwards. What
+    a draft cannot do is answer — see `respond_to_request`.
+    """
+    helper = await session.get(HelperProfile, user.id)
+    if helper is None:
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN, "only helpers can see incoming requests"
+        )
+    # A ban has to cover this too. The feed carries every author's name, photo,
+    # full text and budget — for someone banned for harassment it is a target
+    # list, and being unable to answer in-app does not help if the reason they
+    # were banned is that they contact people outside it.
+    if helper.status is PublishStatus.BANNED:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "this profile is banned")
+
+    axes = (
+        await session.execute(
+            select(Offer.subject_id, Offer.institution_id, Offer.service_type_id).where(
+                Offer.helper_id == user.id, Offer.is_active.is_(True)
+            )
+        )
+    ).all()
+    subject_ids = {row[0] for row in axes if row[0]}
+    institution_ids = {row[1] for row in axes if row[1]}
+    service_ids = {row[2] for row in axes if row[2]}
+    # Their own faculty counts too — a request from your own school is
+    # relevant whether or not you have listed an offer against it.
+    if user.institution_id:
+        institution_ids.add(user.institution_id)
+
+    def matches(column, ids: set[int]):
+        """Does this request hit one of the helper's axes?
+
+        coalesce, because `subject_id IN (...)` is NULL for a request with no
+        subject, and NULL sorts *first* under DESC — which would rank every
+        vague request above every matching one.
+
+        None when the helper has nothing on that axis: the term is then a
+        constant, and a constant cannot go in ORDER BY — Postgres reads a bare
+        `false` there as a column ordinal and rejects it.
+        """
+        if not ids:
+            return None
+        return func.coalesce(column.in_(ids), False)
+
+    subject_match = matches(HelpRequest.subject_id, subject_ids)
+    institution_match = matches(HelpRequest.institution_id, institution_ids)
+    service_match = matches(HelpRequest.service_type_id, service_ids)
+
+    # Strongest signal first. Anything the helper has no axis for is dropped
+    # rather than ordered by, since it would sort every row identically.
+    ranking = [
+        term.desc()
+        for term in (subject_match, service_match, institution_match)
+        if term is not None
+    ]
+
+    now = datetime.now(UTC)
+    answered = (
+        select(RequestResponse.id)
+        .where(
+            RequestResponse.request_id == HelpRequest.id,
+            RequestResponse.helper_id == user.id,
+        )
+        .exists()
+    )
+
+    rows = (
+        await session.execute(
+            select(
+                HelpRequest,
+                User,
+                subject_match if subject_match is not None else false(),
+                institution_match if institution_match is not None else false(),
+                service_match if service_match is not None else false(),
+            )
+            .join(User, User.id == HelpRequest.author_id)
+            .where(
+                HelpRequest.status == RequestStatus.OPEN,
+                # Answering your own request is not a thing.
+                HelpRequest.author_id != user.id,
+                or_(HelpRequest.expires_at.is_(None), HelpRequest.expires_at > now),
+                ~answered,
+            )
+            .order_by(
+                *ranking,
+                HelpRequest.created_at.desc(),
+                # Total, so paging is stable: created_at is the transaction
+                # clock and rows written together share it.
+                HelpRequest.id.desc(),
+            )
+            .limit(limit)
+        )
+    ).all()
+
+    requests = [row[0] for row in rows]
+    rendered = await _requests_out(session, requests, lang)
+    subjects_by_id = {r.id: r.subject for r in rendered}
+
+    out: list[FeedRequestOut] = []
+    for base, (request, author, on_subject, on_institution, on_service) in zip(
+        rendered, rows, strict=True
+    ):
+        out.append(
+            FeedRequestOut(
+                # Only the shared fields. `responses_count` and `responders`
+                # are not on FeedRequestOut at all — see the schema.
+                **base.model_dump(exclude={"responders", "responses_count"}),
+                author=avatar_for(author),
+                author_name=author.first_name,
+                budget=(
+                    Price(
+                        amount=float(request.budget_max),
+                        currency=request.budget_currency,
+                        unit=request.budget_unit or PriceUnit.HOUR,
+                    )
+                    if request.budget_max is not None
+                    else None
+                ),
+                langs=list(request.langs),
+                reason=_feed_reason(
+                    on_subject=bool(on_subject),
+                    on_institution=bool(on_institution),
+                    on_service=bool(on_service),
+                    subject=subjects_by_id.get(request.id),
+                ),
+            )
+        )
+    return out
+
+
+def _feed_reason(
+    *, on_subject: bool, on_institution: bool, on_service: bool, subject: str | None
+) -> Phrase | None:
+    """Why this request is in the list.
+
+    One line, strongest first — and in the *same* order the ranking uses, or
+    the line names a weaker axis than the one that actually lifted the row and
+    reads as a non sequitur next to its neighbours.
+    """
+    if on_subject and subject:
+        return Phrase(code="feed.same_subject", params={"subject": subject})
+    if on_service:
+        return Phrase(code="feed.same_service")
+    if on_institution:
+        return Phrase(code="feed.same_institution")
+    return None
+
+
+@router.post(
+    "/requests/{request_id}/respond",
+    response_model=ResponseOut,
+    status_code=status.HTTP_201_CREATED,
+    tags=["requests"],
+)
+async def respond_to_request(
+    request_id: int,
+    payload: ResponseCreate,
+    background: BackgroundTasks,
+    http: Request,
+    session: SessionDep,
+    lang: LangDep,
+    user: UserDep,
+) -> ResponseOut:
+    """Answer someone's request.
+
+    Published profiles only, unlike the feed: an answer is an invitation to
+    look at a profile, and a draft is not there to be looked at.
+    """
+    helper = await session.get(HelperProfile, user.id)
+    if helper is None or helper.status is not PublishStatus.PUBLISHED:
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN, "publish your profile before answering requests"
+        )
+    # The same rule `start_contact` enforces, for the same reason: we do not
+    # host the conversation, so a public username is the only way the author
+    # can answer back. Without it an accepted answer is a dead end — both
+    # sides told a deal happened and neither able to reach the other.
+    if not user.tg_username:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "set a public @username in Telegram so people can write back",
+        )
+
+    request = await session.get(HelpRequest, request_id)
+    if request is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "no such request")
+    if request.author_id == user.id:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "this is your own request")
+    expired = request.expires_at is not None and request.expires_at <= datetime.now(UTC)
+    if request.status is not RequestStatus.OPEN or expired:
+        raise HTTPException(status.HTTP_409_CONFLICT, "this request is closed")
+
+    # ON CONFLICT rather than a select first: two taps on a slow connection
+    # are two concurrent inserts, and the unique constraint would surface the
+    # second as a 500 instead of "you already answered this".
+    inserted = await session.scalar(
+        pg_insert(RequestResponse)
+        .values(
+            request_id=request.id,
+            helper_id=user.id,
+            message=payload.message.strip(),
+            price_amount=payload.price_amount,
+            price_unit=payload.price_unit,
+        )
+        .on_conflict_do_nothing(constraint="uq_request_responses_pair")
+        .returning(RequestResponse)
+    )
+    if inserted is None:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, "you have already answered this request"
+        )
+
+    await log_event(
+        session,
+        user.id,
+        UserEventKind.REQUEST_RESPONDED,
+        request_id=request.id,
+        subject_id=request.subject_id,
+    )
+    await session.commit()
+
+    author = await session.get(User, request.author_id)
+    [rendered] = await _responses_out(session, [inserted], lang)
+    if author is not None:
+        _queue_notification(
+            background,
+            http,
+            recipient=author,
+            text=pick(NEW_RESPONSE, author.ui_lang).format(
+                topic=quote(_topic_of(rendered_request=request), 120),
+                helper=quote(rendered.name, 64),
+                price=(
+                    pick(FOR_PRICE, author.ui_lang).format(
+                        price=quote(_price_line(rendered.price), 40)
+                    )
+                    if rendered.price and rendered.price.amount is not None
+                    else ""
+                ),
+                message=quote(inserted.message),
+            ),
+        )
+    return rendered
+
+
+@router.get(
+    "/requests/{request_id}/responses",
+    response_model=list[ResponseOut],
+    tags=["requests"],
+)
+async def request_responses(
+    request_id: int, session: SessionDep, lang: LangDep, user: UserDep
+) -> list[ResponseOut]:
+    """Who answered. The author only — this is not a public bid list."""
+    request = await session.get(HelpRequest, request_id)
+    if request is None or request.author_id != user.id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "no such request")
+
+    rows = (
+        await session.scalars(
+            select(RequestResponse)
+            .where(RequestResponse.request_id == request.id)
+            .order_by(RequestResponse.created_at.asc(), RequestResponse.id.asc())
+        )
+    ).all()
+
+    # Rendered *before* marking anything, so this response still carries the
+    # statuses the author has not seen yet — otherwise the client never gets a
+    # chance to badge the new ones, because they arrive already read.
+    out = await _responses_out(session, list(rows), lang)
+
+    # Only the ones still unread, so an accepted or declined answer is not
+    # quietly walked backwards to "read".
+    for row in rows:
+        if row.status is ResponseStatus.SENT:
+            row.status = ResponseStatus.READ
+    await session.commit()
+
+    return out
+
+
+@router.post(
+    "/responses/{response_id}/accept",
+    response_model=ResponseOut,
+    tags=["requests"],
+)
+async def accept_response(
+    response_id: int,
+    background: BackgroundTasks,
+    http: Request,
+    session: SessionDep,
+    lang: LangDep,
+    user: UserDep,
+) -> ResponseOut:
+    """Pick someone.
+
+    Does not close the request: needing two people for two subjects is
+    ordinary, and closing on the first acceptance would make the common case
+    the destructive one.
+    """
+    response, request = await _own_response(session, response_id, user)
+
+    # Idempotent. A double tap, or a retry after a dropped response, would
+    # otherwise write a second `contacts` row — which is the basis for deal
+    # counts and response times — and send the helper a second "you were
+    # picked". `contacts` has no unique index to catch it, and should not:
+    # contacting the same person twice about two different requests is real.
+    if response.status is ResponseStatus.ACCEPTED:
+        [out] = await _responses_out(session, [response], lang)
+        return out
+
+    response.status = ResponseStatus.ACCEPTED
+
+    # The same row the catalog writes when someone taps "write" on a profile,
+    # so response times and deal counts count both routes to a conversation.
+    session.add(
+        Contact(
+            student_id=user.id,
+            helper_id=response.helper_id,
+            request_id=request.id,
+        )
+    )
+    await log_event(
+        session,
+        user.id,
+        UserEventKind.RESPONSE_ACCEPTED,
+        request_id=request.id,
+        helper_id=response.helper_id,
+    )
+    await session.commit()
+
+    helper_user = await session.get(User, response.helper_id)
+    if helper_user is not None:
+        _queue_notification(
+            background,
+            http,
+            recipient=helper_user,
+            text=pick(RESPONSE_ACCEPTED, helper_user.ui_lang).format(
+                topic=quote(_topic_of(rendered_request=request), 120),
+                student=quote(user.first_name, 64),
+                contact=(
+                    pick(WRITE_TO, helper_user.ui_lang).format(
+                        username=quote(user.tg_username, 64)
+                    )
+                    if user.tg_username
+                    else pick(WAIT_FOR_MESSAGE, helper_user.ui_lang)
+                ),
+            ),
+        )
+
+    [out] = await _responses_out(session, [response], lang)
+    return out
+
+
+@router.post(
+    "/responses/{response_id}/decline",
+    response_model=ResponseOut,
+    tags=["requests"],
+)
+async def decline_response(
+    response_id: int, session: SessionDep, lang: LangDep, user: UserDep
+) -> ResponseOut:
+    """Turn one down. Deliberately silent — nobody needs a rejection push."""
+    response, _ = await _own_response(session, response_id, user)
+
+    # An accepted answer cannot be walked back here. The helper has already
+    # been told they were picked and a `contacts` row exists; flipping the
+    # status would leave the author reading "you declined" while the other
+    # side reads "you were chosen", with a recorded deal between them.
+    if response.status is ResponseStatus.ACCEPTED:
+        raise HTTPException(status.HTTP_409_CONFLICT, "you already chose this person")
+
+    response.status = ResponseStatus.DECLINED
+    await session.commit()
+    [out] = await _responses_out(session, [response], lang)
+    return out
+
+
+async def _own_response(
+    session, response_id: int, user: User
+) -> tuple[RequestResponse, HelpRequest]:
+    """Load a response the caller is entitled to act on.
+
+    404 rather than 403 for someone else's: whether a given id exists is not
+    something a stranger should be able to probe.
+    """
+    response = await session.get(RequestResponse, response_id)
+    if response is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "no such response")
+    request = await session.get(HelpRequest, response.request_id)
+    if request is None or request.author_id != user.id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "no such response")
+    return response, request
+
+
+def _topic_of(*, rendered_request: HelpRequest) -> str:
+    """A one-line handle on a request, for a notification.
+
+    The text the person typed, not our parse of it — they recognise their own
+    words, and "Mathematical Analysis I · ČVUT" is our vocabulary, not theirs.
+    """
+    return rendered_request.raw_text
+
+
+def _price_line(price: Price | None) -> str:
+    if price is None or price.amount is None:
+        return ""
+    amount = int(price.amount) if float(price.amount).is_integer() else price.amount
+    return f"{amount} {price.currency}"
+
+
+def _queue_notification(
+    background: BackgroundTasks, http: Request, *, recipient: User, text: str
+) -> None:
+    """Send after the response goes out, not before.
+
+    Telegram is a network call to a third party in the middle of a request the
+    user is waiting on. The action is already committed; the message can take
+    its time.
+    """
+    # `bot_started_at`, not only `bot_can_message`: the latter defaults to true
+    # for every row including someone who reached the app through a direct link
+    # and never messaged the bot. Telegram answers that send with a 403, which
+    # `tell` reads as "blocked" — so the notification is lost *and* the person
+    # is recorded as having blocked a bot they never met.
+    #
+    # `unsubscribed_at` is deliberately not consulted. /stop opts out of us
+    # writing unprompted; this is the answer to something they set in motion.
+    if recipient.bot_started_at is None or not recipient.bot_can_message:
+        return
+    # getattr, because app.state is populated by the lifespan hook and nothing
+    # here should turn "the app was mounted without one" into a 500 on an
+    # action that has already succeeded.
+    bot = getattr(http.app.state, "bot", None)
+    if bot is None:
+        return
+    settings = getattr(http.app.state, "settings", None)
+    background.add_task(
+        notify.tell,
+        bot,
+        tg_id=recipient.tg_id,
+        text=text,
+        lang=recipient.ui_lang,
+        app_url=(settings.public_base_url or None) if settings else None,
+    )
+
+
+async def _responses_out(
+    session, responses: list[RequestResponse], lang
+) -> list[ResponseOut]:
+    """Render answers with their authors, in a fixed number of queries."""
+    if not responses:
+        return []
+
+    helper_ids = {r.helper_id for r in responses}
+    rows = (
+        await session.execute(
+            select(User, HelperProfile)
+            .join(HelperProfile, HelperProfile.user_id == User.id)
+            .where(User.id.in_(helper_ids))
+        )
+    ).all()
+    people = {user.id: (user, profile) for user, profile in rows}
+
+    out = []
+    for response in responses:
+        found = people.get(response.helper_id)
+        if found is None:
+            # The profile was deleted between answering and reading. The row
+            # survives by foreign key, but there is nobody left to show.
+            continue
+        person, profile = found
+        out.append(
+            ResponseOut(
+                id=response.id,
+                request_id=response.request_id,
+                helper_id=response.helper_id,
+                name=" ".join(filter(None, (person.first_name, person.last_name))),
+                avatar=avatar_for(person),
+                username=person.tg_username,
+                affiliation=profile.headline,
+                rating=float(profile.rating) if profile.rating is not None else None,
+                deals_count=profile.deals_count,
+                message=response.message,
+                price=(
+                    Price(
+                        amount=float(response.price_amount),
+                        currency=response.price_currency,
+                        unit=response.price_unit or PriceUnit.HOUR,
+                    )
+                    if response.price_amount is not None
+                    else None
+                ),
+                status=response.status.value,
+                created_at=response.created_at,
+            )
+        )
+    return out
 
 
 @router.post(

--- a/apps/api/src/konnekt/bot/texts.py
+++ b/apps/api/src/konnekt/bot/texts.py
@@ -1,0 +1,104 @@
+"""What the bot says, in the language the recipient chose.
+
+The mini app has a translation catalog; the bot cannot use it, because these
+strings are produced by the server while the recipient's app is closed — which
+is the entire reason to send them. Kept as plain dictionaries rather than
+another gettext setup: there are a handful of strings, and a missing key here
+should be a loud KeyError in a test, not a silent fallback in production.
+
+Values are HTML — the bot is built with parse_mode=HTML — so anything
+interpolated has to be escaped by the caller.
+"""
+
+from konnekt.db.models.enums import UiLang
+
+# The button under a notification. Opening the app is the only action any of
+# these messages asks for, so there is exactly one label per language.
+OPEN_APP: dict[UiLang, str] = {
+    UiLang.RU: "Открыть",
+    UiLang.CS: "Otevřít",
+    UiLang.EN: "Open",
+    UiLang.UK: "Відкрити",
+}
+
+# Someone answered a request you posted.
+NEW_RESPONSE: dict[UiLang, str] = {
+    UiLang.RU: (
+        "<b>Отклик на твою заявку</b>\n"
+        "{topic}\n\n"
+        "{helper} готов помочь{price}.\n"
+        "«{message}»"
+    ),
+    UiLang.CS: (
+        "<b>Odpověď na tvůj inzerát</b>\n"
+        "{topic}\n\n"
+        "{helper} nabízí pomoc{price}.\n"
+        "„{message}“"
+    ),
+    UiLang.EN: (
+        "<b>Someone answered your request</b>\n"
+        "{topic}\n\n"
+        "{helper} can help{price}.\n"
+        "“{message}”"
+    ),
+    UiLang.UK: (
+        "<b>Відгук на твою заявку</b>\n"
+        "{topic}\n\n"
+        "{helper} готовий допомогти{price}.\n"
+        "«{message}»"
+    ),
+}
+
+# The price clause, appended to the line above. Separate because a response
+# without a price must not leave a dangling "for" in the sentence.
+FOR_PRICE: dict[UiLang, str] = {
+    UiLang.RU: " за {price}",
+    UiLang.CS: " za {price}",
+    UiLang.EN: " for {price}",
+    UiLang.UK: " за {price}",
+}
+
+# The student picked your answer.
+#
+# It does not tell the helper to write first. The conversation happens in
+# Telegram and we do not host it, so the helper can only start it if the
+# student has a public username — which most do not. The student always can,
+# because answering a request requires one. `{contact}` fills in only when
+# the helper genuinely has somewhere to write.
+RESPONSE_ACCEPTED: dict[UiLang, str] = {
+    UiLang.RU: ("<b>Твой отклик приняли</b>\n{topic}\n\n{student} выбрал тебя.{contact}"),
+    UiLang.CS: (
+        "<b>Tvoje nabídka byla přijata</b>\n{topic}\n\n{student} si tě vybral.{contact}"
+    ),
+    UiLang.EN: (
+        "<b>Your answer was accepted</b>\n{topic}\n\n{student} chose you.{contact}"
+    ),
+    UiLang.UK: ("<b>Твій відгук прийняли</b>\n{topic}\n\n{student} обрав тебе.{contact}"),
+}
+
+# Appended above when the student has a public username, so the helper does
+# not have to wait to be written to.
+WRITE_TO: dict[UiLang, str] = {
+    UiLang.RU: " Написать: @{username}",
+    UiLang.CS: " Napsat: @{username}",
+    UiLang.EN: " Write to them: @{username}",
+    UiLang.UK: " Написати: @{username}",
+}
+
+# And when they do not: the student has the button, so this is the honest
+# version rather than an instruction the helper cannot follow.
+WAIT_FOR_MESSAGE: dict[UiLang, str] = {
+    UiLang.RU: " Он напишет сам — ответь, когда придёт сообщение.",
+    UiLang.CS: " Ozve se sám — odpověz, až zpráva přijde.",
+    UiLang.EN: " They will write to you — answer when the message arrives.",
+    UiLang.UK: " Він напише сам — відповідай, коли надійде повідомлення.",
+}
+
+
+def pick(table: dict[UiLang, str], lang: UiLang) -> str:
+    """Read a string, falling back to Russian for a language we have not written.
+
+    A new UiLang member should not be able to raise inside a notification and
+    take the request that triggered it with it.
+    """
+    return table.get(lang) or table[UiLang.RU]

--- a/apps/api/src/konnekt/db/migrations/versions/20260726_a1c4e77b0d21_events_for_answering_a_request.py
+++ b/apps/api/src/konnekt/db/migrations/versions/20260726_a1c4e77b0d21_events_for_answering_a_request.py
@@ -1,0 +1,51 @@
+"""answering a request: price unit and two events
+
+Revision ID: a1c4e77b0d21
+Revises: fbdbb4c11417
+Create Date: 2026-07-26 16:05:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "a1c4e77b0d21"
+down_revision: Union[str, Sequence[str], None] = "fbdbb4c11417"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Two new members of the native enum. IF NOT EXISTS because a database
+# stamped from metadata rather than migrated already has them, and this
+# migration must not be the thing that breaks that database.
+NEW_VALUES = ("request_responded", "response_accepted")
+
+
+def upgrade() -> None:
+    for value in NEW_VALUES:
+        op.execute(f"ALTER TYPE user_event_kind ADD VALUE IF NOT EXISTS '{value}'")
+
+    op.add_column(
+        "request_responses",
+        sa.Column(
+            "price_unit",
+            # The type already exists — offers use it — so create_type=False,
+            # or this fails with "type price_unit already exists".
+            postgresql.ENUM(name="price_unit", create_type=False),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drops the column only.
+
+    Postgres cannot drop a value from an enum. Recreating the type would mean
+    rewriting every column that uses it and losing the rows that hold the value
+    being removed — a far worse outcome than an enum with two unused members.
+    """
+    op.drop_column("request_responses", "price_unit")

--- a/apps/api/src/konnekt/db/models/enums.py
+++ b/apps/api/src/konnekt/db/models/enums.py
@@ -186,4 +186,6 @@ class UserEventKind(StrEnum):
     HELPER_VIEW = "helper_view"
     CONTACT = "contact"
     REQUEST_CREATED = "request_created"
+    REQUEST_RESPONDED = "request_responded"
+    RESPONSE_ACCEPTED = "response_accepted"
     PROFILE_PUBLISHED = "profile_published"

--- a/apps/api/src/konnekt/db/models/requests.py
+++ b/apps/api/src/konnekt/db/models/requests.py
@@ -119,6 +119,10 @@ class RequestResponse(IdMixin, TimestampMixin, Base):
     price_currency: Mapped[str] = mapped_column(
         String(3), nullable=False, server_default="CZK"
     )
+    # Nullable, and separately from the amount: "500" alone is ambiguous
+    # between an hour and the whole job, and an offer to do a semester's
+    # worth of work for 500 per hour is a different offer entirely.
+    price_unit: Mapped[PriceUnit | None] = mapped_column(pg_enum(PriceUnit, "price_unit"))
     status: Mapped[ResponseStatus] = mapped_column(
         pg_enum(ResponseStatus, "response_status"),
         nullable=False,

--- a/apps/api/src/konnekt/services/notify.py
+++ b/apps/api/src/konnekt/services/notify.py
@@ -1,0 +1,122 @@
+"""Reaching someone whose app is closed.
+
+Every notification here answers something the recipient started — they posted a
+request, or they answered one — so this is not the announcement channel and
+deliberately does not consult `unsubscribed_at`: /stop opts out of us writing
+unprompted, not out of being told that the thing you asked for happened.
+
+Nothing in here may raise. A notification is a side effect of an action that has
+already been committed; if Telegram is down, the response was still recorded and
+the person will see it in the app.
+"""
+
+import asyncio
+import logging
+from html import escape
+
+from aiogram import Bot
+from aiogram.exceptions import TelegramForbiddenError, TelegramRetryAfter
+from aiogram.types import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    LinkPreviewOptions,
+    WebAppInfo,
+)
+
+from konnekt.bot.texts import OPEN_APP, pick
+from konnekt.db.models.enums import UiLang
+from konnekt.db.session import get_sessionmaker
+from konnekt.services.people import mark_unreachable
+
+log = logging.getLogger("konnekt.notify")
+
+# Telegram occasionally takes seconds to answer. The caller is a background
+# task, but an unbounded wait still leaks a task per stuck send.
+SEND_TIMEOUT = 10.0
+
+
+def _keyboard(lang: UiLang, app_url: str | None) -> InlineKeyboardMarkup | None:
+    """A button that opens the mini app, when we know our own address.
+
+    A web_app button requires an https URL; during local development there is
+    none, and a notification without a button is better than a failed send.
+    """
+    if not app_url or not app_url.startswith("https://"):
+        return None
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text=pick(OPEN_APP, lang),
+                    web_app=WebAppInfo(url=app_url),
+                )
+            ]
+        ]
+    )
+
+
+async def tell(
+    bot: Bot | None,
+    *,
+    tg_id: int,
+    text: str,
+    lang: UiLang,
+    app_url: str | None = None,
+) -> bool:
+    """Send one message. Returns whether it arrived.
+
+    `bot` is None when the API runs without a token, which is how it runs
+    locally — so every caller works unchanged with notifications simply not
+    happening.
+    """
+    if bot is None:
+        log.debug("no bot configured; not notifying %s", tg_id)
+        return False
+
+    try:
+        await asyncio.wait_for(
+            bot.send_message(
+                chat_id=tg_id,
+                text=text,
+                reply_markup=_keyboard(lang, app_url),
+                # These are short and self-contained; a link preview would be
+                # the only thing in the message with a picture. The options
+                # object rather than disable_web_page_preview, which aiogram
+                # keeps only as a deprecated alias.
+                link_preview_options=LinkPreviewOptions(is_disabled=True),
+            ),
+            timeout=SEND_TIMEOUT,
+        )
+    except TelegramForbiddenError as exc:
+        # Blocked, or never started the bot. An answer, not a failure: recorded
+        # so nothing tries again and finds out the same way.
+        async with get_sessionmaker()() as session:
+            await mark_unreachable(session, tg_id, str(exc))
+            await session.commit()
+        return False
+    except TelegramRetryAfter as exc:
+        # Not retried here. This is a single message to a single person, and
+        # holding a background task open for the flood-wait window to deliver
+        # something the app already shows is not worth it.
+        log.warning("flood wait %ss notifying %s", exc.retry_after, tg_id)
+        return False
+    except Exception as exc:
+        # Includes the timeout above: asyncio.TimeoutError is TimeoutError is
+        # an Exception. Everything here is "the message did not arrive", and
+        # none of it is worth failing the caller over.
+        log.warning("could not notify %s: %s", tg_id, exc)
+        return False
+    return True
+
+
+def quote(value: str, limit: int = 300) -> str:
+    """Prepare user-written text for an HTML message.
+
+    Escaped, because the bot sends HTML and someone's request may legitimately
+    contain "<3" or an ampersand; truncated, because a notification is a
+    summary and Telegram rejects a message over 4096 characters outright.
+    """
+    collapsed = " ".join(value.split())
+    if len(collapsed) > limit:
+        collapsed = collapsed[: limit - 1].rstrip() + "…"
+    return escape(collapsed)

--- a/apps/api/tests/test_notify.py
+++ b/apps/api/tests/test_notify.py
@@ -1,0 +1,200 @@
+"""The bits of notification that are pure logic.
+
+Sending itself needs a bot token and Telegram; what can be tested here is
+everything that decides *what* gets sent — and that is where the bugs are,
+because the bot speaks HTML and the text comes from strangers.
+"""
+
+import pytest
+
+from konnekt.bot.texts import (
+    NEW_RESPONSE,
+    OPEN_APP,
+    RESPONSE_ACCEPTED,
+    WAIT_FOR_MESSAGE,
+    WRITE_TO,
+    pick,
+)
+from konnekt.db.models.enums import UiLang
+from konnekt.services.notify import _keyboard, quote, tell
+
+
+def test_quote_escapes_html() -> None:
+    """The bot sends HTML, and "<3" is a thing people write."""
+    assert quote("матан <3 & čeština") == "матан &lt;3 &amp; čeština"
+
+
+def test_quote_collapses_whitespace() -> None:
+    assert quote("нужен\n\n  матан   срочно") == "нужен матан срочно"
+
+
+def test_quote_truncates() -> None:
+    quoted = quote("а" * 500, limit=50)
+    assert len(quoted) == 50
+    assert quoted.endswith("…")
+
+
+def test_quote_truncates_before_escaping_is_undone() -> None:
+    """An entity must not be cut in half.
+
+    Escaping after truncation is what guarantees it: cutting "&amp;" at four
+    characters would leave "&amp" and Telegram rejects the whole message.
+    """
+    quoted = quote("<" * 100, limit=20)
+    assert "&lt;" in quoted
+    assert not quoted.rstrip("…").endswith("&l")
+
+
+@pytest.mark.parametrize("lang", list(UiLang))
+def test_every_language_has_every_string(lang: UiLang) -> None:
+    """A missing key must not raise inside a notification."""
+    for table in (
+        OPEN_APP,
+        NEW_RESPONSE,
+        RESPONSE_ACCEPTED,
+        WRITE_TO,
+        WAIT_FOR_MESSAGE,
+    ):
+        assert pick(table, lang)
+
+
+def test_the_templates_take_the_parameters_the_callers_pass() -> None:
+    """Every placeholder the route fills, filled — a KeyError here is a 500."""
+    for lang in UiLang:
+        assert pick(NEW_RESPONSE, lang).format(
+            topic="матан", helper="Marek", price="", message="помогу"
+        )
+        assert pick(RESPONSE_ACCEPTED, lang).format(
+            topic="матан", student="Азамат", contact=""
+        )
+        assert pick(WRITE_TO, lang).format(username="vsem_azamat")
+        assert pick(WAIT_FOR_MESSAGE, lang)
+
+
+def test_the_acceptance_message_never_tells_the_helper_to_write_first() -> None:
+    """It used to, and the helper has no way to — see the note in texts.py.
+
+    Both endings are complete sentences on their own, because which one is
+    appended depends on whether the student has a public username.
+    """
+    for lang in UiLang:
+        with_contact = pick(RESPONSE_ACCEPTED, lang).format(
+            topic="матан",
+            student="Азамат",
+            contact=pick(WRITE_TO, lang).format(username="vsem_azamat"),
+        )
+        assert "@vsem_azamat" in with_contact
+
+        without = pick(RESPONSE_ACCEPTED, lang).format(
+            topic="матан", student="Азамат", contact=pick(WAIT_FOR_MESSAGE, lang)
+        )
+        assert "@" not in without
+
+
+def test_no_button_without_an_https_address() -> None:
+    """A web_app button requires https, and local development has none."""
+    assert _keyboard(UiLang.RU, None) is None
+    assert _keyboard(UiLang.RU, "http://localhost:8000") is None
+    assert _keyboard(UiLang.RU, "https://tutors.example.com") is not None
+
+
+@pytest.mark.asyncio
+async def test_telling_nobody_is_not_an_error() -> None:
+    """The API runs without a bot locally; every caller must still work."""
+    assert await tell(None, tg_id=1, text="привет", lang=UiLang.RU, app_url=None) is False
+
+
+class _Bag:
+    """An attribute bag, which is all `app.state` is."""
+
+
+def _http(**state):
+    """Just enough of a FastAPI request for the reachability guard.
+
+    Deliberately without a `bot` unless one is passed: that is how the API
+    runs locally, and every caller has to work that way.
+    """
+    request, app = _Bag(), _Bag()
+    app.state = _Bag()
+    for key, value in state.items():
+        setattr(app.state, key, value)
+    request.app = app
+    return request
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.tasks: list[tuple] = []
+
+    def add_task(self, *args, **kwargs) -> None:
+        self.tasks.append((args, kwargs))
+
+
+def _person(**overrides):
+    from datetime import UTC, datetime
+
+    from konnekt.db.models import User
+
+    defaults = {
+        "tg_id": 42,
+        "first_name": "Азамат",
+        "ui_lang": UiLang.RU,
+        "bot_started_at": datetime.now(UTC),
+        "bot_can_message": True,
+    }
+    return User(**{**defaults, **overrides})
+
+
+def test_nobody_is_written_to_who_never_started_the_bot() -> None:
+    """`bot_can_message` defaults to true for everyone, including them.
+
+    Someone who opened the mini app from a direct link and never messaged the
+    bot cannot be written to: Telegram answers 403, which `tell` reads as a
+    block — losing the notification *and* recording them as having blocked a
+    bot they never met.
+    """
+    from konnekt.api.v1.routes import _queue_notification
+
+    recorder = _Recorder()
+    _queue_notification(
+        recorder, _http(), recipient=_person(bot_started_at=None), text="привет"
+    )
+    assert recorder.tasks == []
+
+
+def test_nobody_is_written_to_who_blocked_the_bot() -> None:
+    from konnekt.api.v1.routes import _queue_notification
+
+    recorder = _Recorder()
+    _queue_notification(
+        recorder, _http(), recipient=_person(bot_can_message=False), text="привет"
+    )
+    assert recorder.tasks == []
+
+
+def test_no_task_is_queued_when_there_is_no_bot() -> None:
+    """The API runs without a token locally; the action must still succeed."""
+    from konnekt.api.v1.routes import _queue_notification
+
+    recorder = _Recorder()
+    _queue_notification(recorder, _http(), recipient=_person(), text="привет")
+    assert recorder.tasks == []
+
+
+def test_a_reachable_person_with_a_bot_is_written_to() -> None:
+    """The positive control.
+
+    Without it the three tests above pass for the wrong reason — there is no
+    bot in any of them, so they would still pass with the guard deleted.
+    """
+    from konnekt.api.v1.routes import _queue_notification
+
+    recorder = _Recorder()
+    _queue_notification(
+        recorder,
+        _http(bot=object(), settings=None),
+        recipient=_person(),
+        text="привет",
+    )
+    assert len(recorder.tasks) == 1
+    assert recorder.tasks[0][1]["tg_id"] == 42

--- a/apps/api/tests/test_requests.py
+++ b/apps/api/tests/test_requests.py
@@ -1,0 +1,451 @@
+"""The other direction: a student asks, a helper answers.
+
+The catalog side is tested in test_api; this covers the loop that only exists
+once someone can reply — who may see incoming requests, who may answer them,
+and what the author sees afterwards.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from konnekt.db.models import Contact, HelperProfile, HelpRequest, User
+from konnekt.db.models.enums import PublishStatus, RequestStatus
+
+from .conftest import auth_header
+
+STUDENT = 90501
+HELPER = 90502
+OTHER = 90503
+
+pytestmark = pytest.mark.asyncio
+
+
+def helper_header(tg_id: int = HELPER, **extra) -> dict[str, str]:
+    """A helper, with the public username answering a request now requires."""
+    return auth_header(tg_id, username=f"helper{tg_id}", **extra)
+
+
+async def post_request(client: AsyncClient, text: str, tg_id: int = STUDENT) -> dict:
+    response = await client.post(
+        "/api/v1/requests", json={"text": text}, headers=auth_header(tg_id)
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+# ── who may look ────────────────────────────────────────────────────────
+
+
+async def test_feed_refuses_someone_with_no_profile(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/requests/feed", headers=auth_header(OTHER))
+    assert response.status_code == 403
+
+
+async def test_draft_helper_may_look_but_not_answer(
+    client: AsyncClient, session: AsyncSession, helper_factory
+) -> None:
+    """Seeing the demand is the argument for finishing the profile."""
+    created = await post_request(client, "нужна помощь с матаном, ЧВУТ")
+    helper = await helper_factory(tg_id=HELPER)
+    profile = await session.get(HelperProfile, helper.id)
+    profile.status = PublishStatus.DRAFT
+    await session.commit()
+
+    feed = await client.get("/api/v1/requests/feed", headers=helper_header())
+    assert feed.status_code == 200
+    assert created["id"] in [item["id"] for item in feed.json()]
+
+    answer = await client.post(
+        f"/api/v1/requests/{created['id']}/respond",
+        json={"message": "могу помочь"},
+        headers=helper_header(),
+    )
+    assert answer.status_code == 403
+
+
+async def test_feed_hides_your_own_requests(client: AsyncClient, helper_factory) -> None:
+    await helper_factory(tg_id=HELPER)
+    mine = await post_request(client, "ищу помощь с матаном", tg_id=HELPER)
+
+    feed = await client.get("/api/v1/requests/feed", headers=helper_header())
+    assert mine["id"] not in [item["id"] for item in feed.json()]
+
+
+async def test_feed_ranks_your_subject_first_and_says_why(
+    client: AsyncClient, session: AsyncSession, helper_factory
+) -> None:
+    """A request about what you teach outranks one posted more recently."""
+    await helper_factory(tg_id=HELPER, subject_slug="matematicka-analyza")
+    on_subject = await post_request(client, "матан ЧВУТ, экзамен через неделю")
+    # Posted after, so only relevance can put the other one first.
+    await post_request(client, "нужен фотограф на выпускной")
+
+    feed = (await client.get("/api/v1/requests/feed", headers=helper_header())).json()
+    assert feed[0]["id"] == on_subject["id"]
+    assert feed[0]["reason"]["code"] == "feed.same_subject"
+    # The author is shown; who else is bidding is not.
+    assert feed[0]["author_name"]
+    assert "responders" not in feed[0] or feed[0]["responders"] == []
+
+
+async def test_feed_drops_a_request_you_already_answered(
+    client: AsyncClient, helper_factory
+) -> None:
+    await helper_factory(tg_id=HELPER)
+    created = await post_request(client, "матан, нужна помощь")
+
+    answered = await client.post(
+        f"/api/v1/requests/{created['id']}/respond",
+        json={"message": "помогу, готовил к этому экзамену"},
+        headers=helper_header(),
+    )
+    assert answered.status_code == 201, answered.text
+
+    feed = (await client.get("/api/v1/requests/feed", headers=helper_header())).json()
+    assert created["id"] not in [item["id"] for item in feed]
+
+
+async def test_feed_hides_closed_requests(client: AsyncClient, helper_factory) -> None:
+    await helper_factory(tg_id=HELPER)
+    created = await post_request(client, "матан срочно")
+    await client.post(
+        f"/api/v1/requests/{created['id']}/close", headers=auth_header(STUDENT)
+    )
+
+    feed = (await client.get("/api/v1/requests/feed", headers=helper_header())).json()
+    assert created["id"] not in [item["id"] for item in feed]
+
+
+# ── answering ───────────────────────────────────────────────────────────
+
+
+async def test_answering_shows_up_for_the_author(
+    client: AsyncClient, helper_factory
+) -> None:
+    await helper_factory(tg_id=HELPER, first_name="Marek")
+    created = await post_request(client, "матан, ЧВУТ, экзамен 14 февраля")
+
+    # The name comes from initData, not from our row: Telegram owns it, and
+    # `remember` overwrites what the fixture invented on every call.
+    answer = await client.post(
+        f"/api/v1/requests/{created['id']}/respond",
+        json={"message": "готовил к этому экзамену, могу помочь", "price_amount": 500},
+        headers=helper_header(first_name="Marek"),
+    )
+    assert answer.status_code == 201, answer.text
+    assert answer.json()["price"]["amount"] == 500
+    assert answer.json()["status"] == "sent"
+
+    listed = await client.get(
+        f"/api/v1/requests/{created['id']}/responses", headers=auth_header(STUDENT)
+    )
+    assert listed.status_code == 200
+    [row] = listed.json()
+    assert row["name"].startswith("Marek")
+    assert row["message"].startswith("готовил")
+
+    mine = (await client.get("/api/v1/requests", headers=auth_header(STUDENT))).json()
+    assert mine[0]["responses_count"] == 1
+
+
+async def test_reading_the_answers_marks_them_read(
+    client: AsyncClient, helper_factory
+) -> None:
+    await helper_factory(tg_id=HELPER)
+    created = await post_request(client, "матан")
+    await client.post(
+        f"/api/v1/requests/{created['id']}/respond",
+        json={"message": "могу помочь с этим"},
+        headers=helper_header(),
+    )
+
+    first = await client.get(
+        f"/api/v1/requests/{created['id']}/responses", headers=auth_header(STUDENT)
+    )
+    assert first.json()[0]["status"] == "sent"
+
+    second = await client.get(
+        f"/api/v1/requests/{created['id']}/responses", headers=auth_header(STUDENT)
+    )
+    assert second.json()[0]["status"] == "read"
+
+
+async def test_answering_twice_is_refused(client: AsyncClient, helper_factory) -> None:
+    """One answer per helper. Repeat pitching is spam."""
+    await helper_factory(tg_id=HELPER)
+    created = await post_request(client, "матан")
+    body = {"message": "могу помочь с матаном"}
+
+    first = await client.post(
+        f"/api/v1/requests/{created['id']}/respond",
+        json=body,
+        headers=helper_header(),
+    )
+    assert first.status_code == 201
+    second = await client.post(
+        f"/api/v1/requests/{created['id']}/respond",
+        json=body,
+        headers=helper_header(),
+    )
+    assert second.status_code == 409
+
+
+async def test_answering_your_own_request_is_refused(
+    client: AsyncClient, helper_factory
+) -> None:
+    await helper_factory(tg_id=HELPER)
+    mine = await post_request(client, "матан", tg_id=HELPER)
+
+    answer = await client.post(
+        f"/api/v1/requests/{mine['id']}/respond",
+        json={"message": "сам себе помогу"},
+        headers=helper_header(),
+    )
+    assert answer.status_code == 400
+
+
+async def test_answering_a_closed_request_is_refused(
+    client: AsyncClient, helper_factory
+) -> None:
+    await helper_factory(tg_id=HELPER)
+    created = await post_request(client, "матан")
+    await client.post(
+        f"/api/v1/requests/{created['id']}/close", headers=auth_header(STUDENT)
+    )
+
+    answer = await client.post(
+        f"/api/v1/requests/{created['id']}/respond",
+        json={"message": "могу помочь"},
+        headers=helper_header(),
+    )
+    assert answer.status_code == 409
+
+
+async def test_an_expired_request_cannot_be_answered(
+    client: AsyncClient, session: AsyncSession, helper_factory
+) -> None:
+    """Open but past its deadline is closed in every way that matters."""
+    from datetime import UTC, datetime, timedelta
+
+    await helper_factory(tg_id=HELPER)
+    created = await post_request(client, "матан, экзамен завтра")
+    request = await session.get(HelpRequest, created["id"])
+    request.expires_at = datetime.now(UTC) - timedelta(days=1)
+    await session.commit()
+
+    feed = (await client.get("/api/v1/requests/feed", headers=helper_header())).json()
+    assert created["id"] not in [item["id"] for item in feed]
+
+    answer = await client.post(
+        f"/api/v1/requests/{created['id']}/respond",
+        json={"message": "могу помочь"},
+        headers=helper_header(),
+    )
+    assert answer.status_code == 409
+
+
+# ── the author's side ───────────────────────────────────────────────────
+
+
+async def test_answers_are_not_a_public_bid_list(
+    client: AsyncClient, helper_factory
+) -> None:
+    await helper_factory(tg_id=HELPER)
+    created = await post_request(client, "матан")
+    await client.post(
+        f"/api/v1/requests/{created['id']}/respond",
+        json={"message": "могу помочь"},
+        headers=helper_header(),
+    )
+
+    # Not the author, and not even the helper who answered.
+    for tg_id in (OTHER, HELPER):
+        peeking = await client.get(
+            f"/api/v1/requests/{created['id']}/responses", headers=auth_header(tg_id)
+        )
+        assert peeking.status_code == 404
+
+
+async def test_accepting_records_a_contact_and_leaves_the_request_open(
+    client: AsyncClient, session: AsyncSession, helper_factory
+) -> None:
+    helper = await helper_factory(tg_id=HELPER)
+    created = await post_request(client, "матан")
+    answer = (
+        await client.post(
+            f"/api/v1/requests/{created['id']}/respond",
+            json={"message": "могу помочь"},
+            headers=helper_header(),
+        )
+    ).json()
+
+    accepted = await client.post(
+        f"/api/v1/responses/{answer['id']}/accept", headers=auth_header(STUDENT)
+    )
+    assert accepted.status_code == 200
+    assert accepted.json()["status"] == "accepted"
+
+    student = await session.scalar(select(User).where(User.tg_id == STUDENT))
+    contact = await session.scalar(
+        select(Contact).where(
+            Contact.student_id == student.id, Contact.helper_id == helper.id
+        )
+    )
+    assert contact is not None
+    assert contact.request_id == created["id"]
+
+    # Needing two people for two subjects is ordinary.
+    request = await session.get(HelpRequest, created["id"])
+    await session.refresh(request)
+    assert request.status is RequestStatus.OPEN
+
+
+async def test_only_the_author_may_accept(client: AsyncClient, helper_factory) -> None:
+    await helper_factory(tg_id=HELPER)
+    created = await post_request(client, "матан")
+    answer = (
+        await client.post(
+            f"/api/v1/requests/{created['id']}/respond",
+            json={"message": "могу помочь"},
+            headers=helper_header(),
+        )
+    ).json()
+
+    for tg_id in (OTHER, HELPER):
+        stolen = await client.post(
+            f"/api/v1/responses/{answer['id']}/accept", headers=auth_header(tg_id)
+        )
+        assert stolen.status_code == 404
+
+
+async def test_declining(client: AsyncClient, helper_factory) -> None:
+    await helper_factory(tg_id=HELPER)
+    created = await post_request(client, "матан")
+    answer = (
+        await client.post(
+            f"/api/v1/requests/{created['id']}/respond",
+            json={"message": "могу помочь"},
+            headers=helper_header(),
+        )
+    ).json()
+
+    declined = await client.post(
+        f"/api/v1/responses/{answer['id']}/decline", headers=auth_header(STUDENT)
+    )
+    assert declined.status_code == 200
+    assert declined.json()["status"] == "declined"
+
+
+# ── what the review of this feature turned up ───────────────────────────
+
+
+async def _answer(client: AsyncClient, request_id: int, tg_id: int = HELPER) -> dict:
+    response = await client.post(
+        f"/api/v1/requests/{request_id}/respond",
+        json={"message": "могу помочь с этим"},
+        headers=helper_header(tg_id),
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+async def test_a_banned_profile_cannot_read_the_feed(
+    client: AsyncClient, session: AsyncSession, helper_factory
+) -> None:
+    """The feed is names, faces and budgets — a target list for a banned account."""
+    await post_request(client, "матан, ЧВУТ")
+    helper = await helper_factory(tg_id=HELPER)
+    profile = await session.get(HelperProfile, helper.id)
+    profile.status = PublishStatus.BANNED
+    await session.commit()
+
+    feed = await client.get("/api/v1/requests/feed", headers=helper_header())
+    assert feed.status_code == 403
+
+
+async def test_answering_needs_a_public_username(
+    client: AsyncClient, helper_factory
+) -> None:
+    """Without one the author has nowhere to write, so the deal is a dead end."""
+    await helper_factory(tg_id=HELPER)
+    created = await post_request(client, "матан")
+
+    answer = await client.post(
+        f"/api/v1/requests/{created['id']}/respond",
+        json={"message": "могу помочь"},
+        # No username in the init data.
+        headers=auth_header(HELPER),
+    )
+    assert answer.status_code == 409
+    assert "username" in answer.json()["detail"]
+
+
+async def test_a_blank_answer_is_refused(client: AsyncClient, helper_factory) -> None:
+    """min_length sees the raw string; "   " would be stored as an empty message."""
+    await helper_factory(tg_id=HELPER)
+    created = await post_request(client, "матан")
+
+    answer = await client.post(
+        f"/api/v1/requests/{created['id']}/respond",
+        json={"message": "     "},
+        headers=helper_header(),
+    )
+    assert answer.status_code == 422
+
+
+async def test_accepting_twice_records_one_contact(
+    client: AsyncClient, session: AsyncSession, helper_factory
+) -> None:
+    """A double tap must not invent a second deal, or a second notification."""
+    helper = await helper_factory(tg_id=HELPER)
+    created = await post_request(client, "матан")
+    answer = await _answer(client, created["id"])
+
+    for _ in range(3):
+        accepted = await client.post(
+            f"/api/v1/responses/{answer['id']}/accept", headers=auth_header(STUDENT)
+        )
+        assert accepted.status_code == 200
+        assert accepted.json()["status"] == "accepted"
+
+    student = await session.scalar(select(User).where(User.tg_id == STUDENT))
+    contacts = await session.scalar(
+        select(func.count(Contact.id)).where(
+            Contact.student_id == student.id, Contact.helper_id == helper.id
+        )
+    )
+    assert contacts == 1
+
+
+async def test_an_accepted_answer_cannot_be_declined(
+    client: AsyncClient, helper_factory
+) -> None:
+    """Otherwise the author reads "declined" while the helper reads "chosen"."""
+    await helper_factory(tg_id=HELPER)
+    created = await post_request(client, "матан")
+    answer = await _answer(client, created["id"])
+
+    await client.post(
+        f"/api/v1/responses/{answer['id']}/accept", headers=auth_header(STUDENT)
+    )
+    declined = await client.post(
+        f"/api/v1/responses/{answer['id']}/decline", headers=auth_header(STUDENT)
+    )
+    assert declined.status_code == 409
+
+
+async def test_the_feed_does_not_say_how_many_others_answered(
+    client: AsyncClient, helper_factory
+) -> None:
+    """A helper who can see "already contested" simply skips those."""
+    await helper_factory(tg_id=HELPER)
+    await helper_factory(tg_id=OTHER, first_name="Petra")
+    created = await post_request(client, "матан")
+    await _answer(client, created["id"], tg_id=OTHER)
+
+    feed = (await client.get("/api/v1/requests/feed", headers=helper_header())).json()
+    [row] = [item for item in feed if item["id"] == created["id"]]
+    assert "responses_count" not in row
+    assert "responders" not in row

--- a/apps/web/src/components/Incoming.tsx
+++ b/apps/web/src/components/Incoming.tsx
@@ -1,0 +1,262 @@
+import { Trans, useLingui } from '@lingui/react/macro';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useNavigate } from 'react-router';
+
+import { formatDay, PhraseView } from '@/components/Phrase';
+import {
+  Action,
+  Actions,
+  AvatarView,
+  Card,
+  Cards,
+  Empty,
+  formatMoney,
+  Reason,
+  SkeletonRows,
+  ui,
+} from '@/components/Ui';
+import { hapticSuccess } from '@/hooks/useTelegram';
+import { ApiError, api } from '@/lib/api';
+import type { FeedRequest } from '@/lib/types';
+
+/**
+ * What people are asking for, for someone who could answer.
+ *
+ * The composer is inside the card rather than on a screen of its own: an
+ * answer is two sentences and a number, and making it a destination would put
+ * a navigation either side of thirty seconds of typing.
+ */
+export function Incoming() {
+  const navigate = useNavigate();
+  const { i18n } = useLingui();
+  const [openId, setOpenId] = useState<number | null>(null);
+
+  const { data, isPending, isError, error } = useQuery({
+    queryKey: ['request-feed'],
+    queryFn: ({ signal }) => api.getRequestFeed(signal),
+  });
+
+  // 403 is not a failure here: it is the answer for someone who has no helper
+  // profile, and the useful response is the invitation to make one.
+  if (isError && error instanceof ApiError && error.status === 403) {
+    return (
+      <Empty
+        title={<Trans>Сначала заполни профиль</Trans>}
+        body={<Trans>Заявки видят те, кто может на них ответить.</Trans>}
+      />
+    );
+  }
+
+  if (isPending) return <SkeletonRows count={3} />;
+  if (isError) return <Empty title={<Trans>Не получилось загрузить</Trans>} />;
+  if (data.length === 0) {
+    return (
+      <Empty
+        title={<Trans>Пока никто ничего не просит</Trans>}
+        body={
+          <Trans>
+            Здесь появятся заявки по твоим предметам. Чем больше предметов в профиле, тем
+            чаще.
+          </Trans>
+        }
+      />
+    );
+  }
+
+  return (
+    <Cards>
+      {data.map((request) => (
+        <FeedCard
+          key={request.id}
+          request={request}
+          locale={i18n.locale}
+          isOpen={openId === request.id}
+          onToggle={() => setOpenId(openId === request.id ? null : request.id)}
+          onDone={() => {
+            setOpenId(null);
+            navigate('/mine?tab=incoming');
+          }}
+        />
+      ))}
+    </Cards>
+  );
+}
+
+function FeedCard({
+  request,
+  locale,
+  isOpen,
+  onToggle,
+  onDone,
+}: {
+  request: FeedRequest;
+  locale: string;
+  isOpen: boolean;
+  onToggle: () => void;
+  onDone: () => void;
+}) {
+  const { t } = useLingui();
+  const queryClient = useQueryClient();
+  const [message, setMessage] = useState('');
+  const [price, setPrice] = useState('');
+
+  const respond = useMutation({
+    mutationFn: () =>
+      api.respondToRequest(request.id, {
+        message: message.trim(),
+        // An empty field means "did not say", not zero.
+        price_amount: price.trim() ? Number(price) : undefined,
+        price_unit: price.trim() ? 'hour' : undefined,
+      }),
+    onSuccess: () => {
+      hapticSuccess();
+      // The request drops out of the feed once answered, so the list is stale
+      // the moment this succeeds.
+      void queryClient.invalidateQueries({ queryKey: ['request-feed'] });
+      onDone();
+    },
+  });
+
+  const title =
+    [request.subject, request.institution].filter(Boolean).join(', ') || request.text;
+  const amount = Number(price);
+  const priceValid = !price.trim() || (Number.isFinite(amount) && amount >= 0);
+  const ready = message.trim().length >= 3 && priceValid && !respond.isPending;
+
+  return (
+    <Card>
+      {/* Not a <button> wrapping the whole card: a button may only contain
+          phrasing content, and this holds paragraphs. The toggle is its own
+          control at the bottom, which also makes the affordance explicit
+          instead of "tap the card and find out". */}
+      <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+        <AvatarView avatar={request.author} size={34} />
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div className={ui.cardName}>{title}</div>
+          <div style={{ marginTop: 2, fontSize: 12, color: 'var(--muted)' }}>
+            {request.author_name}
+            {request.deadline_on ? (
+              <>
+                {' · '}
+                <Trans>до {formatDay(request.deadline_on, locale)}</Trans>
+              </>
+            ) : null}
+          </div>
+        </div>
+        {request.budget?.amount != null ? (
+          <div className={ui.priceAmount} style={{ flex: 'none' }}>
+            {formatMoney(request.budget.amount)} {request.budget.currency}
+          </div>
+        ) : null}
+      </div>
+
+      {/* The words they typed, not our parse of them — collapsed to two
+          lines until the card is opened. */}
+      <p
+        style={{
+          margin: '8px 0 0',
+          fontSize: 13,
+          lineHeight: 1.45,
+          color: 'var(--ink-soft)',
+          ...(isOpen
+            ? {}
+            : {
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }),
+        }}
+      >
+        {request.text}
+      </p>
+
+      {request.reason ? (
+        <Reason>
+          <PhraseView phrase={request.reason} locale={locale} />
+        </Reason>
+      ) : null}
+
+      {isOpen ? null : (
+        <Actions>
+          {/* Quiet: the list is a page of these, and a column of filled
+              buttons reads as a wall rather than as a choice. The filled one
+              is the send inside the composer, where there is exactly one. */}
+          <Action quiet onClick={onToggle}>
+            <Trans>Откликнуться</Trans>
+          </Action>
+        </Actions>
+      )}
+
+      {isOpen ? (
+        <div style={{ marginTop: 12 }}>
+          <div className={ui.field} style={{ alignItems: 'flex-start' }}>
+            <textarea
+              value={message}
+              onChange={(event) => setMessage(event.target.value)}
+              placeholder={t`Чем можешь помочь и когда`}
+              rows={3}
+              maxLength={1000}
+              style={{ all: 'unset', width: '100%', resize: 'none', lineHeight: 1.4 }}
+            />
+          </div>
+
+          <div className={ui.field} style={{ marginTop: 8 }}>
+            <input
+              value={price}
+              onChange={(event) => setPrice(event.target.value)}
+              placeholder={t`Цена за час, Kč — необязательно`}
+              // Numeric keypad without the spinner arrows a number input adds.
+              inputMode="decimal"
+              style={{ all: 'unset', width: '100%' }}
+            />
+          </div>
+
+          {respond.isError ? (
+            <Reason weak>
+              <RespondError error={respond.error} />
+            </Reason>
+          ) : null}
+
+          <Actions>
+            <Action onClick={() => respond.mutate()} disabled={!ready}>
+              <Trans>Отправить</Trans>
+            </Action>
+            <Action quiet onClick={onToggle}>
+              <Trans>Не сейчас</Trans>
+            </Action>
+          </Actions>
+        </div>
+      ) : null}
+    </Card>
+  );
+}
+
+/**
+ * Why the answer did not go out.
+ *
+ * Three different things return 409 — the request closed while the composer
+ * was open, this helper has answered before, and Telegram has no public
+ * username to write back to — and each needs a different next step from the
+ * reader, so the status code alone is not enough to pick a sentence.
+ */
+function RespondError({ error }: { error: unknown }) {
+  if (!(error instanceof ApiError)) {
+    return <Trans>Не отправилось — попробуй ещё раз</Trans>;
+  }
+  const detail =
+    typeof error.detail === 'object' && error.detail !== null
+      ? String((error.detail as { detail?: unknown }).detail ?? '')
+      : '';
+
+  if (error.status === 403) return <Trans>Сначала опубликуй профиль</Trans>;
+  if (error.status === 409 && detail.includes('username')) {
+    return <Trans>Заведи в Telegram публичный @username — иначе тебе не ответят</Trans>;
+  }
+  if (error.status === 409 && detail.includes('already')) {
+    return <Trans>На эту заявку ты уже отвечал</Trans>;
+  }
+  if (error.status === 409) return <Trans>Заявку уже закрыли</Trans>;
+  return <Trans>Не отправилось — попробуй ещё раз</Trans>;
+}

--- a/apps/web/src/components/Phrase.tsx
+++ b/apps/web/src/components/Phrase.tsx
@@ -60,6 +60,12 @@ export function PhraseView({
       return <Trans>Ведёт предмет, но не привязан к этому вузу</Trans>;
     case 'reason.your_faculty':
       return <Trans>С твоего факультета</Trans>;
+    case 'feed.same_subject':
+      return <Trans>Твой предмет — {str(p.subject)}</Trans>;
+    case 'feed.same_institution':
+      return <Trans>Вуз, с которым ты работаешь</Trans>;
+    case 'feed.same_service':
+      return <Trans>То, чем ты занимаешься</Trans>;
     case 'reason.experience':
       return (
         <Plural

--- a/apps/web/src/components/Ui.tsx
+++ b/apps/web/src/components/Ui.tsx
@@ -348,6 +348,41 @@ export function Segmented<T extends string>({
   );
 }
 
+// ── actions ─────────────────────────────────────────────────────────────
+
+export function Actions({ children }: { children: ReactNode }) {
+  return <div className={css.actions}>{children}</div>;
+}
+
+/**
+ * A button inside the page, as opposed to Telegram's main button.
+ *
+ * There is only one main button and it belongs to the screen; a list where
+ * every card can be accepted or turned down needs its own.
+ */
+export function Action({
+  children,
+  onClick,
+  quiet,
+  disabled,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+  quiet?: boolean;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      className={`${css.action} ${quiet ? css.actionQuiet : ''} ${css.pressable}`}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+}
+
 // ── states ──────────────────────────────────────────────────────────────
 
 export function Empty({ title, body }: { title: ReactNode; body?: ReactNode }) {

--- a/apps/web/src/components/ui.module.css
+++ b/apps/web/src/components/ui.module.css
@@ -559,6 +559,46 @@
   color: var(--muted);
 }
 
+/* ── actions ────────────────────────────────────────────────────────── */
+
+/* An in-page action, for the ones Telegram's single main button cannot cover:
+   a card with accept and decline needs two, and both live inside a list. */
+.actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.action {
+  flex: 1;
+  min-height: 38px;
+  padding: 9px 14px;
+  border: 0;
+  border-radius: var(--r-pill);
+  background: var(--accent);
+  color: var(--accent-ink);
+  font-size: 13.5px;
+  font-weight: 640;
+  letter-spacing: -0.01em;
+  text-align: center;
+}
+
+.action:active {
+  opacity: 0.82;
+}
+
+.action:disabled {
+  opacity: 0.4;
+}
+
+/* The one you are not meant to reach for first. Same size, no fill — the
+   weight difference is what makes accept the obvious tap. */
+.actionQuiet {
+  background: var(--bg);
+  color: var(--ink-soft);
+  box-shadow: inset 0 0 0 1px var(--hairline);
+}
+
 /* Skeletons rather than a spinner: the layout does not jump when data lands,
    and the shape tells you what is coming. */
 .skeleton {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2,6 +2,7 @@ import { retrieveRawInitData } from '@tma.js/sdk-react';
 
 import type {
   ContactStart,
+  FeedRequest,
   HelperDetail,
   HelperUpsert,
   HelpRequest,
@@ -14,6 +15,8 @@ import type {
   ParseResult,
   Placement,
   RequestCreate,
+  RequestResponse,
+  ResponseCreate,
   SearchParams,
   SearchResult,
   ServiceType,
@@ -233,6 +236,26 @@ export const api = {
 
   closeRequest: (requestId: number) =>
     request<HelpRequest>(`/requests/${requestId}/close`, { method: 'POST' }),
+
+  /** Open requests worth answering. Helpers only; 403 for everyone else. */
+  getRequestFeed: (signal?: AbortSignal) =>
+    request<FeedRequest[]>('/requests/feed', { signal }),
+
+  respondToRequest: (requestId: number, payload: ResponseCreate) =>
+    request<RequestResponse>(`/requests/${requestId}/respond`, {
+      method: 'POST',
+      body: payload,
+    }),
+
+  /** Who answered. The author of the request only. */
+  getResponses: (requestId: number, signal?: AbortSignal) =>
+    request<RequestResponse[]>(`/requests/${requestId}/responses`, { signal }),
+
+  acceptResponse: (responseId: number) =>
+    request<RequestResponse>(`/responses/${responseId}/accept`, { method: 'POST' }),
+
+  declineResponse: (responseId: number) =>
+    request<RequestResponse>(`/responses/${responseId}/decline`, { method: 'POST' }),
 
   // ── becoming a helper ─────────────────────────────────────────────────
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -300,6 +300,43 @@ export interface RequestCreate {
   langs?: string[];
 }
 
+/**
+ * A request as a helper sees it: who is asking, and why it surfaced. No
+ * `responders` — who else is pitching for the same work is not shown.
+ */
+export interface FeedRequest extends Omit<HelpRequest, 'responders'> {
+  author: Avatar;
+  author_name: string;
+  budget: Price | null;
+  langs: string[];
+  reason: Phrase | null;
+}
+
+export type ResponseStatus = 'sent' | 'read' | 'accepted' | 'declined';
+
+/** One helper's answer to a request. */
+export interface RequestResponse {
+  id: number;
+  request_id: number;
+  helper_id: number;
+  name: string;
+  avatar: Avatar;
+  username: string | null;
+  affiliation: string | null;
+  rating: number | null;
+  deals_count: number;
+  message: string;
+  price: Price | null;
+  status: ResponseStatus;
+  created_at: string;
+}
+
+export interface ResponseCreate {
+  message: string;
+  price_amount?: number;
+  price_unit?: PriceUnit;
+}
+
 // ── becoming a helper ───────────────────────────────────────────────────
 
 export interface IntroResult {

--- a/apps/web/src/locales/cs/messages.po
+++ b/apps/web/src/locales/cs/messages.po
@@ -13,9 +13,21 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n>=2 && n<=4) ? 1 : n%1!=0 ? 2 : 3);\n"
 
+#: src/components/Incoming.tsx
+msgid "Заведи в Telegram публичный @username — иначе тебе не ответят"
+msgstr "Nastav si v Telegramu veřejný @username — jinak ti nikdo neodpoví"
+
+#: src/components/Incoming.tsx
+msgid "Здесь появятся заявки по твоим предметам. Чем больше предметов в профиле, тем чаще."
+msgstr "Tady se objeví poptávky k tvým předmětům. Čím víc předmětů máš v profilu, tím častěji."
+
 #: src/components/Phrase.tsx
 msgid "оценка"
 msgstr "hodnocení"
+
+#: src/components/Phrase.tsx
+msgid "То, чем ты занимаешься"
+msgstr "To, co děláš"
 
 #: src/pages/Results.tsx
 msgid "Свободны"
@@ -29,9 +41,17 @@ msgstr "Online"
 msgid "Напиши хотя бы пару предложений — предметы, цену и как удобно заниматься."
 msgstr "Napiš aspoň pár vět — jaké předměty, za kolik a jak ti vyhovuje mít hodiny."
 
+#: src/pages/Request.tsx
+msgid "Такой заявки нет"
+msgstr "Taková poptávka neexistuje"
+
 #: src/components/TabBar.tsx
 msgid "Поиск"
 msgstr "Hledat"
+
+#: src/components/Incoming.tsx
+msgid "Не сейчас"
+msgstr "Teď ne"
 
 #: src/pages/Profile.tsx
 msgid "Чешский для вуза"
@@ -44,6 +64,10 @@ msgstr "Jak to probíhá"
 #: src/components/Phrase.tsx
 msgid "за неделю"
 msgstr "za týden"
+
+#: src/components/Incoming.tsx
+msgid "Откликнуться"
+msgstr "Odpovědět"
 
 #: src/pages/BecomeHelper.tsx
 msgid "Когда ты свободен"
@@ -81,14 +105,29 @@ msgstr "Na tenhle dotaz zatím nikdo není. Založ poptávku — pak si tě najd
 msgid "Хочу помогать"
 msgstr "Chci pomáhat"
 
+#. placeholder {0}: str(p.subject)
+#: src/components/Phrase.tsx
+msgid "Твой предмет — {0}"
+msgstr "Tvůj předmět — {0}"
+
 #: src/pages/Profile.tsx
 msgid "расскажи своими словами, анкету соберём сами"
 msgstr "napiš to vlastními slovy, anketu sestavíme sami"
 
+#: src/components/Incoming.tsx
+msgid "Заявку уже закрыли"
+msgstr "Poptávka už je uzavřená"
+
+#: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
+#: src/pages/Request.tsx
 #: src/pages/Results.tsx
 msgid "Не получилось загрузить"
 msgstr "Nepodařilo se načíst"
+
+#: src/pages/Mine.tsx
+msgid "Мои заявки"
+msgstr "Moje poptávky"
 
 #: src/components/Phrase.tsx
 msgid "Не понял запрос. Попробуй назвать предмет — «матан», «čeština B2», «сопромат»."
@@ -101,6 +140,14 @@ msgstr "uspěli"
 #: src/pages/Life.tsx
 msgid "Партнёр"
 msgstr "Partner"
+
+#: src/pages/Mine.tsx
+msgid "Входящие"
+msgstr "Příchozí"
+
+#: src/components/Incoming.tsx
+msgid "Заявки видят те, кто может на них ответить."
+msgstr "Poptávky vidí ti, kdo na ně můžou odpovědět."
 
 #: src/pages/Helper.tsx
 msgid "Сколько стоит"
@@ -119,6 +166,10 @@ msgstr "Kolik si bereš"
 msgid "опубликована"
 msgstr "zveřejněna"
 
+#: src/pages/Request.tsx
+msgid "Отказать"
+msgstr "Odmítnout"
+
 #: src/pages/Mine.tsx
 msgid "Пока без откликов"
 msgstr "Zatím bez odpovědí"
@@ -130,6 +181,10 @@ msgstr "Rozhovory neukládáme"
 #: src/components/Phrase.tsx
 msgid "за работу"
 msgstr "za práci"
+
+#: src/components/Incoming.tsx
+msgid "Не отправилось — попробуй ещё раз"
+msgstr "Neodeslalo se — zkus to znovu"
 
 #: src/components/Phrase.tsx
 msgid "И то, и другое"
@@ -147,9 +202,17 @@ msgstr "za hodinu"
 msgid "Заявки"
 msgstr "Poptávky"
 
+#: src/pages/Request.tsx
+msgid "Выбрать"
+msgstr "Vybrat"
+
 #: src/pages/Mine.tsx
 msgid "Опиши, что нужно, и получай отклики — вместо того чтобы искать самому."
 msgstr "Popiš, co potřebuješ, a dostávej odpovědi — místo toho, abys hledal sám."
+
+#: src/components/Incoming.tsx
+msgid "Сначала опубликуй профиль"
+msgstr "Nejdřív zveřejni profil"
 
 #: src/components/Phrase.tsx
 msgid "за штуку"
@@ -183,6 +246,10 @@ msgstr "Tady se objeví pojištění, víza, banka a převody."
 msgid "Искать всё равно"
 msgstr "Hledat i tak"
 
+#: src/pages/Request.tsx
+msgid "Заявку видят те, кто ведёт этот предмет. Обычно отвечают в течение дня."
+msgstr "Poptávku vidí ti, kdo tenhle předmět učí. Obvykle odpovídají do dne."
+
 #: src/components/Phrase.tsx
 msgid "Ведёт предмет, но не привязан к этому вузу"
 msgstr "Učí ten předmět, ale na tuhle školu není vázaný"
@@ -207,6 +274,10 @@ msgstr "Bez rozvrhu anketu ukážeme, ale míň často — lidi častěji píšo
 #: src/components/Phrase.tsx
 msgid "Онлайн и очно"
 msgstr "Online i osobně"
+
+#: src/pages/Request.tsx
+msgid "Заявка"
+msgstr "Poptávka"
 
 #. placeholder {0}: formatDay(str(p.date), locale)
 #: src/components/Phrase.tsx
@@ -282,12 +353,18 @@ msgstr "Načítáme"
 msgid "всего {0}"
 msgstr "celkem {0}"
 
+#: src/components/Phrase.tsx
+msgid "Вуз, с которым ты работаешь"
+msgstr "Škola, se kterou pracuješ"
+
 #: src/pages/Chats.tsx
 msgid "Открыть переписку в Telegram"
 msgstr "Otevřít konverzaci v Telegramu"
 
 #. placeholder {0}: num(p.deals)
+#. placeholder {0}: response.deals_count
 #: src/components/Phrase.tsx
+#: src/pages/Request.tsx
 msgid "{0, plural, one {# занятие через нас} few {# занятия через нас} many {# занятий через нас} other {# занятия через нас}}"
 msgstr "{0, plural, one {# lekce přes nás} few {# lekce přes nás} many {# lekce přes nás} other {# lekcí přes nás}}"
 
@@ -299,14 +376,29 @@ msgstr "S čím pomáhá"
 msgid "в месяц"
 msgstr "za měsíc"
 
+#. placeholder {0}: formatDay(request.deadline_on, i18n.locale)
 #. placeholder {0}: formatDay(request.deadline_on, locale)
+#: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
+#: src/pages/Request.tsx
 msgid "до {0}"
 msgstr "do {0}"
 
 #: src/pages/Profile.tsx
 msgid "Жизнь в Чехии"
 msgstr "Život v Česku"
+
+#: src/components/Incoming.tsx
+msgid "Пока никто ничего не просит"
+msgstr "Zatím nikdo o nic nežádá"
+
+#: src/components/Incoming.tsx
+msgid "Отправить"
+msgstr "Odeslat"
+
+#: src/pages/Request.tsx
+msgid "У этого человека нет @username — написать не получится"
+msgstr "Tenhle člověk nemá @username — nedá se mu napsat"
 
 #: src/components/Phrase.tsx
 msgid "за занятие"
@@ -338,6 +430,10 @@ msgstr "Zveřejnit"
 msgid "{0, plural, one {# отклик} few {# отклика} many {# откликов} other {# отклика}}"
 msgstr "{0, plural, one {# odpověď} few {# odpovědi} many {# odpovědi} other {# odpovědí}}"
 
+#: src/components/Incoming.tsx
+msgid "На эту заявку ты уже отвечал"
+msgstr "Na tuhle poptávku jsi už odpovídal"
+
 #: src/pages/Helper.tsx
 msgid "У этого человека нет открытого username в Telegram, написать не получится."
 msgstr "Tenhle člověk nemá veřejný username v Telegramu, napsat mu nepůjde."
@@ -346,6 +442,10 @@ msgstr "Tenhle člověk nemá veřejný username v Telegramu, napsat mu nepůjde
 #: src/pages/Helper.tsx
 msgid "Написать · {0} Kč"
 msgstr "Napsat · {0} Kč"
+
+#: src/pages/Request.tsx
+msgid "выбран"
+msgstr "vybrán"
 
 #: src/components/Phrase.tsx
 msgid "Работает именно с этим вузом"
@@ -366,6 +466,10 @@ msgstr "Profil není dostupný"
 #: src/pages/Home.tsx
 msgid "Нажми, чтобы попробовать ещё раз"
 msgstr "Zkus to znovu"
+
+#: src/components/Incoming.tsx
+msgid "Чем можешь помочь и когда"
+msgstr "S čím můžeš pomoct a kdy"
 
 #: src/pages/Mine.tsx
 msgid "Заявок пока нет"
@@ -397,11 +501,16 @@ msgstr "Jazyk aplikace"
 msgid "{0, plural, one {Отвечает примерно за # минуту} few {Отвечает примерно за # минуты} many {Отвечает примерно за # минут} other {Отвечает примерно за # минуты}}"
 msgstr "{0, plural, one {Odpovídá zhruba za # minutu} few {Odpovídá zhruba za # minuty} many {Odpovídá zhruba za # minuty} other {Odpovídá zhruba za # minut}}"
 
+#: src/pages/Request.tsx
+msgid "Ты отказался"
+msgstr "Odmítl jsi"
+
 #: src/pages/Ask.tsx
 msgid "Поняли так — поправь, если не то"
 msgstr "Pochopili jsme to takhle — oprav to, pokud to není ono"
 
 #: src/pages/Helper.tsx
+#: src/pages/Request.tsx
 msgid "Написать"
 msgstr "Napsat"
 
@@ -418,6 +527,14 @@ msgstr "Zobrazit {0}"
 msgid "Моя анкета"
 msgstr "Moje anketa"
 
+#: src/components/Incoming.tsx
+msgid "Цена за час, Kč — необязательно"
+msgstr "Cena za hodinu, Kč — nepovinné"
+
+#: src/pages/Request.tsx
+msgid "Откликов пока нет"
+msgstr "Zatím žádné odpovědi"
+
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"
 msgstr "Potřebuješ pomoc před zkouškou, nebo přímo na ní?"
@@ -426,6 +543,10 @@ msgstr "Potřebuješ pomoc před zkouškou, nebo přímo na ní?"
 #: src/pages/Mine.tsx
 msgid "Мои"
 msgstr "Moje"
+
+#: src/pages/Request.tsx
+msgid "Отклики"
+msgstr "Odpovědi"
 
 #: src/pages/Results.tsx
 msgid "Ищем…"
@@ -450,6 +571,10 @@ msgstr "za den"
 #: src/pages/Results.tsx
 msgid "Подходят"
 msgstr "Vyhovují"
+
+#: src/components/Incoming.tsx
+msgid "Сначала заполни профиль"
+msgstr "Nejdřív vyplň profil"
 
 #: src/components/Phrase.tsx
 msgid "Разобраться заранее"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -13,9 +13,21 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: src/components/Incoming.tsx
+msgid "Заведи в Telegram публичный @username — иначе тебе не ответят"
+msgstr "Set a public @username in Telegram — otherwise nobody can write back"
+
+#: src/components/Incoming.tsx
+msgid "Здесь появятся заявки по твоим предметам. Чем больше предметов в профиле, тем чаще."
+msgstr "Requests about your subjects will show up here. The more subjects in your profile, the more often."
+
 #: src/components/Phrase.tsx
 msgid "оценка"
 msgstr "rating"
+
+#: src/components/Phrase.tsx
+msgid "То, чем ты занимаешься"
+msgstr "What you do"
 
 #: src/pages/Results.tsx
 msgid "Свободны"
@@ -29,9 +41,17 @@ msgstr "Online"
 msgid "Напиши хотя бы пару предложений — предметы, цену и как удобно заниматься."
 msgstr "Write at least a couple sentences — subjects, price, and how you like to meet."
 
+#: src/pages/Request.tsx
+msgid "Такой заявки нет"
+msgstr "No such request"
+
 #: src/components/TabBar.tsx
 msgid "Поиск"
 msgstr "Search"
+
+#: src/components/Incoming.tsx
+msgid "Не сейчас"
+msgstr "Not now"
 
 #: src/pages/Profile.tsx
 msgid "Чешский для вуза"
@@ -44,6 +64,10 @@ msgstr "How it works"
 #: src/components/Phrase.tsx
 msgid "за неделю"
 msgstr "per week"
+
+#: src/components/Incoming.tsx
+msgid "Откликнуться"
+msgstr "Respond"
 
 #: src/pages/BecomeHelper.tsx
 msgid "Когда ты свободен"
@@ -81,14 +105,29 @@ msgstr "No one matches this search yet. Post a request — then people will find
 msgid "Хочу помогать"
 msgstr "I want to help"
 
+#. placeholder {0}: str(p.subject)
+#: src/components/Phrase.tsx
+msgid "Твой предмет — {0}"
+msgstr "Your subject — {0}"
+
 #: src/pages/Profile.tsx
 msgid "расскажи своими словами, анкету соберём сами"
 msgstr "tell it in your own words, we'll build the profile"
 
+#: src/components/Incoming.tsx
+msgid "Заявку уже закрыли"
+msgstr "This request is already closed"
+
+#: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
+#: src/pages/Request.tsx
 #: src/pages/Results.tsx
 msgid "Не получилось загрузить"
 msgstr "Couldn't load"
+
+#: src/pages/Mine.tsx
+msgid "Мои заявки"
+msgstr "My requests"
 
 #: src/components/Phrase.tsx
 msgid "Не понял запрос. Попробуй назвать предмет — «матан», «čeština B2», «сопромат»."
@@ -101,6 +140,14 @@ msgstr "passed"
 #: src/pages/Life.tsx
 msgid "Партнёр"
 msgstr "Partner"
+
+#: src/pages/Mine.tsx
+msgid "Входящие"
+msgstr "Incoming"
+
+#: src/components/Incoming.tsx
+msgid "Заявки видят те, кто может на них ответить."
+msgstr "Requests are visible to people who can answer them."
 
 #: src/pages/Helper.tsx
 msgid "Сколько стоит"
@@ -119,6 +166,10 @@ msgstr "What you charge"
 msgid "опубликована"
 msgstr "published"
 
+#: src/pages/Request.tsx
+msgid "Отказать"
+msgstr "Decline"
+
 #: src/pages/Mine.tsx
 msgid "Пока без откликов"
 msgstr "No responses yet"
@@ -130,6 +181,10 @@ msgstr "We don't store conversations"
 #: src/components/Phrase.tsx
 msgid "за работу"
 msgstr "per assignment"
+
+#: src/components/Incoming.tsx
+msgid "Не отправилось — попробуй ещё раз"
+msgstr "Did not send — try again"
 
 #: src/components/Phrase.tsx
 msgid "И то, и другое"
@@ -147,9 +202,17 @@ msgstr "per hour"
 msgid "Заявки"
 msgstr "Requests"
 
+#: src/pages/Request.tsx
+msgid "Выбрать"
+msgstr "Choose"
+
 #: src/pages/Mine.tsx
 msgid "Опиши, что нужно, и получай отклики — вместо того чтобы искать самому."
 msgstr "Describe what you need and get responses — instead of searching yourself."
+
+#: src/components/Incoming.tsx
+msgid "Сначала опубликуй профиль"
+msgstr "Publish your profile first"
 
 #: src/components/Phrase.tsx
 msgid "за штуку"
@@ -183,6 +246,10 @@ msgstr "Insurance, visas, banking, and transfers will show up here."
 msgid "Искать всё равно"
 msgstr "Search anyway"
 
+#: src/pages/Request.tsx
+msgid "Заявку видят те, кто ведёт этот предмет. Обычно отвечают в течение дня."
+msgstr "People who teach this subject can see your request. They usually answer within a day."
+
 #: src/components/Phrase.tsx
 msgid "Ведёт предмет, но не привязан к этому вузу"
 msgstr "Teaches the subject, but isn't tied to this university"
@@ -207,6 +274,10 @@ msgstr "Without a schedule we'll still show your profile, just less often — pe
 #: src/components/Phrase.tsx
 msgid "Онлайн и очно"
 msgstr "Online and in person"
+
+#: src/pages/Request.tsx
+msgid "Заявка"
+msgstr "Request"
 
 #. placeholder {0}: formatDay(str(p.date), locale)
 #: src/components/Phrase.tsx
@@ -282,12 +353,18 @@ msgstr "Loading"
 msgid "всего {0}"
 msgstr "{0} total"
 
+#: src/components/Phrase.tsx
+msgid "Вуз, с которым ты работаешь"
+msgstr "A school you work with"
+
 #: src/pages/Chats.tsx
 msgid "Открыть переписку в Telegram"
 msgstr "Open the chat in Telegram"
 
 #. placeholder {0}: num(p.deals)
+#. placeholder {0}: response.deals_count
 #: src/components/Phrase.tsx
+#: src/pages/Request.tsx
 msgid "{0, plural, one {# занятие через нас} few {# занятия через нас} many {# занятий через нас} other {# занятия через нас}}"
 msgstr "{0, plural, one {# lesson through us} other {# lessons through us}}"
 
@@ -299,14 +376,29 @@ msgstr "What they help with"
 msgid "в месяц"
 msgstr "per month"
 
+#. placeholder {0}: formatDay(request.deadline_on, i18n.locale)
 #. placeholder {0}: formatDay(request.deadline_on, locale)
+#: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
+#: src/pages/Request.tsx
 msgid "до {0}"
 msgstr "by {0}"
 
 #: src/pages/Profile.tsx
 msgid "Жизнь в Чехии"
 msgstr "Life in Czechia"
+
+#: src/components/Incoming.tsx
+msgid "Пока никто ничего не просит"
+msgstr "Nobody is asking for anything yet"
+
+#: src/components/Incoming.tsx
+msgid "Отправить"
+msgstr "Send"
+
+#: src/pages/Request.tsx
+msgid "У этого человека нет @username — написать не получится"
+msgstr "This person has no @username — there is no way to write to them"
 
 #: src/components/Phrase.tsx
 msgid "за занятие"
@@ -338,6 +430,10 @@ msgstr "Publish"
 msgid "{0, plural, one {# отклик} few {# отклика} many {# откликов} other {# отклика}}"
 msgstr "{0, plural, one {# response} other {# responses}}"
 
+#: src/components/Incoming.tsx
+msgid "На эту заявку ты уже отвечал"
+msgstr "You have already answered this request"
+
 #: src/pages/Helper.tsx
 msgid "У этого человека нет открытого username в Telegram, написать не получится."
 msgstr "This person doesn't have a public Telegram username, so you can't message them."
@@ -346,6 +442,10 @@ msgstr "This person doesn't have a public Telegram username, so you can't messag
 #: src/pages/Helper.tsx
 msgid "Написать · {0} Kč"
 msgstr "Message · {0} Kč"
+
+#: src/pages/Request.tsx
+msgid "выбран"
+msgstr "chosen"
 
 #: src/components/Phrase.tsx
 msgid "Работает именно с этим вузом"
@@ -366,6 +466,10 @@ msgstr "Profile unavailable"
 #: src/pages/Home.tsx
 msgid "Нажми, чтобы попробовать ещё раз"
 msgstr "Tap to try again"
+
+#: src/components/Incoming.tsx
+msgid "Чем можешь помочь и когда"
+msgstr "What you can help with, and when"
 
 #: src/pages/Mine.tsx
 msgid "Заявок пока нет"
@@ -397,11 +501,16 @@ msgstr "App language"
 msgid "{0, plural, one {Отвечает примерно за # минуту} few {Отвечает примерно за # минуты} many {Отвечает примерно за # минут} other {Отвечает примерно за # минуты}}"
 msgstr "{0, plural, one {Replies in about # minute} other {Replies in about # minutes}}"
 
+#: src/pages/Request.tsx
+msgid "Ты отказался"
+msgstr "You declined"
+
 #: src/pages/Ask.tsx
 msgid "Поняли так — поправь, если не то"
 msgstr "This is what we understood — fix it if that's wrong"
 
 #: src/pages/Helper.tsx
+#: src/pages/Request.tsx
 msgid "Написать"
 msgstr "Message"
 
@@ -418,6 +527,14 @@ msgstr "Show {0}"
 msgid "Моя анкета"
 msgstr "My profile"
 
+#: src/components/Incoming.tsx
+msgid "Цена за час, Kč — необязательно"
+msgstr "Price per hour, Kč — optional"
+
+#: src/pages/Request.tsx
+msgid "Откликов пока нет"
+msgstr "No responses yet"
+
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"
 msgstr "Do you need help before the exam or during it?"
@@ -426,6 +543,10 @@ msgstr "Do you need help before the exam or during it?"
 #: src/pages/Mine.tsx
 msgid "Мои"
 msgstr "Mine"
+
+#: src/pages/Request.tsx
+msgid "Отклики"
+msgstr "Responses"
 
 #: src/pages/Results.tsx
 msgid "Ищем…"
@@ -450,6 +571,10 @@ msgstr "per day"
 #: src/pages/Results.tsx
 msgid "Подходят"
 msgstr "Good match"
+
+#: src/components/Incoming.tsx
+msgid "Сначала заполни профиль"
+msgstr "Fill in your profile first"
 
 #: src/components/Phrase.tsx
 msgid "Разобраться заранее"

--- a/apps/web/src/locales/ru/messages.po
+++ b/apps/web/src/locales/ru/messages.po
@@ -13,9 +13,21 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
+#: src/components/Incoming.tsx
+msgid "Заведи в Telegram публичный @username — иначе тебе не ответят"
+msgstr "Заведи в Telegram публичный @username — иначе тебе не ответят"
+
+#: src/components/Incoming.tsx
+msgid "Здесь появятся заявки по твоим предметам. Чем больше предметов в профиле, тем чаще."
+msgstr "Здесь появятся заявки по твоим предметам. Чем больше предметов в профиле, тем чаще."
+
 #: src/components/Phrase.tsx
 msgid "оценка"
 msgstr "оценка"
+
+#: src/components/Phrase.tsx
+msgid "То, чем ты занимаешься"
+msgstr "То, чем ты занимаешься"
 
 #: src/pages/Results.tsx
 msgid "Свободны"
@@ -29,9 +41,17 @@ msgstr "Онлайн"
 msgid "Напиши хотя бы пару предложений — предметы, цену и как удобно заниматься."
 msgstr "Напиши хотя бы пару предложений — предметы, цену и как удобно заниматься."
 
+#: src/pages/Request.tsx
+msgid "Такой заявки нет"
+msgstr "Такой заявки нет"
+
 #: src/components/TabBar.tsx
 msgid "Поиск"
 msgstr "Поиск"
+
+#: src/components/Incoming.tsx
+msgid "Не сейчас"
+msgstr "Не сейчас"
 
 #: src/pages/Profile.tsx
 msgid "Чешский для вуза"
@@ -44,6 +64,10 @@ msgstr "Как проходит"
 #: src/components/Phrase.tsx
 msgid "за неделю"
 msgstr "за неделю"
+
+#: src/components/Incoming.tsx
+msgid "Откликнуться"
+msgstr "Откликнуться"
 
 #: src/pages/BecomeHelper.tsx
 msgid "Когда ты свободен"
@@ -81,14 +105,29 @@ msgstr "По этому запросу ещё нет никого. Создай 
 msgid "Хочу помогать"
 msgstr "Хочу помогать"
 
+#. placeholder {0}: str(p.subject)
+#: src/components/Phrase.tsx
+msgid "Твой предмет — {0}"
+msgstr "Твой предмет — {0}"
+
 #: src/pages/Profile.tsx
 msgid "расскажи своими словами, анкету соберём сами"
 msgstr "расскажи своими словами, анкету соберём сами"
 
+#: src/components/Incoming.tsx
+msgid "Заявку уже закрыли"
+msgstr "Заявку уже закрыли"
+
+#: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
+#: src/pages/Request.tsx
 #: src/pages/Results.tsx
 msgid "Не получилось загрузить"
 msgstr "Не получилось загрузить"
+
+#: src/pages/Mine.tsx
+msgid "Мои заявки"
+msgstr "Мои заявки"
 
 #: src/components/Phrase.tsx
 msgid "Не понял запрос. Попробуй назвать предмет — «матан», «čeština B2», «сопромат»."
@@ -101,6 +140,14 @@ msgstr "сдали"
 #: src/pages/Life.tsx
 msgid "Партнёр"
 msgstr "Партнёр"
+
+#: src/pages/Mine.tsx
+msgid "Входящие"
+msgstr "Входящие"
+
+#: src/components/Incoming.tsx
+msgid "Заявки видят те, кто может на них ответить."
+msgstr "Заявки видят те, кто может на них ответить."
 
 #: src/pages/Helper.tsx
 msgid "Сколько стоит"
@@ -119,6 +166,10 @@ msgstr "Сколько берёшь"
 msgid "опубликована"
 msgstr "опубликована"
 
+#: src/pages/Request.tsx
+msgid "Отказать"
+msgstr "Отказать"
+
 #: src/pages/Mine.tsx
 msgid "Пока без откликов"
 msgstr "Пока без откликов"
@@ -130,6 +181,10 @@ msgstr "Разговоры мы не храним"
 #: src/components/Phrase.tsx
 msgid "за работу"
 msgstr "за работу"
+
+#: src/components/Incoming.tsx
+msgid "Не отправилось — попробуй ещё раз"
+msgstr "Не отправилось — попробуй ещё раз"
 
 #: src/components/Phrase.tsx
 msgid "И то, и другое"
@@ -147,9 +202,17 @@ msgstr "за час"
 msgid "Заявки"
 msgstr "Заявки"
 
+#: src/pages/Request.tsx
+msgid "Выбрать"
+msgstr "Выбрать"
+
 #: src/pages/Mine.tsx
 msgid "Опиши, что нужно, и получай отклики — вместо того чтобы искать самому."
 msgstr "Опиши, что нужно, и получай отклики — вместо того чтобы искать самому."
+
+#: src/components/Incoming.tsx
+msgid "Сначала опубликуй профиль"
+msgstr "Сначала опубликуй профиль"
 
 #: src/components/Phrase.tsx
 msgid "за штуку"
@@ -183,6 +246,10 @@ msgstr "Здесь появятся страховка, визы, банк и п
 msgid "Искать всё равно"
 msgstr "Искать всё равно"
 
+#: src/pages/Request.tsx
+msgid "Заявку видят те, кто ведёт этот предмет. Обычно отвечают в течение дня."
+msgstr "Заявку видят те, кто ведёт этот предмет. Обычно отвечают в течение дня."
+
 #: src/components/Phrase.tsx
 msgid "Ведёт предмет, но не привязан к этому вузу"
 msgstr "Ведёт предмет, но не привязан к этому вузу"
@@ -207,6 +274,10 @@ msgstr "Без расписания анкету покажем, но реже �
 #: src/components/Phrase.tsx
 msgid "Онлайн и очно"
 msgstr "Онлайн и очно"
+
+#: src/pages/Request.tsx
+msgid "Заявка"
+msgstr "Заявка"
 
 #. placeholder {0}: formatDay(str(p.date), locale)
 #: src/components/Phrase.tsx
@@ -282,12 +353,18 @@ msgstr "Загружаем"
 msgid "всего {0}"
 msgstr "всего {0}"
 
+#: src/components/Phrase.tsx
+msgid "Вуз, с которым ты работаешь"
+msgstr "Вуз, с которым ты работаешь"
+
 #: src/pages/Chats.tsx
 msgid "Открыть переписку в Telegram"
 msgstr "Открыть переписку в Telegram"
 
 #. placeholder {0}: num(p.deals)
+#. placeholder {0}: response.deals_count
 #: src/components/Phrase.tsx
+#: src/pages/Request.tsx
 msgid "{0, plural, one {# занятие через нас} few {# занятия через нас} many {# занятий через нас} other {# занятия через нас}}"
 msgstr "{0, plural, one {# занятие через нас} few {# занятия через нас} many {# занятий через нас} other {# занятия через нас}}"
 
@@ -299,14 +376,29 @@ msgstr "Чем помогает"
 msgid "в месяц"
 msgstr "в месяц"
 
+#. placeholder {0}: formatDay(request.deadline_on, i18n.locale)
 #. placeholder {0}: formatDay(request.deadline_on, locale)
+#: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
+#: src/pages/Request.tsx
 msgid "до {0}"
 msgstr "до {0}"
 
 #: src/pages/Profile.tsx
 msgid "Жизнь в Чехии"
 msgstr "Жизнь в Чехии"
+
+#: src/components/Incoming.tsx
+msgid "Пока никто ничего не просит"
+msgstr "Пока никто ничего не просит"
+
+#: src/components/Incoming.tsx
+msgid "Отправить"
+msgstr "Отправить"
+
+#: src/pages/Request.tsx
+msgid "У этого человека нет @username — написать не получится"
+msgstr "У этого человека нет @username — написать не получится"
 
 #: src/components/Phrase.tsx
 msgid "за занятие"
@@ -338,6 +430,10 @@ msgstr "Опубликовать"
 msgid "{0, plural, one {# отклик} few {# отклика} many {# откликов} other {# отклика}}"
 msgstr "{0, plural, one {# отклик} few {# отклика} many {# откликов} other {# отклика}}"
 
+#: src/components/Incoming.tsx
+msgid "На эту заявку ты уже отвечал"
+msgstr "На эту заявку ты уже отвечал"
+
 #: src/pages/Helper.tsx
 msgid "У этого человека нет открытого username в Telegram, написать не получится."
 msgstr "У этого человека нет открытого username в Telegram, написать не получится."
@@ -346,6 +442,10 @@ msgstr "У этого человека нет открытого username в Tel
 #: src/pages/Helper.tsx
 msgid "Написать · {0} Kč"
 msgstr "Написать · {0} Kč"
+
+#: src/pages/Request.tsx
+msgid "выбран"
+msgstr "выбран"
 
 #: src/components/Phrase.tsx
 msgid "Работает именно с этим вузом"
@@ -366,6 +466,10 @@ msgstr "Профиль недоступен"
 #: src/pages/Home.tsx
 msgid "Нажми, чтобы попробовать ещё раз"
 msgstr "Нажми, чтобы попробовать ещё раз"
+
+#: src/components/Incoming.tsx
+msgid "Чем можешь помочь и когда"
+msgstr "Чем можешь помочь и когда"
 
 #: src/pages/Mine.tsx
 msgid "Заявок пока нет"
@@ -397,11 +501,16 @@ msgstr "Язык приложения"
 msgid "{0, plural, one {Отвечает примерно за # минуту} few {Отвечает примерно за # минуты} many {Отвечает примерно за # минут} other {Отвечает примерно за # минуты}}"
 msgstr "{0, plural, one {Отвечает примерно за # минуту} few {Отвечает примерно за # минуты} many {Отвечает примерно за # минут} other {Отвечает примерно за # минуты}}"
 
+#: src/pages/Request.tsx
+msgid "Ты отказался"
+msgstr "Ты отказался"
+
 #: src/pages/Ask.tsx
 msgid "Поняли так — поправь, если не то"
 msgstr "Поняли так — поправь, если не то"
 
 #: src/pages/Helper.tsx
+#: src/pages/Request.tsx
 msgid "Написать"
 msgstr "Написать"
 
@@ -418,6 +527,14 @@ msgstr "Показать {0}"
 msgid "Моя анкета"
 msgstr "Моя анкета"
 
+#: src/components/Incoming.tsx
+msgid "Цена за час, Kč — необязательно"
+msgstr "Цена за час, Kč — необязательно"
+
+#: src/pages/Request.tsx
+msgid "Откликов пока нет"
+msgstr "Откликов пока нет"
+
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"
 msgstr "Помощь нужна до экзамена или на нём?"
@@ -426,6 +543,10 @@ msgstr "Помощь нужна до экзамена или на нём?"
 #: src/pages/Mine.tsx
 msgid "Мои"
 msgstr "Мои"
+
+#: src/pages/Request.tsx
+msgid "Отклики"
+msgstr "Отклики"
 
 #: src/pages/Results.tsx
 msgid "Ищем…"
@@ -450,6 +571,10 @@ msgstr "в день"
 #: src/pages/Results.tsx
 msgid "Подходят"
 msgstr "Подходят"
+
+#: src/components/Incoming.tsx
+msgid "Сначала заполни профиль"
+msgstr "Сначала заполни профиль"
 
 #: src/components/Phrase.tsx
 msgid "Разобраться заранее"

--- a/apps/web/src/locales/uk/messages.po
+++ b/apps/web/src/locales/uk/messages.po
@@ -13,9 +13,21 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
+#: src/components/Incoming.tsx
+msgid "Заведи в Telegram публичный @username — иначе тебе не ответят"
+msgstr "Заведи в Telegram публічний @username — інакше тобі не відповідять"
+
+#: src/components/Incoming.tsx
+msgid "Здесь появятся заявки по твоим предметам. Чем больше предметов в профиле, тем чаще."
+msgstr "Тут з'являтимуться заявки з твоїх предметів. Що більше предметів у профілі, то частіше."
+
 #: src/components/Phrase.tsx
 msgid "оценка"
 msgstr "оцінка"
+
+#: src/components/Phrase.tsx
+msgid "То, чем ты занимаешься"
+msgstr "Те, чим ти займаєшся"
 
 #: src/pages/Results.tsx
 msgid "Свободны"
@@ -29,9 +41,17 @@ msgstr "Онлайн"
 msgid "Напиши хотя бы пару предложений — предметы, цену и как удобно заниматься."
 msgstr "Напиши хоча б кілька речень — предмети, ціну і як тобі зручно займатися."
 
+#: src/pages/Request.tsx
+msgid "Такой заявки нет"
+msgstr "Такої заявки немає"
+
 #: src/components/TabBar.tsx
 msgid "Поиск"
 msgstr "Пошук"
+
+#: src/components/Incoming.tsx
+msgid "Не сейчас"
+msgstr "Не зараз"
 
 #: src/pages/Profile.tsx
 msgid "Чешский для вуза"
@@ -44,6 +64,10 @@ msgstr "Як це працює"
 #: src/components/Phrase.tsx
 msgid "за неделю"
 msgstr "за тиждень"
+
+#: src/components/Incoming.tsx
+msgid "Откликнуться"
+msgstr "Відгукнутися"
 
 #: src/pages/BecomeHelper.tsx
 msgid "Когда ты свободен"
@@ -81,14 +105,29 @@ msgstr "За цим запитом поки нікого немає. Створ�
 msgid "Хочу помогать"
 msgstr "Хочу допомагати"
 
+#. placeholder {0}: str(p.subject)
+#: src/components/Phrase.tsx
+msgid "Твой предмет — {0}"
+msgstr "Твій предмет — {0}"
+
 #: src/pages/Profile.tsx
 msgid "расскажи своими словами, анкету соберём сами"
 msgstr "розкажи своїми словами, анкету складемо самі"
 
+#: src/components/Incoming.tsx
+msgid "Заявку уже закрыли"
+msgstr "Заявку вже закрили"
+
+#: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
+#: src/pages/Request.tsx
 #: src/pages/Results.tsx
 msgid "Не получилось загрузить"
 msgstr "Не вдалося завантажити"
+
+#: src/pages/Mine.tsx
+msgid "Мои заявки"
+msgstr "Мої заявки"
 
 #: src/components/Phrase.tsx
 msgid "Не понял запрос. Попробуй назвать предмет — «матан», «čeština B2», «сопромат»."
@@ -101,6 +140,14 @@ msgstr "склали"
 #: src/pages/Life.tsx
 msgid "Партнёр"
 msgstr "Партнер"
+
+#: src/pages/Mine.tsx
+msgid "Входящие"
+msgstr "Вхідні"
+
+#: src/components/Incoming.tsx
+msgid "Заявки видят те, кто может на них ответить."
+msgstr "Заявки бачать ті, хто може на них відповісти."
 
 #: src/pages/Helper.tsx
 msgid "Сколько стоит"
@@ -119,6 +166,10 @@ msgstr "Скільки береш"
 msgid "опубликована"
 msgstr "опублікована"
 
+#: src/pages/Request.tsx
+msgid "Отказать"
+msgstr "Відмовити"
+
 #: src/pages/Mine.tsx
 msgid "Пока без откликов"
 msgstr "Поки без відгуків"
@@ -130,6 +181,10 @@ msgstr "Розмови ми не зберігаємо"
 #: src/components/Phrase.tsx
 msgid "за работу"
 msgstr "за роботу"
+
+#: src/components/Incoming.tsx
+msgid "Не отправилось — попробуй ещё раз"
+msgstr "Не надіслалося — спробуй ще раз"
 
 #: src/components/Phrase.tsx
 msgid "И то, и другое"
@@ -147,9 +202,17 @@ msgstr "за годину"
 msgid "Заявки"
 msgstr "Заявки"
 
+#: src/pages/Request.tsx
+msgid "Выбрать"
+msgstr "Обрати"
+
 #: src/pages/Mine.tsx
 msgid "Опиши, что нужно, и получай отклики — вместо того чтобы искать самому."
 msgstr "Опиши, що потрібно, і отримуй відгуки — замість того щоб шукати самому."
+
+#: src/components/Incoming.tsx
+msgid "Сначала опубликуй профиль"
+msgstr "Спершу опублікуй профіль"
 
 #: src/components/Phrase.tsx
 msgid "за штуку"
@@ -183,6 +246,10 @@ msgstr "Тут з'являться страхування, візи, банк і
 msgid "Искать всё равно"
 msgstr "Шукати попри це"
 
+#: src/pages/Request.tsx
+msgid "Заявку видят те, кто ведёт этот предмет. Обычно отвечают в течение дня."
+msgstr "Заявку бачать ті, хто веде цей предмет. Зазвичай відповідають протягом дня."
+
 #: src/components/Phrase.tsx
 msgid "Ведёт предмет, но не привязан к этому вузу"
 msgstr "Веде предмет, але не прив'язаний до цього вишу"
@@ -207,6 +274,10 @@ msgstr "Без розкладу анкету покажемо, але рідше
 #: src/components/Phrase.tsx
 msgid "Онлайн и очно"
 msgstr "Онлайн і очно"
+
+#: src/pages/Request.tsx
+msgid "Заявка"
+msgstr "Заявка"
 
 #. placeholder {0}: formatDay(str(p.date), locale)
 #: src/components/Phrase.tsx
@@ -282,12 +353,18 @@ msgstr "Завантажуємо"
 msgid "всего {0}"
 msgstr "всього {0}"
 
+#: src/components/Phrase.tsx
+msgid "Вуз, с которым ты работаешь"
+msgstr "Виш, з яким ти працюєш"
+
 #: src/pages/Chats.tsx
 msgid "Открыть переписку в Telegram"
 msgstr "Відкрити переписку в Telegram"
 
 #. placeholder {0}: num(p.deals)
+#. placeholder {0}: response.deals_count
 #: src/components/Phrase.tsx
+#: src/pages/Request.tsx
 msgid "{0, plural, one {# занятие через нас} few {# занятия через нас} many {# занятий через нас} other {# занятия через нас}}"
 msgstr "{0, plural, one {# заняття з нами} few {# заняття з нами} many {# занять з нами} other {# заняття з нами}}"
 
@@ -299,14 +376,29 @@ msgstr "Чим допомагає"
 msgid "в месяц"
 msgstr "за місяць"
 
+#. placeholder {0}: formatDay(request.deadline_on, i18n.locale)
 #. placeholder {0}: formatDay(request.deadline_on, locale)
+#: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
+#: src/pages/Request.tsx
 msgid "до {0}"
 msgstr "до {0}"
 
 #: src/pages/Profile.tsx
 msgid "Жизнь в Чехии"
 msgstr "Життя в Чехії"
+
+#: src/components/Incoming.tsx
+msgid "Пока никто ничего не просит"
+msgstr "Поки ніхто нічого не просить"
+
+#: src/components/Incoming.tsx
+msgid "Отправить"
+msgstr "Надіслати"
+
+#: src/pages/Request.tsx
+msgid "У этого человека нет @username — написать не получится"
+msgstr "У цієї людини немає @username — написати не вийде"
 
 #: src/components/Phrase.tsx
 msgid "за занятие"
@@ -338,6 +430,10 @@ msgstr "Опублікувати"
 msgid "{0, plural, one {# отклик} few {# отклика} many {# откликов} other {# отклика}}"
 msgstr "{0, plural, one {# відповідь} few {# відповіді} many {# відповідей} other {# відповіді}}"
 
+#: src/components/Incoming.tsx
+msgid "На эту заявку ты уже отвечал"
+msgstr "На цю заявку ти вже відповідав"
+
 #: src/pages/Helper.tsx
 msgid "У этого человека нет открытого username в Telegram, написать не получится."
 msgstr "У цієї людини немає відкритого username в Telegram, написати не вийде."
@@ -346,6 +442,10 @@ msgstr "У цієї людини немає відкритого username в Tel
 #: src/pages/Helper.tsx
 msgid "Написать · {0} Kč"
 msgstr "Написати · {0} Kč"
+
+#: src/pages/Request.tsx
+msgid "выбран"
+msgstr "обраний"
 
 #: src/components/Phrase.tsx
 msgid "Работает именно с этим вузом"
@@ -366,6 +466,10 @@ msgstr "Профіль недоступний"
 #: src/pages/Home.tsx
 msgid "Нажми, чтобы попробовать ещё раз"
 msgstr "Натисни, щоб спробувати ще раз"
+
+#: src/components/Incoming.tsx
+msgid "Чем можешь помочь и когда"
+msgstr "Чим можеш допомогти і коли"
 
 #: src/pages/Mine.tsx
 msgid "Заявок пока нет"
@@ -397,11 +501,16 @@ msgstr "Мова застосунку"
 msgid "{0, plural, one {Отвечает примерно за # минуту} few {Отвечает примерно за # минуты} many {Отвечает примерно за # минут} other {Отвечает примерно за # минуты}}"
 msgstr "{0, plural, one {Відповідає приблизно за # хвилину} few {Відповідає приблизно за # хвилини} many {Відповідає приблизно за # хвилин} other {Відповідає приблизно за # хвилини}}"
 
+#: src/pages/Request.tsx
+msgid "Ты отказался"
+msgstr "Ти відмовив"
+
 #: src/pages/Ask.tsx
 msgid "Поняли так — поправь, если не то"
 msgstr "Ми зрозуміли так — виправ, якщо не те"
 
 #: src/pages/Helper.tsx
+#: src/pages/Request.tsx
 msgid "Написать"
 msgstr "Написати"
 
@@ -418,6 +527,14 @@ msgstr "Показати {0}"
 msgid "Моя анкета"
 msgstr "Моя анкета"
 
+#: src/components/Incoming.tsx
+msgid "Цена за час, Kč — необязательно"
+msgstr "Ціна за годину, Kč — необов'язково"
+
+#: src/pages/Request.tsx
+msgid "Откликов пока нет"
+msgstr "Відгуків поки немає"
+
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"
 msgstr "Допомога потрібна до іспиту чи на ньому?"
@@ -426,6 +543,10 @@ msgstr "Допомога потрібна до іспиту чи на ньому
 #: src/pages/Mine.tsx
 msgid "Мои"
 msgstr "Мої"
+
+#: src/pages/Request.tsx
+msgid "Отклики"
+msgstr "Відгуки"
 
 #: src/pages/Results.tsx
 msgid "Ищем…"
@@ -450,6 +571,10 @@ msgstr "за день"
 #: src/pages/Results.tsx
 msgid "Подходят"
 msgstr "Підходять"
+
+#: src/components/Incoming.tsx
+msgid "Сначала заполни профиль"
+msgstr "Спершу заповни профіль"
 
 #: src/components/Phrase.tsx
 msgid "Разобраться заранее"

--- a/apps/web/src/pages/Mine.tsx
+++ b/apps/web/src/pages/Mine.tsx
@@ -1,6 +1,7 @@
 import { Plural, Trans, useLingui } from '@lingui/react/macro';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
+import { Incoming } from '@/components/Incoming';
 import { DocumentIcon, iconForService } from '@/components/icons';
 import { formatDay } from '@/components/Phrase';
 import { TabBar } from '@/components/TabBar';
@@ -13,6 +14,7 @@ import {
   Label,
   Reason,
   Screen,
+  Segmented,
   SkeletonRows,
   Tile,
   Title,
@@ -20,15 +22,38 @@ import {
 import { api } from '@/lib/api';
 import type { HelpRequest } from '@/lib/types';
 
+type Tab = 'mine' | 'incoming';
+
 /**
- * The other direction: what you asked for, and who answered.
+ * Both directions of the same relationship.
  *
- * A catalog only works once it is full. Until then this is the side that does
- * work — you post what you need and helpers come to you.
+ * What you asked for, and — if you are also a helper — what other people are
+ * asking for. One screen rather than a fifth tab: the two are the same person's
+ * business, and most people will only ever see the first.
  */
 export default function MinePage() {
   const navigate = useNavigate();
   const { i18n } = useLingui();
+  // In the URL, so the notification that brings a helper back can land on the
+  // right half and a reload does not lose it.
+  const [params, setParams] = useSearchParams();
+
+  const me = useQuery({ queryKey: ['me'], queryFn: ({ signal }) => api.getMe(signal) });
+  const isHelper = me.data?.is_helper ?? false;
+
+  // Forced back to 'mine' for someone who is not a helper: the control that
+  // switches back is only rendered for helpers, so /mine?tab=incoming would
+  // otherwise strand them on "fill in your profile" with no way out.
+  const tab: Tab = isHelper && params.get('tab') === 'incoming' ? 'incoming' : 'mine';
+
+  const switchTo = (next: Tab) => {
+    // Rebuilt from the current params rather than replaced: a wholesale
+    // object drops every other search parameter on the screen.
+    const updated = new URLSearchParams(params);
+    if (next === 'mine') updated.delete('tab');
+    else updated.set('tab', next);
+    setParams(updated, { replace: true });
+  };
 
   const { data, isPending, isError } = useQuery({
     queryKey: ['requests'],
@@ -43,11 +68,30 @@ export default function MinePage() {
           <Trans>Мои</Trans>
         </Title>
 
-        <Label>
-          <Trans>Заявки</Trans>
-        </Label>
+        {isHelper ? (
+          <div style={{ marginTop: 14 }}>
+            <Segmented<Tab>
+              value={tab}
+              onChange={switchTo}
+              options={[
+                { value: 'mine', label: <Trans>Мои заявки</Trans> },
+                { value: 'incoming', label: <Trans>Входящие</Trans> },
+              ]}
+            />
+          </div>
+        ) : (
+          <Label>
+            <Trans>Заявки</Trans>
+          </Label>
+        )}
 
-        {isPending ? (
+        {/* The segmented control replaces the section label, and with it the
+            gap the label used to provide above the list. */}
+        <div style={{ height: isHelper ? 14 : 0 }} />
+
+        {tab === 'incoming' ? (
+          <Incoming />
+        ) : isPending ? (
           <SkeletonRows count={2} />
         ) : isError ? (
           <Empty title={<Trans>Не получилось загрузить</Trans>} />
@@ -67,7 +111,7 @@ export default function MinePage() {
                 key={request.id}
                 request={request}
                 locale={i18n.locale}
-                onClick={() => navigate(`/ask?from=${request.id}`)}
+                onClick={() => navigate(`/request/${request.id}`)}
               />
             ))}
           </Cards>

--- a/apps/web/src/pages/Request.tsx
+++ b/apps/web/src/pages/Request.tsx
@@ -1,0 +1,229 @@
+import { Plural, Trans, useLingui } from '@lingui/react/macro';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { openTelegramLink } from '@tma.js/sdk-react';
+import { useParams } from 'react-router';
+
+import { formatDay, PriceUnitLabel } from '@/components/Phrase';
+import {
+  Action,
+  Actions,
+  AvatarView,
+  Badge,
+  Card,
+  Cards,
+  Empty,
+  Head,
+  Hint,
+  Label,
+  PriceView,
+  Reason,
+  Screen,
+  SkeletonRows,
+  Sub,
+  Title,
+} from '@/components/Ui';
+import { hapticSuccess } from '@/hooks/useTelegram';
+import { api } from '@/lib/api';
+import type { RequestResponse } from '@/lib/types';
+
+/**
+ * One request of yours, and who answered it.
+ *
+ * The list is the decision: each answer carries the price, what the person
+ * said, and enough of their profile to judge it. Accepting does not close the
+ * request — needing two people for two subjects is ordinary.
+ */
+export default function RequestPage() {
+  const { id } = useParams();
+  const requestId = Number(id);
+  const { i18n } = useLingui();
+
+  // From the list rather than its own endpoint: this screen is only ever
+  // reached from it, so the request is already in the cache.
+  const requests = useQuery({
+    queryKey: ['requests'],
+    queryFn: ({ signal }) => api.getRequests(signal),
+  });
+  const request = requests.data?.find((row) => row.id === requestId);
+
+  // A path like /request/abc parses to NaN. Disabling the query on it leaves
+  // `isPending` true for ever, so the screen would sit on a skeleton with no
+  // way out — the id has to be checked before anything is rendered.
+  const validId = Number.isInteger(requestId) && requestId > 0;
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: ['responses', requestId],
+    queryFn: ({ signal }) => api.getResponses(requestId, signal),
+    enabled: validId,
+  });
+
+  if (!validId) {
+    return (
+      <Screen>
+        <Head />
+        <Empty title={<Trans>Такой заявки нет</Trans>} />
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen>
+      <Head />
+      <Title>{request?.subject ?? <Trans>Заявка</Trans>}</Title>
+
+      {request ? (
+        <>
+          <Sub>{request.text}</Sub>
+          {request.deadline_on ? (
+            <Hint>
+              <Trans>до {formatDay(request.deadline_on, i18n.locale)}</Trans>
+            </Hint>
+          ) : null}
+        </>
+      ) : null}
+
+      <Label>
+        <Trans>Отклики</Trans>
+      </Label>
+
+      {isPending ? (
+        <SkeletonRows count={2} />
+      ) : isError ? (
+        <Empty title={<Trans>Не получилось загрузить</Trans>} />
+      ) : data.length === 0 ? (
+        <Empty
+          title={<Trans>Откликов пока нет</Trans>}
+          body={
+            <Trans>
+              Заявку видят те, кто ведёт этот предмет. Обычно отвечают в течение дня.
+            </Trans>
+          }
+        />
+      ) : (
+        <Cards>
+          {data.map((response) => (
+            <ResponseCard key={response.id} response={response} />
+          ))}
+        </Cards>
+      )}
+      <div style={{ height: 20 }} />
+    </Screen>
+  );
+}
+
+function ResponseCard({ response }: { response: RequestResponse }) {
+  const queryClient = useQueryClient();
+
+  const settle = useMutation({
+    mutationFn: (verdict: 'accept' | 'decline') =>
+      verdict === 'accept'
+        ? api.acceptResponse(response.id)
+        : api.declineResponse(response.id),
+    onSuccess: (updated) => {
+      if (updated.status === 'accepted') hapticSuccess();
+      void queryClient.invalidateQueries({
+        queryKey: ['responses', response.request_id],
+      });
+    },
+  });
+
+  const write = () => {
+    if (!response.username) return;
+    openTelegramLink(`https://t.me/${response.username}`);
+  };
+
+  const decided = response.status === 'accepted' || response.status === 'declined';
+
+  return (
+    <Card>
+      <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+        <AvatarView avatar={response.avatar} size={38} />
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{ fontSize: 14.5, fontWeight: 680, letterSpacing: '-0.015em' }}>
+              {response.name}
+            </span>
+            {response.status === 'accepted' ? (
+              <Badge>
+                <Trans>выбран</Trans>
+              </Badge>
+            ) : null}
+          </div>
+          {response.affiliation ? (
+            <div style={{ marginTop: 2, fontSize: 12, color: 'var(--muted)' }}>
+              {response.affiliation}
+            </div>
+          ) : null}
+        </div>
+        {response.price ? (
+          <PriceView
+            price={response.price}
+            unitLabel={<PriceUnitLabel unit={response.price.unit} />}
+          />
+        ) : null}
+      </div>
+
+      <p
+        style={{
+          margin: '9px 0 0',
+          fontSize: 13.5,
+          lineHeight: 1.45,
+          color: 'var(--ink-soft)',
+        }}
+      >
+        {response.message}
+      </p>
+
+      {response.deals_count > 0 ? (
+        <Reason>
+          <Plural
+            value={response.deals_count}
+            one="# занятие через нас"
+            few="# занятия через нас"
+            many="# занятий через нас"
+            other="# занятия через нас"
+          />
+        </Reason>
+      ) : null}
+
+      {response.status === 'declined' ? (
+        <Reason weak>
+          <Trans>Ты отказался</Trans>
+        </Reason>
+      ) : response.username ? (
+        <Actions>
+          {/* Writing is the point; accepting is what records that it happened,
+              so both are offered and neither is buried. */}
+          <Action onClick={write}>
+            <Trans>Написать</Trans>
+          </Action>
+          {decided ? null : (
+            <>
+              <Action
+                quiet
+                onClick={() => settle.mutate('accept')}
+                disabled={settle.isPending}
+              >
+                <Trans>Выбрать</Trans>
+              </Action>
+              <Action
+                quiet
+                onClick={() => settle.mutate('decline')}
+                disabled={settle.isPending}
+              >
+                <Trans>Отказать</Trans>
+              </Action>
+            </>
+          )}
+        </Actions>
+      ) : (
+        // Answering requires a public username, so this only happens if the
+        // person removed theirs afterwards. Saying so beats an empty row of
+        // buttons that lead nowhere.
+        <Reason weak>
+          <Trans>У этого человека нет @username — написать не получится</Trans>
+        </Reason>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -8,6 +8,7 @@ import LifePage from '@/pages/Life';
 import MinePage from '@/pages/Mine';
 import NotFoundPage from '@/pages/NotFound';
 import ProfilePage from '@/pages/Profile';
+import RequestPage from '@/pages/Request';
 import ResultsPage from '@/pages/Results';
 import Root from '@/Root';
 
@@ -28,6 +29,7 @@ export const router = createBrowserRouter([
       { path: 'results', element: <ResultsPage /> },
       { path: 'helper/:id', element: <HelperPage /> },
       { path: 'mine', element: <MinePage /> },
+      { path: 'request/:id', element: <RequestPage /> },
       { path: 'chats', element: <ChatsPage /> },
       { path: 'become-helper', element: <BecomeHelperPage /> },
       { path: 'life', element: <LifePage /> },

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -113,7 +113,16 @@ other one: `help_requests` lets a student post "calculus, ČVUT, exam on
 repeat pitching is spam, and the unique constraint says so.
 
 Requests carry `expires_at` because they rot: an exam on 14 February is
-worthless on the 15th.
+worthless on the 15th. A request past it is filtered out of the helper feed and
+refuses new answers even while its `status` still reads `open` — expiry is a
+deadline, not a job that has to have run.
+
+An answer carries `price_amount` **and** `price_unit`: "500" alone is ambiguous
+between an hour and the whole job, and the two readings are different offers.
+Accepting one writes a `contacts` row — the same row the catalog writes when
+someone taps "write" on a profile — so response times and deal counts count
+both routes to a conversation, and accepting deliberately does not close the
+request: needing two people for two subjects is ordinary.
 
 ## Availability
 


### PR DESCRIPTION
A student could post a request and nobody could reply — `request_responses` existed with no endpoint and no screen, so the second half of the marketplace was a dead end. This closes the loop.

## What works now

- **`GET /requests/feed`** — open requests for a helper, ranked by what they actually offer (subject → service type → faculty), each with one `Phrase` saying why it surfaced. Own requests, closed ones, expired ones and ones you already answered are excluded.
- **`POST /requests/{id}/respond`** — one answer per helper, with a price and the unit that disambiguates it.
- **`GET /requests/{id}/responses`** — the author's list; marks answers read *after* rendering, so the client gets one chance to badge the new ones.
- **`POST /responses/{id}/accept` / `decline`** — accepting records a `contacts` row and does not close the request.
- Bot notifications to both sides, in the recipient's language, sent as a background task so Telegram is never in the request path.

Screens: an **Входящие** tab inside `Мои` for helpers (a segmented control rather than a fifth tab), with the composer inline in the card, and a new `/request/:id` where the author reads answers and picks one.

## Choices worth arguing with

- **A draft profile may read the feed but not answer.** Seeing that four people want help with the thing you teach is the argument for finishing the profile.
- **Answering requires a public @username.** We do not host the conversation; without one an accepted answer is a dead end. Same rule `start_contact` already enforces.
- **A banned profile gets neither.** The feed is names, faces, budgets and full text.
- **The feed omits `responses_count` and `responders`.** A helper who can see "already contested" skips those.
- **Accepting is idempotent** and cannot be reversed by a later decline.
- **Notifications require `bot_started_at`**, not just `bot_can_message` — the latter is true by default for people who never messaged the bot, and Telegram answers those with a 403 we would have recorded as a block.

## Migration

Adds two `user_event_kind` members and `request_responses.price_unit`. Replayed against a copy of production's current revision with real rows: up, down, up again — all clean. The deploy stack already runs `alembic upgrade head`.

## Verification

- 147 tests pass, up from 109.
- Whole loop walked over HTTP against local Postgres, including eight concurrent answers from one helper: one 201, seven 409, exactly one row.
- Screens rendered in a real browser at 390×844, no console errors.
- All four catalogs complete — `lingui compile --strict` clean.

An earlier review pass found seven defects in the first cut of this (non-idempotent accept, the banned-profile hole, the username dead end, a blank answer passing `min_length`, the notification gate, decline-after-accept, and the leaked competitor count). All are fixed here with a regression test each.