### PR TITLE
Keep the webhook registered, not just register it

### DIFF
--- a/apps/api/src/konnekt/api/v1/health.py
+++ b/apps/api/src/konnekt/api/v1/health.py
@@ -58,6 +58,26 @@ async def healthz(request: Request, session: SessionDep) -> dict[str, str | int]
     }
 
 
+def name_webhook_state(
+    observed: str, *, expected: str, registration_error: str | None
+) -> str:
+    """The one place a webhook URL becomes an answer somebody reads.
+
+    Named here rather than wherever the observation was made: the endpoint and
+    the watch in `main.py` both make it, and two copies of this vocabulary
+    drift — one of them quietly losing the registration error, which is the
+    only thing that says *why* the bot is deaf.
+    """
+    if observed == expected:
+        return "ok"
+    if observed:
+        return f"elsewhere: {observed}"
+    # "Missing" says the bot is deaf; the registration attempt's own error, if
+    # there was one, says why.
+    why = f" (registration failed: {registration_error})" if registration_error else ""
+    return f"missing: Telegram has no webhook for this bot{why}"
+
+
 async def webhook_state(app: FastAPI) -> str:
     """Where Telegram says it is sending updates, not where we asked it to.
 
@@ -125,6 +145,11 @@ def _cached(app: FastAPI) -> str | None:
 async def _ask_telegram(app: FastAPI, bot) -> str:
     expected = get_settings().webhook_url
     failed = False
+    # Noted before the call, not after: the watch in `main.py` may heal the
+    # webhook while this one is still waiting on Telegram, and an older answer
+    # must not overwrite a newer one — least of all by replacing "ok" with the
+    # "missing" it was sent to check.
+    started = clock.monotonic()
     try:
         info = await asyncio.wait_for(
             bot.get_webhook_info(), timeout=WEBHOOK_CHECK_TIMEOUT
@@ -140,20 +165,18 @@ async def _ask_telegram(app: FastAPI, bot) -> str:
         failed = True
     else:
         observed = str(getattr(info, "url", "") or "")
-        if observed == expected:
-            state = "ok"
-        elif observed:
-            state = f"elsewhere: {observed}"
+        state = name_webhook_state(
+            observed,
+            expected=expected,
+            registration_error=getattr(app.state, "webhook_error", None),
+        )
+        if observed and observed != expected:
             log.error("Telegram points at %s, expected %s", observed, expected)
-        else:
-            # Carry the reason registration gave, if it gave one: "missing"
-            # says the bot is deaf, and the attempt's own error says why.
-            attempted = getattr(app.state, "webhook_error", None)
-            why = f" (registration failed: {attempted})" if attempted else ""
-            state = f"missing: Telegram has no webhook for this bot{why}"
-            log.error("Telegram has no webhook; expected %s%s", expected, why)
+        elif not observed:
+            log.error("Telegram has no webhook; expected %s", expected)
 
-    app.state.webhook_observed = state
-    app.state.webhook_observed_failed = failed
-    app.state.webhook_checked_at = clock.monotonic()
+    if getattr(app.state, "webhook_checked_at", 0.0) <= started:
+        app.state.webhook_observed = state
+        app.state.webhook_observed_failed = failed
+        app.state.webhook_checked_at = clock.monotonic()
     return state

--- a/apps/api/src/konnekt/main.py
+++ b/apps/api/src/konnekt/main.py
@@ -8,6 +8,7 @@ origin, so the page and the API it talks to have to be the same host anyway.
 import asyncio
 import logging
 import secrets
+import time as clock
 from contextlib import asynccontextmanager, suppress
 
 from aiogram.types import Update
@@ -16,7 +17,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from konnekt.api.v1 import router as api_router
-from konnekt.api.v1.health import health_router
+from konnekt.api.v1.health import health_router, name_webhook_state
 from konnekt.bot import build_bot, build_dispatcher, configure
 from konnekt.core.config import get_settings
 from konnekt.db.session import dispose_engine
@@ -53,8 +54,103 @@ def configure_logging(level: str) -> None:
 WEBHOOK_RETRY_DELAYS = (5, 15, 60, 180, 300)
 
 
-async def _register_webhook(app: FastAPI, bot, dispatcher, settings) -> None:
-    """Point Telegram at us, and keep trying until it agrees."""
+# How often Telegram is asked whether it still points here. A webhook that has
+# been cleared costs at most this much silence.
+WEBHOOK_RECHECK_SECONDS = 60.0
+
+# The recheck must not outlive its interval, or a hanging call would stop the
+# watch for as long as aiogram's default session is willing to wait.
+WEBHOOK_RECHECK_TIMEOUT = 10.0
+
+
+async def keep_webhook_registered(
+    app: FastAPI,
+    bot,
+    dispatcher,
+    settings,
+    recheck_seconds: float = WEBHOOK_RECHECK_SECONDS,
+    recheck_timeout: float = WEBHOOK_RECHECK_TIMEOUT,
+) -> None:
+    """Point Telegram at us, and keep it pointed.
+
+    Registration is not a thing that happens once. The webhook is state held
+    by Telegram, and anything holding the same bot token can take it away —
+    `deleteWebhook` from a stray process, or a `polling` bot, which deletes it
+    on every start. Without this the bot goes deaf until somebody restarts the
+    process, and nothing says why.
+
+    Re-registering is deliberately conditional: `set_webhook` on a timer would
+    be a call to Telegram every minute for nothing. When it does have to
+    happen, it keeps whatever queued while the bot was deaf — those are the
+    messages the outage was about.
+    """
+    # Dropping what queued before the process existed is right at boot, and
+    # wrong on a heal — see below.
+    await _set_webhook(app, bot, dispatcher, settings, drop_pending=True)
+
+    while True:
+        await asyncio.sleep(recheck_seconds)
+        try:
+            info = await asyncio.wait_for(bot.get_webhook_info(), timeout=recheck_timeout)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # A check we could not make says nothing about the webhook, and is
+            # not a reason to stop making them.
+            log.warning("could not check the webhook: %s", str(exc) or type(exc).__name__)
+            continue
+
+        observed = str(getattr(info, "url", "") or "")
+        _publish(app, observed, expected=settings.webhook_url)
+        if observed == settings.webhook_url:
+            continue
+
+        if observed:
+            log.error(
+                "the webhook points at %s, not at %s — something else is holding "
+                "this bot token and setting its own. Setting ours again; if this "
+                "repeats, the two are taking turns and one of them has to stop",
+                observed,
+                settings.webhook_url,
+            )
+        else:
+            log.error(
+                "webhook was cleared by someone else — setting it again. Something "
+                "else is holding this bot token; a polling bot deletes the webhook "
+                "on every start"
+            )
+
+        # drop_pending=False: whatever queued while the bot was deaf is exactly
+        # what this watch exists to save. Dropping it here would throw away the
+        # messages the outage was about.
+        await _set_webhook(app, bot, dispatcher, settings, drop_pending=False)
+        # Say so immediately. Otherwise /healthz serves the pre-heal reading
+        # from its cache and reports a deaf bot for up to a minute after it
+        # can hear again.
+        _publish(app, settings.webhook_url, expected=settings.webhook_url)
+
+
+def _publish(app: FastAPI, observed: str, *, expected: str) -> None:
+    """Hand the observation to /healthz, so Telegram is asked once, not twice.
+
+    The endpoint keeps its own ability to ask — it has to answer when no watch
+    is running — but while one is, this is the fresher answer and the endpoint
+    reuses it rather than repeating the call seconds later. The wording is the
+    endpoint's, not a second copy of it.
+    """
+    app.state.webhook_observed = name_webhook_state(
+        observed,
+        expected=expected,
+        registration_error=getattr(app.state, "webhook_error", None),
+    )
+    app.state.webhook_observed_failed = False
+    app.state.webhook_checked_at = clock.monotonic()
+
+
+async def _set_webhook(
+    app: FastAPI, bot, dispatcher, settings, *, drop_pending: bool
+) -> None:
+    """Ask Telegram to send updates here, retrying until it agrees."""
     url = settings.webhook_url
     attempt = 0
     while True:
@@ -65,7 +161,7 @@ async def _register_webhook(app: FastAPI, bot, dispatcher, settings) -> None:
                 # Only the update types something actually handles, so Telegram
                 # stops sending the rest.
                 allowed_updates=dispatcher.resolve_used_update_types(),
-                drop_pending_updates=True,
+                drop_pending_updates=drop_pending,
             )
             await configure(bot, settings)
         except asyncio.CancelledError:
@@ -114,7 +210,7 @@ async def lifespan(app: FastAPI):
             # down. The state is reported by /healthz so a webhook that never
             # registers is visible rather than merely quiet.
             app.state.webhook_task = asyncio.create_task(
-                _register_webhook(app, bot, dispatcher, settings)
+                keep_webhook_registered(app, bot, dispatcher, settings)
             )
         else:
             log.warning("PUBLIC_BASE_URL is unset — bot is loaded but not reachable")

--- a/apps/api/tests/test_health.py
+++ b/apps/api/tests/test_health.py
@@ -282,3 +282,35 @@ async def test_a_registration_failure_is_carried_into_the_missing_message(
     )
     assert body["webhook"].startswith("missing:")
     assert "Bad Request: bad webhook" in body["webhook"]
+
+
+async def test_a_slow_probe_does_not_overwrite_a_newer_answer(app_with) -> None:
+    """The watch can heal the webhook while a probe is still asking about it.
+
+    The probe then answers with what was true when it started. Writing that
+    into the cache would replace a fresh "ok" with a stale "missing" and hold
+    it for a full cache window — undoing the heal as far as anyone reading
+    /healthz is concerned.
+    """
+    import time as clock
+
+    from konnekt.api.v1.health import webhook_state
+
+    class Slow:
+        async def get_webhook_info(self):
+            await asyncio.sleep(0.05)
+            return SimpleNamespace(url="")
+
+    app = app_with(Slow())
+    app.state.webhook_checked_at = 0.0
+
+    async def heal_midway() -> None:
+        await asyncio.sleep(0.02)
+        app.state.webhook_observed = "ok"
+        app.state.webhook_observed_failed = False
+        app.state.webhook_checked_at = clock.monotonic()
+
+    answered, _ = await asyncio.gather(webhook_state(app), heal_midway())
+
+    assert answered.startswith("missing:"), "the probe should say what it saw"
+    assert app.state.webhook_observed == "ok", "but it must not cache it over the heal"

--- a/apps/api/tests/test_webhook_watchdog.py
+++ b/apps/api/tests/test_webhook_watchdog.py
@@ -1,0 +1,215 @@
+"""The webhook is Telegram's state, not ours, and it can be taken away.
+
+Anything holding the same bot token can clear it — a stray `deleteWebhook`, or
+a `polling` bot, which deletes it on every start. Registering once at boot
+therefore is not enough: the application has to keep checking that Telegram
+still points here.
+"""
+
+import asyncio
+from contextlib import suppress
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+
+pytestmark = pytest.mark.asyncio
+
+
+class Telegram:
+    """Enough of aiogram's Bot to hold — and lose — a webhook."""
+
+    def __init__(self, *, clear_after: int | None = None) -> None:
+        self.url = ""
+        self.sets = 0
+        self.reads = 0
+        self.clear_after = clear_after
+        self.dropped: list[bool] = []
+
+    async def set_webhook(self, url: str, **kwargs: object) -> None:
+        self.sets += 1
+        self.url = url
+        self.dropped.append(bool(kwargs.get("drop_pending_updates")))
+
+    async def set_chat_menu_button(self, **_: object) -> None:
+        """Called right after registration, to point the menu at the app."""
+
+    async def get_webhook_info(self):
+        self.reads += 1
+        if self.clear_after is not None and self.reads >= self.clear_after:
+            # Somebody else called deleteWebhook between our reads.
+            self.url = ""
+        return SimpleNamespace(url=self.url)
+
+
+def _app() -> FastAPI:
+    """A real app, because that is what the watch is annotated to take."""
+    app = FastAPI()
+    app.state.webhook_error = None
+    return app
+
+
+def _dispatcher() -> SimpleNamespace:
+    return SimpleNamespace(resolve_used_update_types=lambda: ["message"])
+
+
+async def _run_briefly(coro, seconds: float = 0.4) -> None:
+    task = asyncio.create_task(coro)
+    await asyncio.sleep(seconds)
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
+
+
+async def test_a_webhook_cleared_by_someone_else_is_set_again(settings) -> None:
+    from konnekt.main import keep_webhook_registered
+
+    bot = Telegram(clear_after=1)
+    app = _app()
+
+    await _run_briefly(
+        keep_webhook_registered(app, bot, _dispatcher(), settings, recheck_seconds=0.05)
+    )
+
+    assert bot.sets > 1, "the webhook was set once and never restored"
+    assert bot.url == settings.webhook_url
+
+
+async def test_a_webhook_that_stays_put_is_not_set_again(settings) -> None:
+    """Re-registering for no reason would drop pending updates every minute."""
+    from konnekt.main import keep_webhook_registered
+
+    bot = Telegram()
+    app = _app()
+
+    await _run_briefly(
+        keep_webhook_registered(app, bot, _dispatcher(), settings, recheck_seconds=0.05)
+    )
+
+    assert bot.sets == 1
+    assert bot.reads > 1, "it should have kept checking"
+
+
+async def test_telegram_failing_a_check_does_not_end_the_watch(settings) -> None:
+    from konnekt.main import keep_webhook_registered
+
+    class Flaky(Telegram):
+        async def get_webhook_info(self):
+            self.reads += 1
+            if self.reads == 1:
+                raise RuntimeError("Telegram is having a moment")
+            return SimpleNamespace(url=self.url)
+
+    bot = Flaky()
+    app = _app()
+
+    await _run_briefly(
+        keep_webhook_registered(app, bot, _dispatcher(), settings, recheck_seconds=0.05)
+    )
+
+    assert bot.reads > 2, "one failed check ended the watch"
+
+
+async def test_healing_keeps_the_updates_that_queued_while_it_was_deaf(
+    settings,
+) -> None:
+    """The messages that arrived during the outage are the point of the watch.
+
+    `set_webhook(drop_pending_updates=True)` throws away everything Telegram
+    queued. That is right at boot — those predate the process — and wrong on a
+    heal, where the queue is exactly what the outage cost.
+    """
+    from konnekt.main import keep_webhook_registered
+
+    bot = Telegram(clear_after=1)
+    await _run_briefly(
+        keep_webhook_registered(
+            _app(), bot, _dispatcher(), settings, recheck_seconds=0.05
+        )
+    )
+
+    assert bot.dropped[0] is True, "the first registration should start clean"
+    assert all(dropped is False for dropped in bot.dropped[1:]), (
+        f"a heal discarded queued updates: {bot.dropped}"
+    )
+
+
+async def test_a_check_that_hangs_does_not_stop_the_watch(settings) -> None:
+    """Without a timeout the watch waits as long as aiogram's session will."""
+    from konnekt.main import keep_webhook_registered
+
+    class Hanging(Telegram):
+        async def get_webhook_info(self):
+            self.reads += 1
+            await asyncio.sleep(30)
+
+    bot = Hanging()
+    await _run_briefly(
+        keep_webhook_registered(
+            _app(),
+            bot,
+            _dispatcher(),
+            settings,
+            recheck_seconds=0.02,
+            recheck_timeout=0.02,
+        ),
+        seconds=0.3,
+    )
+
+    assert bot.reads > 2, f"the watch stopped after {bot.reads} check(s)"
+
+
+async def test_the_check_is_given_up_on_before_the_next_one_is_due(settings) -> None:
+    """Otherwise checks pile up on each other."""
+    from konnekt import main
+
+    assert main.WEBHOOK_RECHECK_TIMEOUT < main.WEBHOOK_RECHECK_SECONDS
+
+
+async def test_what_the_watch_saw_is_handed_to_healthz(settings) -> None:
+    """One asker, not two: /healthz reuses this rather than repeating the call."""
+    from konnekt.main import keep_webhook_registered
+
+    app = _app()
+    bot = Telegram()
+    await _run_briefly(
+        keep_webhook_registered(app, bot, _dispatcher(), settings, recheck_seconds=0.05)
+    )
+
+    assert app.state.webhook_observed == "ok"
+    assert app.state.webhook_checked_at > 0
+
+
+async def test_healthz_is_told_the_moment_the_webhook_is_back(settings) -> None:
+    """Otherwise the endpoint serves its cached pre-heal reading for a minute.
+
+    Which would mean reporting a deaf bot for as long after the fix as the
+    outage itself lasted — during exactly the incident this watch exists for.
+    """
+    from konnekt.main import keep_webhook_registered
+
+    app = _app()
+    bot = Telegram(clear_after=1)
+    await _run_briefly(
+        keep_webhook_registered(app, bot, _dispatcher(), settings, recheck_seconds=0.05)
+    )
+
+    assert bot.sets > 1, "no heal happened, so this proves nothing"
+    assert app.state.webhook_observed == "ok"
+
+
+async def test_the_watch_reports_a_missing_webhook_in_the_endpoint_s_words(
+    settings,
+) -> None:
+    """One vocabulary, so /healthz reads the same either way."""
+    from konnekt.api.v1.health import name_webhook_state
+    from konnekt.main import _publish
+
+    app = _app()
+    app.state.webhook_error = "Bad Request: bad webhook"
+    _publish(app, "", expected=settings.webhook_url)
+
+    assert app.state.webhook_observed == name_webhook_state(
+        "", expected=settings.webhook_url, registration_error="Bad Request: bad webhook"
+    )
+    assert "Bad Request: bad webhook" in app.state.webhook_observed

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -196,7 +196,22 @@ Cloudflare or the edge, not this project.
 
 ### If the webhook goes missing
 
-`docker compose restart api` re-registers it: the application sets the webhook
-on startup and retries until Telegram agrees. Confirm from Telegram's side
-afterwards, not from `/healthz` alone, and give it a minute — the answer there
-is cached.
+The application re-registers it by itself. A webhook is state held by Telegram,
+not by us, and anything holding the same bot token can clear it — `deleteWebhook`
+from a stray process, or a `polling` bot, which deletes it on every start. So
+registration is not a thing that happens once at boot: the application checks
+once a minute that Telegram still points here, and sets it again when it does
+not, logging `webhook was cleared by someone else` each time it has to.
+
+Restoring it keeps whatever Telegram queued while the bot was deaf — those
+are the messages the outage cost. Only the first registration at boot drops
+the queue, because that queue predates the process.
+
+Those log lines are the evidence trail. Repeated entries mean the token is
+live somewhere else, and the fix is to find that process — not to restart this
+one. `docker compose logs api | grep webhook` reads them. A line saying the
+webhook *points somewhere else* rather than that it was cleared means the
+other holder is setting its own, and the two are taking turns.
+
+If it cannot be found, rotate the token in @BotFather: the other holder stops
+working immediately, and the new value reaches the server on the next deploy.


### PR DESCRIPTION
Production's bot has been going deaf about a minute after every start. The webhook is set, Telegram confirms it, and some time later Telegram has none. Measured three times: gone after roughly **50, 78 and 162 seconds**.

## What this is and is not

It is **not** the fix. The cause is outside this deployment and the code cannot find it.

What was ruled out, by me and independently by three reviewers reading the tree:

- Nothing in the shipped image can clear a webhook. `delete_webhook` exists only in the retired polling bot at the repository root, which is in no image and run by no workflow. Only the `api` service is given the token.
- One container, `--workers 1`.
- No other container on the host holds this bot's token — checked each one by asking Telegram for its username, never printing a token.
- A `getUpdates` probe at the moment the webhook was gone reported no competing long-poll.

So something outside holds the token, and a `polling` bot deletes the webhook on every start. Finding that process is a question for a human. **Surviving it** is what this change does.

## What it does

Registration stops being a thing that happens once. Every minute the application asks Telegram whether it still points here, sets it again when it does not, and logs which case it saw — cleared, or claimed by something that set its own URL. Those lines are the evidence trail: repeated entries mean the token is live elsewhere, and the fix is to find that process rather than restart this one.

**Re-registering keeps whatever queued while the bot was deaf.** `set_webhook` drops pending updates, which is right at boot — that queue predates the process — and wrong on a heal, where the queue is exactly what the outage cost. That was round 1's blocking finding, and it would have thrown away the messages this exists to save.

The watch hands its reading to `/healthz`, so Telegram is asked once a minute rather than twice, in the endpoint's vocabulary rather than a second copy of it, and republishes immediately after healing — otherwise the endpoint serves its cached `missing` for a minute after the bot can hear again.

## Review

Four rounds.

- **Round 1** — the heal discarded queued updates (blocking).
- **Round 2** — the observation was published before the heal and never after it, so `/healthz` reported deaf for a minute after the fix; and `_publish` re-derived the state vocabulary `health.py` owns, silently dropping the registration reason.
- **Round 3** — a race where a slow probe could overwrite the watch's fresh `ok` with its own stale `missing`, cached as fresh for a full window. The reviewer reproduced it before I closed it.
- **Round 4** — nothing.

## Checks

- 196 tests pass, recorded through `stdd verify`
- Every behaviour the ten new tests name was verified to go red when removed
- `ruff`, `ty`, `biome`, `tsc` clean

Docs updated first: docs/deploy.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL