### PR TITLE
Carry the language cut into production with a migration

### DIFF
--- a/apps/api/src/konnekt/db/migrations/versions/20260726_c3f1a80d47b2_retire_the_working_languages_nobody_.py
+++ b/apps/api/src/konnekt/db/migrations/versions/20260726_c3f1a80d47b2_retire_the_working_languages_nobody_.py
@@ -1,0 +1,52 @@
+"""Retire the working languages nobody was matched on
+
+Cutting the list in `db/seed.py` is enough for a database that gets seeded —
+a fresh checkout, CI — and does nothing at all for production, where the
+deploy runs `alembic upgrade head` and never the seed. So the retirement has
+to happen here too, or the nine stay on the profile screen for ever.
+
+Deactivated, not deleted. `users.spoken_langs` and `offers.langs` are plain
+text arrays that reference nothing, so a deleted row leaves a profile claiming
+a language with no name to show for it.
+
+Revision ID: c3f1a80d47b2
+Revises: a1c4e77b0d21
+Create Date: 2026-07-26
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c3f1a80d47b2"
+down_revision: str | Sequence[str] | None = "a1c4e77b0d21"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# The same four the interface speaks. Written out rather than imported from
+# `seed.py`: a migration describes the database at one moment in time, and one
+# that follows a constant would quietly change meaning the next time that
+# constant did.
+KEPT = ("ru", "uk", "cs", "en")
+RETIRED = ("sk", "de", "kk", "uz", "vi")
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text("UPDATE languages SET is_active = false WHERE code NOT IN :kept").bindparams(
+            sa.bindparam("kept", value=KEPT, expanding=True)
+        )
+    )
+
+
+def downgrade() -> None:
+    # The five this migration retired, and only those: anything else that is
+    # inactive was made so by hand and is not ours to revive.
+    op.execute(
+        sa.text(
+            "UPDATE languages SET is_active = true WHERE code IN :retired"
+        ).bindparams(sa.bindparam("retired", value=RETIRED, expanding=True))
+    )

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -41,6 +41,19 @@ If anything fails before step 6, the previous `.env` is restored and the
 previous stack is brought back up. After step 6 the release is committed;
 recovering from a bad release is `Rollback production`.
 
+### Reference data does not ship with the code
+
+Step 4 runs Alembic and nothing else. `konnekt.db.seed` — subjects,
+institutions, service types, languages — is a development and CI convenience;
+production was seeded once and is never re-seeded.
+
+So a change to `seed.py` alone reaches every fresh checkout and never reaches
+the catalog people are using. Anything that has to take effect in production
+needs a migration carrying the same change, and the migration writes the
+values out rather than importing the constant: a migration describes the
+database at one moment, and one that follows a constant changes meaning the
+next time that constant does.
+
 ## Rolling back
 
 Run the **Rollback production** workflow with a tag such as `prod-1a2b3c4`. It


### PR DESCRIPTION
The four-language list shipped in #10 as a change to `db/seed.py`. That reaches every database which gets seeded — a fresh checkout, CI — and does not reach production, where the deploy runs `alembic upgrade head` and never the seed.

Checked over SSH after that release landed:

```
 code | is_active
------+-----------
 ru   | t
 uk   | t
 cs   | t
 en   | t
 sk   | t
 de   | t
 kk   | t
 uz   | t
 vi   | t
```

Still nine, still offering Kazakh on the profile screen.

So the retirement happens in a migration as well. Deactivated rather than deleted, for the same reason as in the seed: `users.spoken_langs` and `offers.langs` are plain text arrays that reference nothing, so a deleted row leaves a profile claiming a language with no name to show for it. The codes are written out rather than imported from `seed.py` — a migration describes the database at one moment, and one that follows a constant would quietly change meaning the next time that constant did.

Replayed up, down and up again against a production-shaped database; `alembic check` reports no drift.

`docs/deploy.md` now states what was only true implicitly: step 4 runs Alembic and nothing else, so any reference-data change that has to be live needs a migration carrying it. That is the gap this PR exists to close, and it will apply to service types and subjects next time too.

Docs updated first: docs/deploy.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL