### PR TITLE
Make the connection pool a decision rather than a default

### DIFF
--- a/apps/api/src/konnekt/core/config.py
+++ b/apps/api/src/konnekt/core/config.py
@@ -47,6 +47,18 @@ class Settings(BaseSettings):
     database_url: str | None = None
     db_echo: bool = False
 
+    # One pool per process, and the Dockerfile pins `--workers 1`, so these are
+    # the whole connection budget: at most `db_pool_size + db_max_overflow`
+    # against Postgres. Raise them together with the worker count, never one
+    # without looking at the other.
+    db_pool_size: int = 5
+    db_max_overflow: int = 10
+    # Postgres and anything in front of it will close an idle connection
+    # eventually and say nothing. pool_pre_ping catches that on checkout at the
+    # cost of a round trip; recycling retires connections before they get old
+    # enough for it to matter.
+    db_pool_recycle_seconds: int = 1800
+
     @computed_field
     @property
     def sqlalchemy_url(self) -> str:

--- a/apps/api/src/konnekt/db/session.py
+++ b/apps/api/src/konnekt/db/session.py
@@ -15,14 +15,28 @@ _sessionmaker: async_sessionmaker[AsyncSession] | None = None
 
 
 def get_engine() -> AsyncEngine:
+    """The one engine, and with it the one connection pool.
+
+    A module-level singleton rather than something on `app.state`, because the
+    API is not the only door: the bot's middleware, the notifier's background
+    task and the seed scripts all need a session and none of them has a
+    FastAPI app to reach through. One pool for all of them is the point — a
+    second engine would double the connection count against Postgres without
+    anybody deciding to.
+
+    A session is not a connection. `session_scope` makes one per request; the
+    connection underneath it is checked out of this pool on the first query
+    and handed back when the session closes.
+    """
     global _engine
     if _engine is None:
         settings = get_settings()
         _engine = create_async_engine(
             settings.sqlalchemy_url,
             echo=settings.db_echo,
-            pool_size=5,
-            max_overflow=10,
+            pool_size=settings.db_pool_size,
+            max_overflow=settings.db_max_overflow,
+            pool_recycle=settings.db_pool_recycle_seconds,
             pool_pre_ping=True,
         )
     return _engine

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,6 +66,26 @@ Screens are assembled server-side — the client renders what it is given rather
 than joining data itself — so a schema often mirrors a screen, and that is
 intended.
 
+## One engine, one pool
+
+`db/session.py` holds the engine and the sessionmaker as module singletons,
+created once and lazily. Not on `app.state`, deliberately: the API is not the
+only door. The bot's middleware, the notifier's background task and the seed
+scripts all need a session and none of them has a FastAPI app to reach
+through, and a second engine would double the connection count against
+Postgres without anybody deciding to.
+
+A session is not a connection. Each request gets its own `AsyncSession`; the
+connection underneath it is checked out on the first query and handed back
+when the session closes, so a screen that runs four queries uses one
+connection, not four. FastAPI caches dependencies within a request, so
+`SessionDep`, `UserDep` and `LangDep` all resolve to the same session.
+
+`db_pool_size` and `db_max_overflow` are therefore the whole connection budget
+for the process — and the Dockerfile pins `--workers 1`, so process and
+deployment are the same thing here. Raise them together with the worker count,
+never one without looking at the other.
+
 ## One transaction per request
 
 **Services never commit. The request commits.**

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -133,6 +133,10 @@ the webhook and holds aiogram's dispatcher state. Two workers register the
 webhook twice and keep half the state in the wrong process. The Dockerfile
 pins `--workers 1`; leave it there until the bot moves out of the API process.
 
+The connection pool is per process, so that pin is also what makes
+`db_pool_size` and `db_max_overflow` the whole budget against Postgres —
+15 connections by default. Raising the worker count multiplies it.
+
 ## Backups
 
 A sidecar runs `pg_dump --format=custom` daily at `BACKUP_HOUR_UTC` into


### PR DESCRIPTION
The pool worked; nobody had chosen it. `pool_size=5, max_overflow=10` were literals in a constructor with no note saying what they were weighed against, and `pool_recycle` was absent.

## What changes

- `db_pool_size`, `db_max_overflow` and `db_pool_recycle_seconds` are settings, with today's values as defaults so nothing moves unless someone moves it.
- `pool_recycle` is now set to 30 minutes. `pool_pre_ping` already catches a connection the server closed while idle, at the cost of a round trip on every checkout; recycling retires them before they get old enough for that to matter.
- `get_engine` says why it is a module singleton and not something on `app.state`: the API is not the only door. The bot's middleware, the notifier's background task and the seed scripts all need a session and none of them has a FastAPI app to reach through, and a second engine would double the connection count against Postgres without anybody deciding to.
- `docs/architecture.md` gains the section that was missing, and `docs/deploy.md` records that `--workers 1` is what makes these numbers the whole budget — 15 connections — and that raising the worker count multiplies it.

## Measured, not assumed

```
engine is a singleton: True
during session 1: Connections in pool: 0  Checked out: 1
after  session 1: Connections in pool: 1  Checked out: 0
during session 2: Connections in pool: 0  Checked out: 1   <- the same connection
after 8 concurrent: Connections in pool: 5  Overflow: 0
```

Three sequential sessions reuse one connection; eight concurrent ones grow the pool to five and borrow three overflow slots. Configured values reach the engine: `pool.size() == 5`, `_recycle == 1800`.

## Checks

- 173 tests pass, recorded through `stdd verify`
- `ruff`, `ty`, `biome`, `tsc` clean

Classified implementation-only: no product behaviour changes.

Docs updated first: docs/architecture.md, docs/deploy.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL