### PR TITLE
Make the request a unit of work

### DIFF
--- a/apps/api/src/konnekt/api/deps.py
+++ b/apps/api/src/konnekt/api/deps.py
@@ -11,7 +11,7 @@ from konnekt.db.session import session_scope
 from konnekt.services.people import remember
 
 SettingsDep = Annotated[Settings, Depends(get_settings)]
-SessionDep = Annotated[AsyncSession, Depends(session_scope)]
+SessionDep = Annotated[AsyncSession, Depends(session_scope, scope="function")]
 
 
 def _extract_init_data(authorization: str | None) -> str:
@@ -66,6 +66,12 @@ async def current_user(
         supported_langs=settings.supported_ui_langs,
         source=identity.start_param,
     )
+    # The one write that outlives a failed request, deliberately. Telegram is
+    # the identity provider and the first authenticated request is the
+    # registration, so first sight of a person — and the `source` that says
+    # where they came from — should survive whatever the handler goes on to do
+    # with them. It also releases the lock on the users unique index, which the
+    # mini app's several parallel opening requests would otherwise queue on.
     await session.commit()
 
     if user.is_blocked:

--- a/apps/api/src/konnekt/api/v1/browse.py
+++ b/apps/api/src/konnekt/api/v1/browse.py
@@ -30,7 +30,6 @@ async def home(session: SessionDep, lang: LangDep, user: UserDep) -> HomeOut:
     # The first screen stands in for "opened the app". Logging every request
     # would drown the signal in taxonomy fetches.
     await log_event(session, user.id, UserEventKind.APP_OPEN, lang=lang.value)
-    await session.commit()
     return HomeOut(people=people, things=things)
 
 
@@ -42,7 +41,6 @@ async def helper_detail(
     if detail is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "no such published profile")
     await log_event(session, user.id, UserEventKind.HELPER_VIEW, helper_id=user_id)
-    await session.commit()
     return detail
 
 
@@ -78,6 +76,5 @@ async def start_contact(
 
     session.add(Contact(student_id=user.id, helper_id=user_id, intro_text=None))
     await log_event(session, user.id, UserEventKind.CONTACT, helper_id=user_id)
-    await session.commit()
 
     return ContactOut(telegram_url=f"https://t.me/{helper.user.tg_username}")

--- a/apps/api/src/konnekt/api/v1/cabinet.py
+++ b/apps/api/src/konnekt/api/v1/cabinet.py
@@ -291,5 +291,4 @@ async def upsert_helper(
     dropped = [row.id for axes, row in existing.items() if axes not in seen_axes]
     if dropped:
         await session.execute(delete(Offer).where(Offer.id.in_(dropped)))
-    await session.commit()
     return await read_me(user, session, lang)

--- a/apps/api/src/konnekt/api/v1/me.py
+++ b/apps/api/src/konnekt/api/v1/me.py
@@ -63,5 +63,4 @@ async def update_me(
             session, Institution, payload.institution_id or None, "institution_id"
         )
         user.institution_id = payload.institution_id or None
-    await session.commit()
     return await read_me(user, session, payload.ui_lang or lang)

--- a/apps/api/src/konnekt/api/v1/requests.py
+++ b/apps/api/src/konnekt/api/v1/requests.py
@@ -117,7 +117,10 @@ async def create_request(
         subject_id=subject_id,
         institution_id=institution_id,
     )
-    await session.commit()
+    # flush, not commit: the row has to exist for `refresh` to read the
+    # defaults the database fills in, but the transaction belongs to the
+    # request and ends when the request does.
+    await session.flush()
     await session.refresh(request)
     return await _request_out(session, request, lang)
 
@@ -370,7 +373,6 @@ async def respond_to_request(
         request_id=request.id,
         subject_id=request.subject_id,
     )
-    await session.commit()
 
     author = await session.get(User, request.author_id)
     [rendered] = await _responses_out(session, [inserted], lang)
@@ -426,7 +428,6 @@ async def request_responses(
     for row in rows:
         if row.status is ResponseStatus.SENT:
             row.status = ResponseStatus.READ
-    await session.commit()
 
     return out
 
@@ -479,7 +480,6 @@ async def accept_response(
         request_id=request.id,
         helper_id=response.helper_id,
     )
-    await session.commit()
 
     helper_user = await session.get(User, response.helper_id)
     if helper_user is not None:
@@ -523,7 +523,6 @@ async def decline_response(
         raise HTTPException(status.HTTP_409_CONFLICT, "you already chose this person")
 
     response.status = ResponseStatus.DECLINED
-    await session.commit()
     [out] = await _responses_out(session, [response], lang)
     return out
 
@@ -662,7 +661,6 @@ async def close_request(
     if request is None or request.author_id != user.id:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "no such request")
     request.status = RequestStatus.CLOSED
-    await session.commit()
     return await _request_out(session, request, lang)
 
 

--- a/apps/api/src/konnekt/api/v1/search.py
+++ b/apps/api/src/konnekt/api/v1/search.py
@@ -127,7 +127,6 @@ async def parse_query(
             parser="rules.v1",
         )
     )
-    await session.commit()
 
     return ParseOut(
         chips=chips,

--- a/apps/api/src/konnekt/db/session.py
+++ b/apps/api/src/konnekt/db/session.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -37,9 +38,41 @@ def get_sessionmaker() -> async_sessionmaker[AsyncSession]:
     return _sessionmaker
 
 
-async def session_scope() -> AsyncIterator[AsyncSession]:
-    async with get_sessionmaker()() as session:
+@asynccontextmanager
+async def unit_of_work(session: AsyncSession) -> AsyncIterator[AsyncSession]:
+    """Commit on the way out, roll back on a raise.
+
+    Separate from `session_scope` so the test fixture can wrap its own session
+    in the same rule rather than reimplementing it — a fixture more forgiving
+    than production hides exactly the bugs this exists to prevent.
+    """
+    try:
         yield session
+    except Exception:
+        await session.rollback()
+        raise
+    else:
+        await session.commit()
+
+
+async def session_scope() -> AsyncIterator[AsyncSession]:
+    """One transaction per request.
+
+    A unit of work rather than a bare provider. Without it every endpoint has
+    to remember to put its commit after the last thing that can fail, and the
+    one that did not left an answer in the database that its author was never
+    told about.
+
+    Depended on with `scope="function"`: FastAPI runs the teardown of a
+    request-scoped dependency after the response has been sent and after its
+    background tasks have run, which would mean notifying somebody about a
+    write before it committed, and answering a success to a request whose
+    commit then failed. The function stack closes earlier — after the handler
+    has returned and its response model has been validated, and before the
+    response is sent — so a serialisation error rolls back too.
+    """
+    async with get_sessionmaker()() as session, unit_of_work(session) as scoped:
+        yield scoped
 
 
 async def dispose_engine() -> None:

--- a/apps/api/src/konnekt/services/placements.py
+++ b/apps/api/src/konnekt/services/placements.py
@@ -103,8 +103,6 @@ async def for_slot(
                 kind=PlacementEventKind.IMPRESSION,
             )
         )
-    if out:
-        await session.commit()
     return out
 
 
@@ -125,4 +123,3 @@ async def record(
             kind=PlacementEventKind(kind),
         )
     )
-    await session.commit()

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -69,11 +69,19 @@ async def session(engine) -> AsyncIterator[AsyncSession]:
 @pytest_asyncio.fixture
 async def client(session: AsyncSession) -> AsyncIterator[AsyncClient]:
     """An HTTP client whose requests share the test's rolled-back session."""
-    from konnekt.db.session import session_scope
+    from konnekt.db.session import session_scope, unit_of_work
     from konnekt.main import create_app
 
     app = create_app()
-    app.dependency_overrides[session_scope] = lambda: session
+
+    # The same rule the real scope applies, not a copy of it. The whole test
+    # still disappears: this session is joined to an outer transaction as a
+    # savepoint, so its commits end only the inner one.
+    async def scope():
+        async with unit_of_work(session):
+            yield session
+
+    app.dependency_overrides[session_scope] = scope
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as http:

--- a/apps/api/tests/test_landing.py
+++ b/apps/api/tests/test_landing.py
@@ -37,12 +37,16 @@ class BrokenBot:
 @pytest_asyncio.fixture
 async def app_with(session: AsyncSession):
     """An app with a bot of the caller's choosing on its state."""
-    from konnekt.db.session import session_scope
+    from konnekt.db.session import session_scope, unit_of_work
     from konnekt.main import create_app
+
+    async def scope():
+        async with unit_of_work(session):
+            yield session
 
     async def build(bot) -> FastAPI:
         app = create_app()
-        app.dependency_overrides[session_scope] = lambda: session
+        app.dependency_overrides[session_scope] = scope
         app.state.bot = bot
         return app
 

--- a/apps/api/tests/test_requests.py
+++ b/apps/api/tests/test_requests.py
@@ -10,7 +10,13 @@ from httpx import AsyncClient
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from konnekt.db.models import Contact, HelperProfile, HelpRequest, User
+from konnekt.db.models import (
+    Contact,
+    HelperProfile,
+    HelpRequest,
+    RequestResponse,
+    User,
+)
 from konnekt.db.models.enums import PublishStatus, RequestStatus
 
 from .conftest import auth_header
@@ -455,3 +461,40 @@ async def test_the_feed_does_not_say_how_many_others_answered(
     [row] = [item for item in feed if item["id"] == created["id"]]
     assert "responses_count" not in row
     assert "responders" not in row
+
+
+# ── the request is one transaction ──────────────────────────────────────
+
+
+async def test_a_failure_after_the_write_leaves_nothing_behind(
+    client: AsyncClient, session: AsyncSession, helper_factory, monkeypatch
+) -> None:
+    """Answering a request is all of it or none of it.
+
+    The row is written first and the notification to the author is composed
+    afterwards, so a failure in between used to leave an answer nobody was
+    told about — the helper saw a 500 and assumed it had not gone through.
+    """
+    from konnekt.api.v1 import requests as requests_api
+
+    await helper_factory(tg_id=HELPER)
+    created = await post_request(client, "матан")
+
+    def explode(*args, **kwargs):
+        raise RuntimeError("rendering the notification blew up")
+
+    monkeypatch.setattr(requests_api, "_queue_notification", explode)
+
+    with pytest.raises(RuntimeError):
+        await client.post(
+            f"/api/v1/requests/{created['id']}/respond",
+            json={"message": "могу помочь с этим"},
+            headers=helper_header(),
+        )
+
+    answered = await session.scalar(
+        select(func.count())
+        .select_from(RequestResponse)
+        .where(RequestResponse.request_id == created["id"])
+    )
+    assert answered == 0

--- a/apps/api/tests/test_transactions.py
+++ b/apps/api/tests/test_transactions.py
@@ -1,0 +1,47 @@
+"""The request is one transaction, and it ends before the answer goes out.
+
+The rule itself is exercised all over the suite — every test that writes and
+reads back depends on it. What is tested here is the part that is easy to
+break without noticing: *when* the transaction ends relative to the response.
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .conftest import auth_header
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_a_failing_commit_is_not_answered_with_a_success(
+    session: AsyncSession,
+) -> None:
+    """A commit that fails must reach the client as a failure.
+
+    FastAPI tears a request-scoped `yield` dependency down *after* the response
+    has been sent and after its background tasks have run. A session committed
+    there would answer a success to a request whose write then failed, and
+    would notify somebody about a row that never landed. `SessionDep` therefore
+    asks for function scope; drop that argument and this test sees 200.
+    """
+    from konnekt.db.session import session_scope
+    from konnekt.main import create_app
+
+    async def failing_scope():
+        try:
+            yield session
+        except Exception:
+            await session.rollback()
+            raise
+        else:
+            raise RuntimeError("commit blew up")
+
+    app = create_app()
+    app.dependency_overrides[session_scope] = failing_scope
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as http:
+        response = await http.get("/api/v1/home", headers=auth_header(90777))
+
+    assert response.status_code == 500, response.text

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,6 +63,51 @@ Screens are assembled server-side — the client renders what it is given rather
 than joining data itself — so a schema often mirrors a screen, and that is
 intended.
 
+## One transaction per request
+
+**Services never commit. The request commits.**
+
+`db/session.py::session_scope` is the unit of work: it commits when the
+handler returns and rolls back when the handler raises. So a request either
+happened or it did not, and no endpoint has to remember which of its writes
+came before the failure.
+
+The rule is worth more than the tidiness. Answering a request wrote the
+response row, committed, and only then rendered the notification to its
+author — so a rendering error left an answer in the database that the author
+was never told about, and the helper saw a 500 and assumed nothing had
+happened. That state is now unreachable by construction rather than by
+everybody remembering to put the commit last.
+
+The scope is asked for with `scope="function"`. FastAPI tears a
+request-scoped `yield` dependency down *after* the response has been sent and
+after its background tasks have run, which would answer 201 to a request whose
+commit then failed, and would notify somebody about a row that never landed.
+The function stack closes earlier — after the handler has returned and its
+response model has been validated, and before the response is sent — so a
+serialisation error rolls back too.
+
+Everything that commits outside it:
+
+- `api/deps.py::current_user` commits the person's own row before the handler
+  runs, so that first sight of someone — and the `source` that says where they
+  came from — survives whatever the handler goes on to do.
+- `services/notify.py` opens its own session: it runs in a background task,
+  after the response, and therefore after this transaction has closed.
+- The bot has no request to hang a transaction on, so `bot/middleware.py` and
+  the `/stop` handler open and commit their own sessions. The middleware
+  commits the person's record before the handler runs, for the same reason
+  `current_user` does: neither a slow handler nor a throwing one should decide
+  whether we remember that this person exists. So a bot update is two
+  transactions, deliberately, and not one.
+- `db/seed.py` and `db/demo.py` are scripts, not requests. They commit because
+  nothing else will.
+
+Tests share one session per test, rolled back at the end, and the override in
+`tests/conftest.py` commits and rolls back exactly where `session_scope`
+does. A test fixture that is more forgiving than production is a fixture that
+hides the bugs this rule exists to prevent.
+
 ## Where the code does not follow this yet
 
 Written down because an agent greps this tree and builds against what it
@@ -72,10 +117,6 @@ finds, and a rule with silent exceptions is worse than no rule.
   largest are `cabinet.upsert_helper` — the publish state machine and the
   offer diff — and `requests.request_feed`, which holds the matching and
   ranking algorithm.
-- **There is no transaction rule.** Commits happen in route bodies, in two
-  services, and once inside dependency resolution. The intended rule is
-  *services never commit; the request commits*, and `db/session.py` is not yet
-  a unit of work that could enforce it.
 - **`services/` imports `api/schemas`,** which points the domain layer at the
   HTTP layer. Moving `schemas.py` to the package root fixes it.
 - **`services/catalog._localised` is imported across the package boundary** by


### PR DESCRIPTION
Step 2 of five. `session_scope` becomes a real unit of work and the fourteen scattered commits go away.

## The bug this removes

Answering a request wrote the response row, committed, and only then rendered the notification to its author. A rendering error left an answer in the database that the author was never told about, while the helper saw a 500 and assumed nothing had happened.

`tests/test_requests.py::test_a_failure_after_the_write_leaves_nothing_behind` was written first and failed with `assert 1 == 0`.

## The part worth reading twice

`SessionDep` is declared with `scope="function"`.

FastAPI tears a **request-scoped** `yield` dependency down *after* the response has been sent and after its background tasks have run. Committing there would have sent the notification before the write landed, and answered a success to a request whose commit then failed — the same bug, moved one layer down.

The function stack closes after the handler returns and its response model validates, and before the response is sent. `tests/test_transactions.py` fails if the argument is dropped; verified by dropping it.

I had convinced myself this was not a problem. My own check could not tell "raised before the response" from "raised after it", and I read the result the way I wanted to. The first review round caught it.

## What still commits outside the rule

All four are listed in `docs/architecture.md`:

- `current_user` commits the person's own row, so first sight of someone survives whatever the handler does next
- `services/notify.py` opens its own session — it runs after the response
- the bot has no request to hang a transaction on; its middleware and `/stop` open their own
- `db/seed.py` and `db/demo.py` are scripts

## Review

Four rounds, independent read-only reviewers, none given this session's history. Round 1 found the scope defect; rounds 2 and 3 found claims in comments and docs that overstated what the code did; round 4: "verified sound".

## Checks

- 167 tests pass (165 + 2 new), recorded through `stdd verify`
- `ruff`, `ty`, `biome`, `tsc` clean
- `stdd check` OK

## Out of scope

The three-line scope-override wrapper is duplicated between `tests/conftest.py` and `tests/test_landing.py`. Recorded as deferred rather than fixed here, so the tree that shipped is the tree that was reviewed.

Docs updated first: docs/architecture.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL