### PR TITLE
Move the request feed out of the request handler

### DIFF
--- a/apps/api/src/konnekt/api/v1/requests.py
+++ b/apps/api/src/konnekt/api/v1/requests.py
@@ -7,7 +7,7 @@ accepted, closed — and every step of it notifies somebody.
 from datetime import UTC, datetime, time, timedelta
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query, Request, status
-from sqlalchemy import false, func, or_, select
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import selectinload
 
@@ -34,7 +34,6 @@ from konnekt.db.models import (
     HelperProfile,
     HelpRequest,
     Institution,
-    Offer,
     RequestResponse,
     ServiceType,
     Subject,
@@ -49,6 +48,7 @@ from konnekt.db.models.enums import (
     UserEventKind,
 )
 from konnekt.services import notify, parser
+from konnekt.services import requests as requests_service
 from konnekt.services.catalog import _localised, avatar_for
 from konnekt.services.notify import quote
 from konnekt.services.people import log_event
@@ -149,139 +149,38 @@ async def request_feed(
     user: UserDep,
     limit: int = Query(20, ge=1, le=50),
 ) -> list[FeedRequestOut]:
-    """Open requests, for someone who could answer them.
+    """Open requests, for someone who could answer them."""
+    rows = await requests_service.feed_for(session, user=user, limit=limit)
 
-    Visible to any helper profile including a draft one: seeing that four
-    people want help with the thing you teach is the argument for finishing
-    the profile, and withholding it until published gets that backwards. What
-    a draft cannot do is answer — see `respond_to_request`.
-    """
-    helper = await session.get(HelperProfile, user.id)
-    if helper is None:
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN, "only helpers can see incoming requests"
+    rendered = await _requests_out(session, [row.request for row in rows], lang)
+    subjects_by_id = {item.id: item.subject for item in rendered}
+
+    return [
+        FeedRequestOut(
+            # Only the shared fields. `responses_count` and `responders` are
+            # not on FeedRequestOut at all — see the schema.
+            **base.model_dump(exclude={"responders", "responses_count"}),
+            author=avatar_for(row.author),
+            author_name=row.author.first_name,
+            budget=(
+                Price(
+                    amount=float(row.request.budget_max),
+                    currency=row.request.budget_currency,
+                    unit=row.request.budget_unit or PriceUnit.HOUR,
+                )
+                if row.request.budget_max is not None
+                else None
+            ),
+            langs=list(row.request.langs),
+            reason=_feed_reason(
+                on_subject=row.on_subject,
+                on_institution=row.on_institution,
+                on_service=row.on_service,
+                subject=subjects_by_id.get(row.request.id),
+            ),
         )
-    # A ban has to cover this too. The feed carries every author's name, photo,
-    # full text and budget — for someone banned for harassment it is a target
-    # list, and being unable to answer in-app does not help if the reason they
-    # were banned is that they contact people outside it.
-    if helper.status is PublishStatus.BANNED:
-        raise HTTPException(status.HTTP_403_FORBIDDEN, "this profile is banned")
-
-    axes = (
-        await session.execute(
-            select(Offer.subject_id, Offer.institution_id, Offer.service_type_id).where(
-                Offer.helper_id == user.id, Offer.is_active.is_(True)
-            )
-        )
-    ).all()
-    subject_ids = {row[0] for row in axes if row[0]}
-    institution_ids = {row[1] for row in axes if row[1]}
-    service_ids = {row[2] for row in axes if row[2]}
-    # Their own faculty counts too — a request from your own school is
-    # relevant whether or not you have listed an offer against it.
-    if user.institution_id:
-        institution_ids.add(user.institution_id)
-
-    def matches(column, ids: set[int]):
-        """Does this request hit one of the helper's axes?
-
-        coalesce, because `subject_id IN (...)` is NULL for a request with no
-        subject, and NULL sorts *first* under DESC — which would rank every
-        vague request above every matching one.
-
-        None when the helper has nothing on that axis: the term is then a
-        constant, and a constant cannot go in ORDER BY — Postgres reads a bare
-        `false` there as a column ordinal and rejects it.
-        """
-        if not ids:
-            return None
-        return func.coalesce(column.in_(ids), False)
-
-    subject_match = matches(HelpRequest.subject_id, subject_ids)
-    institution_match = matches(HelpRequest.institution_id, institution_ids)
-    service_match = matches(HelpRequest.service_type_id, service_ids)
-
-    # Strongest signal first. Anything the helper has no axis for is dropped
-    # rather than ordered by, since it would sort every row identically.
-    ranking = [
-        term.desc()
-        for term in (subject_match, service_match, institution_match)
-        if term is not None
+        for base, row in zip(rendered, rows, strict=True)
     ]
-
-    now = datetime.now(UTC)
-    answered = (
-        select(RequestResponse.id)
-        .where(
-            RequestResponse.request_id == HelpRequest.id,
-            RequestResponse.helper_id == user.id,
-        )
-        .exists()
-    )
-
-    rows = (
-        await session.execute(
-            select(
-                HelpRequest,
-                User,
-                subject_match if subject_match is not None else false(),
-                institution_match if institution_match is not None else false(),
-                service_match if service_match is not None else false(),
-            )
-            .join(User, User.id == HelpRequest.author_id)
-            .where(
-                HelpRequest.status == RequestStatus.OPEN,
-                # Answering your own request is not a thing.
-                HelpRequest.author_id != user.id,
-                or_(HelpRequest.expires_at.is_(None), HelpRequest.expires_at > now),
-                ~answered,
-            )
-            .order_by(
-                *ranking,
-                HelpRequest.created_at.desc(),
-                # Total, so paging is stable: created_at is the transaction
-                # clock and rows written together share it.
-                HelpRequest.id.desc(),
-            )
-            .limit(limit)
-        )
-    ).all()
-
-    requests = [row[0] for row in rows]
-    rendered = await _requests_out(session, requests, lang)
-    subjects_by_id = {r.id: r.subject for r in rendered}
-
-    out: list[FeedRequestOut] = []
-    for base, (request, author, on_subject, on_institution, on_service) in zip(
-        rendered, rows, strict=True
-    ):
-        out.append(
-            FeedRequestOut(
-                # Only the shared fields. `responses_count` and `responders`
-                # are not on FeedRequestOut at all — see the schema.
-                **base.model_dump(exclude={"responders", "responses_count"}),
-                author=avatar_for(author),
-                author_name=author.first_name,
-                budget=(
-                    Price(
-                        amount=float(request.budget_max),
-                        currency=request.budget_currency,
-                        unit=request.budget_unit or PriceUnit.HOUR,
-                    )
-                    if request.budget_max is not None
-                    else None
-                ),
-                langs=list(request.langs),
-                reason=_feed_reason(
-                    on_subject=bool(on_subject),
-                    on_institution=bool(on_institution),
-                    on_service=bool(on_service),
-                    subject=subjects_by_id.get(request.id),
-                ),
-            )
-        )
-    return out
 
 
 def _feed_reason(

--- a/apps/api/src/konnekt/services/requests.py
+++ b/apps/api/src/konnekt/services/requests.py
@@ -1,0 +1,158 @@
+"""Which open requests a helper is shown, and in what order.
+
+The second-largest algorithm in the product. It is a rule about the catalog —
+who may look, what counts as a match, which signal outranks which — and not a
+fact about HTTP, so it lives here and the endpoint only renders what it
+returns.
+"""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy import false, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from konnekt.db.models import (
+    HelperProfile,
+    HelpRequest,
+    Offer,
+    RequestResponse,
+    User,
+)
+from konnekt.db.models.enums import PublishStatus, RequestStatus
+from konnekt.services.errors import Forbidden
+
+
+@dataclass(frozen=True, slots=True)
+class FeedRow:
+    """One request, its author, and which of the helper's axes it hit.
+
+    The three flags are the contract, not the sentence built out of them: the
+    line the reader sees is rendered from these, and it has to name the same
+    axis that lifted the row or it reads as a non sequitur.
+    """
+
+    request: HelpRequest
+    author: User
+    on_subject: bool
+    on_institution: bool
+    on_service: bool
+
+
+async def feed_for(session: AsyncSession, *, user: User, limit: int) -> list[FeedRow]:
+    """Open requests, for someone who could answer them.
+
+    Visible to any helper profile including a draft one: seeing that four
+    people want help with the thing you teach is the argument for finishing
+    the profile, and withholding it until published gets that backwards. What
+    a draft cannot do is answer.
+    """
+    helper = await session.get(HelperProfile, user.id)
+    if helper is None:
+        raise Forbidden("only helpers can see incoming requests")
+    # A ban has to cover this too. The feed carries every author's name, photo,
+    # full text and budget — for someone banned for harassment it is a target
+    # list, and being unable to answer in-app does not help if the reason they
+    # were banned is that they contact people outside it.
+    if helper.status is PublishStatus.BANNED:
+        raise Forbidden("this profile is banned")
+
+    subject_ids, institution_ids, service_ids = await _axes_of(session, user)
+
+    subject_match = _matches(HelpRequest.subject_id, subject_ids)
+    institution_match = _matches(HelpRequest.institution_id, institution_ids)
+    service_match = _matches(HelpRequest.service_type_id, service_ids)
+
+    # Strongest signal first. Anything the helper has no axis for is dropped
+    # rather than ordered by, since it would sort every row identically.
+    ranking = [
+        term.desc()
+        for term in (subject_match, service_match, institution_match)
+        if term is not None
+    ]
+
+    now = datetime.now(UTC)
+    answered = (
+        select(RequestResponse.id)
+        .where(
+            RequestResponse.request_id == HelpRequest.id,
+            RequestResponse.helper_id == user.id,
+        )
+        .exists()
+    )
+
+    rows = (
+        await session.execute(
+            select(
+                HelpRequest,
+                User,
+                subject_match if subject_match is not None else false(),
+                institution_match if institution_match is not None else false(),
+                service_match if service_match is not None else false(),
+            )
+            .join(User, User.id == HelpRequest.author_id)
+            .where(
+                HelpRequest.status == RequestStatus.OPEN,
+                # Answering your own request is not a thing.
+                HelpRequest.author_id != user.id,
+                or_(HelpRequest.expires_at.is_(None), HelpRequest.expires_at > now),
+                ~answered,
+            )
+            .order_by(
+                *ranking,
+                HelpRequest.created_at.desc(),
+                # Total, so paging is stable: created_at is the transaction
+                # clock and rows written together share it.
+                HelpRequest.id.desc(),
+            )
+            .limit(limit)
+        )
+    ).all()
+
+    return [
+        FeedRow(
+            request=request,
+            author=author,
+            on_subject=bool(on_subject),
+            on_institution=bool(on_institution),
+            on_service=bool(on_service),
+        )
+        for request, author, on_subject, on_institution, on_service in rows
+    ]
+
+
+async def _axes_of(
+    session: AsyncSession, user: User
+) -> tuple[set[int], set[int], set[int]]:
+    """What this helper actually offers, as three sets of ids."""
+    axes = (
+        await session.execute(
+            select(Offer.subject_id, Offer.institution_id, Offer.service_type_id).where(
+                Offer.helper_id == user.id, Offer.is_active.is_(True)
+            )
+        )
+    ).all()
+    subject_ids = {row[0] for row in axes if row[0]}
+    institution_ids = {row[1] for row in axes if row[1]}
+    service_ids = {row[2] for row in axes if row[2]}
+    # Their own faculty counts too — a request from your own school is
+    # relevant whether or not you have listed an offer against it.
+    if user.institution_id:
+        institution_ids.add(user.institution_id)
+    return subject_ids, institution_ids, service_ids
+
+
+def _matches(column, ids: set[int]):
+    """Does this request hit one of the helper's axes?
+
+    coalesce, because `subject_id IN (...)` is NULL for a request with no
+    subject, and NULL sorts *first* under DESC — which would rank every vague
+    request above every matching one.
+
+    None when the helper has nothing on that axis: the term is then a
+    constant, and a constant cannot go in ORDER BY — Postgres reads a bare
+    `false` there as a column ordinal and rejects it.
+    """
+    if not ids:
+        return None
+    return func.coalesce(column.in_(ids), False)

--- a/apps/api/tests/test_requests_service.py
+++ b/apps/api/tests/test_requests_service.py
@@ -1,0 +1,182 @@
+"""Who sees the feed, and in what order — without an HTTP client.
+
+The feed is the second-largest algorithm in the product: a helper is shown
+open requests ranked by how well they match what they actually offer. Both
+halves of it are rules, not rendering, so both belong somewhere a test can
+reach directly.
+"""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from konnekt.db.models import (
+    HelperProfile,
+    HelpRequest,
+    Institution,
+    Offer,
+    ServiceType,
+    Subject,
+    User,
+)
+from konnekt.db.models.enums import PublishStatus, RequestStatus, UiLang
+from konnekt.services import errors
+from konnekt.services import requests as requests_service
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _person(session: AsyncSession, tg_id: int) -> User:
+    user = User(tg_id=tg_id, first_name="Marek", ui_lang=UiLang.RU)
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def _ask(session: AsyncSession, author: User, text: str, **extra) -> HelpRequest:
+    request = HelpRequest(
+        author_id=author.id,
+        raw_text=text,
+        status=RequestStatus.OPEN,
+        langs=["ru"],
+        **extra,
+    )
+    session.add(request)
+    await session.flush()
+    return request
+
+
+async def test_somebody_with_no_helper_profile_is_refused(
+    session: AsyncSession,
+) -> None:
+    user = await _person(session, 91201)
+    with pytest.raises(errors.Forbidden):
+        await requests_service.feed_for(session, user=user, limit=20)
+
+
+async def test_a_draft_profile_may_look(session: AsyncSession) -> None:
+    """Seeing that four people want your subject is the argument for finishing
+    the profile; withholding it until published gets that backwards."""
+    user = await _person(session, 91202)
+    session.add(HelperProfile(user_id=user.id, status=PublishStatus.DRAFT))
+    await session.flush()
+
+    assert await requests_service.feed_for(session, user=user, limit=20) is not None
+
+
+async def test_a_banned_profile_is_refused(session: AsyncSession) -> None:
+    """The feed carries every author's name, photo, text and budget."""
+    user = await _person(session, 91203)
+    session.add(HelperProfile(user_id=user.id, status=PublishStatus.BANNED))
+    await session.flush()
+
+    with pytest.raises(errors.Forbidden):
+        await requests_service.feed_for(session, user=user, limit=20)
+
+
+async def test_your_own_requests_are_not_in_your_feed(session: AsyncSession) -> None:
+    user = await _person(session, 91204)
+    session.add(HelperProfile(user_id=user.id, status=PublishStatus.PUBLISHED))
+    await session.flush()
+    mine = await _ask(session, user, "мой собственный вопрос")
+
+    rows = await requests_service.feed_for(session, user=user, limit=50)
+    assert mine.id not in {row.request.id for row in rows}
+
+
+async def test_a_closed_request_is_not_in_the_feed(session: AsyncSession) -> None:
+    helper = await _person(session, 91205)
+    session.add(HelperProfile(user_id=helper.id, status=PublishStatus.PUBLISHED))
+    student = await _person(session, 91206)
+    await session.flush()
+
+    closed = await _ask(session, student, "уже не нужно")
+    closed.status = RequestStatus.CLOSED
+    await session.flush()
+
+    rows = await requests_service.feed_for(session, user=helper, limit=50)
+    assert closed.id not in {row.request.id for row in rows}
+
+
+async def test_a_row_says_which_axes_it_matched(session: AsyncSession) -> None:
+    """The reason line is rendered from these three flags, so they are the
+    contract — not the sentence built out of them."""
+    helper = await _person(session, 91207)
+    session.add(HelperProfile(user_id=helper.id, status=PublishStatus.PUBLISHED))
+    student = await _person(session, 91208)
+    await session.flush()
+    asked = await _ask(session, student, "нужен матан")
+
+    rows = await requests_service.feed_for(session, user=helper, limit=50)
+    [row] = [item for item in rows if item.request.id == asked.id]
+    assert row.on_subject is False
+    assert row.on_institution is False
+    assert row.on_service is False
+    assert row.author.id == student.id
+
+
+async def test_a_request_on_your_subject_outranks_one_that_is_not(
+    session: AsyncSession,
+) -> None:
+    """The ranking, not just the reason line.
+
+    Both requests are open and answerable; the only difference is that one
+    names a subject this helper offers. If the ORDER BY is lost, the two come
+    back in insertion order and this fails — which is the point, because a
+    silently reordered feed fails nothing else.
+    """
+    helper = await _person(session, 91209)
+    student = await _person(session, 91210)
+    session.add(HelperProfile(user_id=helper.id, status=PublishStatus.PUBLISHED))
+    await session.flush()
+
+    service_type_id = await session.scalar(
+        select(ServiceType.id).where(ServiceType.code == "tutoring")
+    )
+    subject_id = await session.scalar(select(Subject.id).limit(1))
+    assert service_type_id is not None and subject_id is not None
+
+    session.add(
+        Offer(
+            helper_id=helper.id,
+            service_type_id=service_type_id,
+            subject_id=subject_id,
+            is_active=True,
+        )
+    )
+
+    # The matching one is written *first*, so every tiebreak works against it:
+    # rows written in one transaction share created_at, and the id tiebreak is
+    # descending. Only the ranking can lift it, which is what makes this a test
+    # of the ranking rather than of insertion order.
+    on_subject = await _ask(session, student, "мой предмет", subject_id=subject_id)
+    unrelated = await _ask(session, student, "что-то другое")
+
+    rows = await requests_service.feed_for(session, user=helper, limit=50)
+    ordered = [
+        row.request.id for row in rows if row.request.id in {unrelated.id, on_subject.id}
+    ]
+
+    assert ordered == [on_subject.id, unrelated.id]
+    matched = next(row for row in rows if row.request.id == on_subject.id)
+    assert matched.on_subject is True
+
+
+async def test_your_own_faculty_counts_even_without_an_offer_for_it(
+    session: AsyncSession,
+) -> None:
+    """A request from your own school is relevant whether or not you listed it."""
+    institution_id = await session.scalar(select(Institution.id).limit(1))
+    assert institution_id is not None
+
+    helper = await _person(session, 91211)
+    helper.institution_id = institution_id
+    student = await _person(session, 91212)
+    session.add(HelperProfile(user_id=helper.id, status=PublishStatus.PUBLISHED))
+    await session.flush()
+
+    asked = await _ask(session, student, "с факультета", institution_id=institution_id)
+
+    rows = await requests_service.feed_for(session, user=helper, limit=50)
+    [row] = [item for item in rows if item.request.id == asked.id]
+    assert row.on_institution is True

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,9 +136,12 @@ hides the bugs this rule exists to prevent.
 Written down because an agent greps this tree and builds against what it
 finds, and a rule with silent exceptions is worse than no rule.
 
-- **Ten endpoints write to the database directly**, without a service. The
-  largest is `requests.request_feed`, which holds the matching and ranking
-  algorithm.
+- **Most writes still happen in route bodies**, without a service: the whole
+  request lifecycle (`create`, `respond`, `accept`, `decline`, `close`, and
+  marking answers read), `browse.start_contact`, `me.update_me`, and the event
+  logging behind `home`, `helper_detail` and `search.parse`. Named rather than
+  counted — a number here is one nobody remembers to decrement, and this one
+  had already drifted twice.
 - **`services/` imports `api/schemas`,** which points the domain layer at the
   HTTP layer. Moving `schemas.py` to the package root fixes it.
 - **`services/catalog._localised` is imported across the package boundary** by


### PR DESCRIPTION
Step 3b of five. The product's second-largest algorithm gets a home and tests that do not need HTTP.

**Not merging this yet** — see the note at the bottom.

## What moved

`request_feed` was 140 lines in a handler: two permission gates, the helper's axes read out of their offers, the SQL ranking, and the rendering. The rules are now `services/requests.py::feed_for`, returning `FeedRow` dataclasses — the request, its author, and which of the three axes it hit. The handler renders and nothing else.

## The test that was worthless

Eight tests call the service directly, two of them about the ranking rather than the permissions — ranking is what the move actually put at risk, because a reordered feed fails nothing, it just quietly shows the wrong thing first.

The first version of that test passed with the ORDER BY terms deleted. Rows written in one transaction share `created_at`, so the id tiebreak already produced the order I was asserting. The matching request is now written **first**, so every tiebreak works against it and only the ranking can lift it. Verified by deleting the terms and watching it fail.

## Behaviour

Unchanged: the same rows in the same order, the same reason line, and the same status and `detail` for both refusals — inline `HTTPException(403, …)` before, `Forbidden` mapped centrally now.

The doc's count of endpoints that still write directly is replaced by an enumeration. A number there is one nobody remembers to decrement, and it had drifted twice in two changes.

## Checks

- 194 tests pass, recorded through `stdd verify`
- `ruff`, `ty`, `biome`, `tsc` clean
- Two review rounds; the second found nothing

## Why this is not merged yet

Production's bot is currently losing its webhook about a minute after every start — under investigation, unrelated to this change. Merging would run a deploy whose final step ("Confirm Telegram accepted the webhook") fails for that reason, marking an unrelated release red. Holding until the webhook is understood.

Docs updated first: docs/architecture.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL