### PR TITLE
Move the request lifecycle into the service

### DIFF
--- a/apps/api/src/konnekt/api/v1/requests.py
+++ b/apps/api/src/konnekt/api/v1/requests.py
@@ -4,11 +4,8 @@ The largest domain here, because a request has a life — posted, seen, answered
 accepted, closed — and every step of it notifies somebody.
 """
 
-from datetime import UTC, datetime, time, timedelta
-
-from fastapi import APIRouter, BackgroundTasks, HTTPException, Query, Request, status
+from fastapi import APIRouter, BackgroundTasks, Query, Request, status
 from sqlalchemy import func, select
-from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import selectinload
 
 from konnekt.api.deps import LangDep, SessionDep, UserDep
@@ -30,7 +27,6 @@ from konnekt.bot.texts import (
     pick,
 )
 from konnekt.db.models import (
-    Contact,
     HelperProfile,
     HelpRequest,
     Institution,
@@ -40,19 +36,12 @@ from konnekt.db.models import (
     User,
 )
 from konnekt.db.models.enums import (
-    ContentLang,
     PriceUnit,
-    PublishStatus,
-    RequestStatus,
-    ResponseStatus,
-    UserEventKind,
 )
-from konnekt.services import notify, parser
+from konnekt.services import notify
 from konnekt.services import requests as requests_service
 from konnekt.services.catalog import _localised, avatar_for
 from konnekt.services.notify import quote
-from konnekt.services.people import log_event
-from konnekt.services.refs import require_row
 
 router = APIRouter()
 
@@ -66,62 +55,19 @@ router = APIRouter()
 async def create_request(
     payload: RequestCreate, session: SessionDep, lang: LangDep, user: UserDep
 ) -> RequestOut:
-    """Post "I need help with X" and let helpers answer.
-
-    Anything the caller did not fill in is read out of the text, so the form
-    can be a single field. A request without a deadline expires in thirty
-    days; with one, the day after — an exam on the 14th is worthless on the
-    15th, and a stale board is worse than an empty one.
-    """
-    await require_row(session, Subject, payload.subject_id, "subject_id")
-    await require_row(session, Institution, payload.institution_id, "institution_id")
-    await require_row(session, ServiceType, payload.service_type_id, "service_type_id")
-
-    parsed = await parser.parse(session, payload.text, lang.value)
-
-    subject_id = payload.subject_id or (parsed.subject.id if parsed.subject else None)
-    institution_id = payload.institution_id or (
-        parsed.institution.id if parsed.institution else None
-    )
-    service_type_id = payload.service_type_id
-    if service_type_id is None and parsed.service_type:
-        service_type_id = await session.scalar(
-            select(ServiceType.id).where(ServiceType.code == parsed.service_type)
-        )
-    deadline = payload.deadline_on or parsed.deadline
-
-    expires_at = (
-        datetime.combine(deadline, time.max, tzinfo=UTC)
-        if deadline
-        else datetime.now(UTC) + timedelta(days=30)
-    )
-
-    request = HelpRequest(
-        author_id=user.id,
-        raw_text=payload.text,
-        lang=ContentLang(lang.value),
-        subject_id=subject_id,
-        institution_id=institution_id,
-        service_type_id=service_type_id,
-        deadline_on=deadline,
-        budget_max=payload.budget_max or parsed.budget_max,
-        langs=payload.langs or list(user.spoken_langs),
-        status=RequestStatus.OPEN,
-        expires_at=expires_at,
-    )
-    session.add(request)
-    await log_event(
+    """Post "I need help with X" and let helpers answer."""
+    request = await requests_service.create(
         session,
-        user.id,
-        UserEventKind.REQUEST_CREATED,
-        subject_id=subject_id,
-        institution_id=institution_id,
+        user=user,
+        text=payload.text,
+        lang=lang,
+        subject_id=payload.subject_id,
+        institution_id=payload.institution_id,
+        service_type_id=payload.service_type_id,
+        deadline_on=payload.deadline_on,
+        budget_max=payload.budget_max,
+        langs=payload.langs,
     )
-    # flush, not commit: the row has to exist for `refresh` to read the
-    # defaults the database fills in, but the transaction belongs to the
-    # request and ends when the request does.
-    await session.flush()
-    await session.refresh(request)
     return await _request_out(session, request, lang)
 
 
@@ -129,17 +75,10 @@ async def create_request(
 async def my_requests(
     session: SessionDep, lang: LangDep, user: UserDep
 ) -> list[RequestOut]:
-    rows = (
-        await session.scalars(
-            select(HelpRequest)
-            .where(HelpRequest.author_id == user.id)
-            # id as a tiebreaker: created_at comes from now(), which is the
-            # transaction's clock, so two rows written together share it.
-            .order_by(HelpRequest.created_at.desc(), HelpRequest.id.desc())
-            .limit(50)
-        )
-    ).all()
-    return await _requests_out(session, list(rows), lang)
+    """Your own, newest first."""
+    return await _requests_out(
+        session, await requests_service.mine(session, user=user), lang
+    )
 
 
 @router.get("/requests/feed", response_model=list[FeedRequestOut], tags=["requests"])
@@ -216,72 +155,25 @@ async def respond_to_request(
     lang: LangDep,
     user: UserDep,
 ) -> ResponseOut:
-    """Answer someone's request.
-
-    Published profiles only, unlike the feed: an answer is an invitation to
-    look at a profile, and a draft is not there to be looked at.
-    """
-    helper = await session.get(HelperProfile, user.id)
-    if helper is None or helper.status is not PublishStatus.PUBLISHED:
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN, "publish your profile before answering requests"
-        )
-    # The same rule `start_contact` enforces, for the same reason: we do not
-    # host the conversation, so a public username is the only way the author
-    # can answer back. Without it an accepted answer is a dead end — both
-    # sides told a deal happened and neither able to reach the other.
-    if not user.tg_username:
-        raise HTTPException(
-            status.HTTP_409_CONFLICT,
-            "set a public @username in Telegram so people can write back",
-        )
-
-    request = await session.get(HelpRequest, request_id)
-    if request is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "no such request")
-    if request.author_id == user.id:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "this is your own request")
-    expired = request.expires_at is not None and request.expires_at <= datetime.now(UTC)
-    if request.status is not RequestStatus.OPEN or expired:
-        raise HTTPException(status.HTTP_409_CONFLICT, "this request is closed")
-
-    # ON CONFLICT rather than a select first: two taps on a slow connection
-    # are two concurrent inserts, and the unique constraint would surface the
-    # second as a 500 instead of "you already answered this".
-    inserted = await session.scalar(
-        pg_insert(RequestResponse)
-        .values(
-            request_id=request.id,
-            helper_id=user.id,
-            message=payload.message.strip(),
-            price_amount=payload.price_amount,
-            price_unit=payload.price_unit,
-        )
-        .on_conflict_do_nothing(constraint="uq_request_responses_pair")
-        .returning(RequestResponse)
-    )
-    if inserted is None:
-        raise HTTPException(
-            status.HTTP_409_CONFLICT, "you have already answered this request"
-        )
-
-    await log_event(
+    """Answer someone's request."""
+    answered = await requests_service.respond(
         session,
-        user.id,
-        UserEventKind.REQUEST_RESPONDED,
-        request_id=request.id,
-        subject_id=request.subject_id,
+        user=user,
+        request_id=request_id,
+        message=payload.message,
+        price_amount=payload.price_amount,
+        price_unit=payload.price_unit,
     )
 
-    author = await session.get(User, request.author_id)
-    [rendered] = await _responses_out(session, [inserted], lang)
+    [rendered] = await _responses_out(session, [answered.response], lang)
+    author = answered.author
     if author is not None:
         _queue_notification(
             background,
             http,
             recipient=author,
             text=pick(NEW_RESPONSE, author.ui_lang).format(
-                topic=quote(_topic_of(rendered_request=request), 120),
+                topic=quote(_topic_of(rendered_request=answered.request), 120),
                 helper=quote(rendered.name, 64),
                 price=(
                     pick(FOR_PRICE, author.ui_lang).format(
@@ -290,7 +182,7 @@ async def respond_to_request(
                     if rendered.price and rendered.price.amount is not None
                     else ""
                 ),
-                message=quote(inserted.message),
+                message=quote(answered.response.message),
             ),
         )
     return rendered
@@ -305,29 +197,15 @@ async def request_responses(
     request_id: int, session: SessionDep, lang: LangDep, user: UserDep
 ) -> list[ResponseOut]:
     """Who answered. The author only — this is not a public bid list."""
-    request = await session.get(HelpRequest, request_id)
-    if request is None or request.author_id != user.id:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "no such request")
-
-    rows = (
-        await session.scalars(
-            select(RequestResponse)
-            .where(RequestResponse.request_id == request.id)
-            .order_by(RequestResponse.created_at.asc(), RequestResponse.id.asc())
-        )
-    ).all()
+    rows = await requests_service.responses_for_author(
+        session, user=user, request_id=request_id
+    )
 
     # Rendered *before* marking anything, so this response still carries the
     # statuses the author has not seen yet — otherwise the client never gets a
     # chance to badge the new ones, because they arrive already read.
-    out = await _responses_out(session, list(rows), lang)
-
-    # Only the ones still unread, so an accepted or declined answer is not
-    # quietly walked backwards to "read".
-    for row in rows:
-        if row.status is ResponseStatus.SENT:
-            row.status = ResponseStatus.READ
-
+    out = await _responses_out(session, rows, lang)
+    requests_service.mark_read(rows)
     return out
 
 
@@ -344,50 +222,17 @@ async def accept_response(
     lang: LangDep,
     user: UserDep,
 ) -> ResponseOut:
-    """Pick someone.
+    """Pick someone."""
+    accepted = await requests_service.accept(session, user=user, response_id=response_id)
 
-    Does not close the request: needing two people for two subjects is
-    ordinary, and closing on the first acceptance would make the common case
-    the destructive one.
-    """
-    response, request = await _own_response(session, response_id, user)
-
-    # Idempotent. A double tap, or a retry after a dropped response, would
-    # otherwise write a second `contacts` row — which is the basis for deal
-    # counts and response times — and send the helper a second "you were
-    # picked". `contacts` has no unique index to catch it, and should not:
-    # contacting the same person twice about two different requests is real.
-    if response.status is ResponseStatus.ACCEPTED:
-        [out] = await _responses_out(session, [response], lang)
-        return out
-
-    response.status = ResponseStatus.ACCEPTED
-
-    # The same row the catalog writes when someone taps "write" on a profile,
-    # so response times and deal counts count both routes to a conversation.
-    session.add(
-        Contact(
-            student_id=user.id,
-            helper_id=response.helper_id,
-            request_id=request.id,
-        )
-    )
-    await log_event(
-        session,
-        user.id,
-        UserEventKind.RESPONSE_ACCEPTED,
-        request_id=request.id,
-        helper_id=response.helper_id,
-    )
-
-    helper_user = await session.get(User, response.helper_id)
-    if helper_user is not None:
+    helper_user = accepted.helper
+    if accepted.notify and helper_user is not None:
         _queue_notification(
             background,
             http,
             recipient=helper_user,
             text=pick(RESPONSE_ACCEPTED, helper_user.ui_lang).format(
-                topic=quote(_topic_of(rendered_request=request), 120),
+                topic=quote(_topic_of(rendered_request=accepted.request), 120),
                 student=quote(user.first_name, 64),
                 contact=(
                     pick(WRITE_TO, helper_user.ui_lang).format(
@@ -399,7 +244,7 @@ async def accept_response(
             ),
         )
 
-    [out] = await _responses_out(session, [response], lang)
+    [out] = await _responses_out(session, [accepted.response], lang)
     return out
 
 
@@ -412,35 +257,9 @@ async def decline_response(
     response_id: int, session: SessionDep, lang: LangDep, user: UserDep
 ) -> ResponseOut:
     """Turn one down. Deliberately silent — nobody needs a rejection push."""
-    response, _ = await _own_response(session, response_id, user)
-
-    # An accepted answer cannot be walked back here. The helper has already
-    # been told they were picked and a `contacts` row exists; flipping the
-    # status would leave the author reading "you declined" while the other
-    # side reads "you were chosen", with a recorded deal between them.
-    if response.status is ResponseStatus.ACCEPTED:
-        raise HTTPException(status.HTTP_409_CONFLICT, "you already chose this person")
-
-    response.status = ResponseStatus.DECLINED
+    response = await requests_service.decline(session, user=user, response_id=response_id)
     [out] = await _responses_out(session, [response], lang)
     return out
-
-
-async def _own_response(
-    session, response_id: int, user: User
-) -> tuple[RequestResponse, HelpRequest]:
-    """Load a response the caller is entitled to act on.
-
-    404 rather than 403 for someone else's: whether a given id exists is not
-    something a stranger should be able to probe.
-    """
-    response = await session.get(RequestResponse, response_id)
-    if response is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "no such response")
-    request = await session.get(HelpRequest, response.request_id)
-    if request is None or request.author_id != user.id:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "no such response")
-    return response, request
 
 
 def _topic_of(*, rendered_request: HelpRequest) -> str:
@@ -556,10 +375,8 @@ async def _responses_out(
 async def close_request(
     request_id: int, session: SessionDep, lang: LangDep, user: UserDep
 ) -> RequestOut:
-    request = await session.get(HelpRequest, request_id)
-    if request is None or request.author_id != user.id:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "no such request")
-    request.status = RequestStatus.CLOSED
+    """Stop taking answers."""
+    request = await requests_service.close(session, user=user, request_id=request_id)
     return await _request_out(session, request, lang)
 
 

--- a/apps/api/src/konnekt/main.py
+++ b/apps/api/src/konnekt/main.py
@@ -239,6 +239,7 @@ SERVICE_ERROR_STATUS: dict[type[errors.ServiceError], int] = {
     errors.Forbidden: status.HTTP_403_FORBIDDEN,
     errors.Conflict: status.HTTP_409_CONFLICT,
     errors.Invalid: status.HTTP_422_UNPROCESSABLE_CONTENT,
+    errors.BadRequest: status.HTTP_400_BAD_REQUEST,
 }
 
 

--- a/apps/api/src/konnekt/services/errors.py
+++ b/apps/api/src/konnekt/services/errors.py
@@ -1,17 +1,17 @@
 """What a service raises when the caller broke a rule.
 
-Four of them, stated without reference to HTTP. A service that raises
+Five of them, stated without reference to HTTP. A service that raises
 `HTTPException` has an opinion about a protocol, which is exactly what stops
 the bot from calling it — and the bot answering "422 Unprocessable Content" to
 somebody typing into a chat is not an answer.
 
 `main.py` maps each to a status code in one place. Anything else that calls a
-service catches the same four and says something in words.
+service catches them and says something in words.
 """
 
 
 class ServiceError(Exception):
-    """A rule the caller broke. Never raised directly — one of the four below."""
+    """A rule the caller broke. Never raised directly — one of the five below."""
 
 
 class NotFound(ServiceError):
@@ -27,4 +27,18 @@ class Conflict(ServiceError):
 
 
 class Invalid(ServiceError):
-    """The request contradicts itself or names something that is not there."""
+    """The request names something that is not there, or contradicts itself.
+
+    The default for anything wrong with what was sent: an unknown id, the same
+    offer twice, a field that cannot mean what it says. Answers 422.
+    """
+
+
+class BadRequest(ServiceError):
+    """Answers 400, and exists only because one endpoint already did.
+
+    Not a category — `Invalid` is the category. This is here so that
+    "you cannot answer your own request", which answered 400 long before any
+    of this moved into services, still answers 400. Reach for `Invalid`
+    unless you are preserving an existing 400.
+    """

--- a/apps/api/src/konnekt/services/requests.py
+++ b/apps/api/src/konnekt/services/requests.py
@@ -1,26 +1,51 @@
-"""Which open requests a helper is shown, and in what order.
+"""The catalog in reverse: a student posts, helpers answer.
 
-The second-largest algorithm in the product. It is a rule about the catalog —
-who may look, what counts as a match, which signal outranks which — and not a
-fact about HTTP, so it lives here and the endpoint only renders what it
-returns.
+Everything a request goes through — posted, listed, answered, read, accepted,
+declined, closed — plus the feed that decides which open requests a helper is
+shown and in what order. The feed is the second-largest algorithm in the
+product; the rest is a state machine with an audience on both sides.
+
+All of it is rules about the catalog rather than facts about HTTP, so the
+endpoints above this only parse, delegate, render, and send the notifications
+that each step owes somebody.
 """
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime, time, timedelta
 
 from sqlalchemy import false, func, or_, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from konnekt.db.models import (
+    Contact,
     HelperProfile,
     HelpRequest,
+    Institution,
     Offer,
     RequestResponse,
+    ServiceType,
+    Subject,
     User,
 )
-from konnekt.db.models.enums import PublishStatus, RequestStatus
-from konnekt.services.errors import Forbidden
+from konnekt.db.models.enums import (
+    ContentLang,
+    PriceUnit,
+    PublishStatus,
+    RequestStatus,
+    ResponseStatus,
+    UiLang,
+    UserEventKind,
+)
+from konnekt.services import parser
+from konnekt.services.errors import (
+    BadRequest,
+    Conflict,
+    Forbidden,
+    NotFound,
+)
+from konnekt.services.people import log_event
+from konnekt.services.refs import require_row
 
 
 @dataclass(frozen=True, slots=True)
@@ -156,3 +181,302 @@ def _matches(column, ids: set[int]):
     if not ids:
         return None
     return func.coalesce(column.in_(ids), False)
+
+
+async def create(
+    session: AsyncSession,
+    *,
+    user: User,
+    text: str,
+    lang: UiLang,
+    subject_id: int | None = None,
+    institution_id: int | None = None,
+    service_type_id: int | None = None,
+    deadline_on: date | None = None,
+    budget_max: float | None = None,
+    langs: list[str] | None = None,
+) -> HelpRequest:
+    """Post "I need help with X" and let helpers answer.
+
+    Anything the caller did not fill in is read out of the text, so the form
+    can be a single field. A request without a deadline expires in thirty
+    days; with one, the day after — an exam on the 14th is worthless on the
+    15th, and a stale board is worse than an empty one.
+    """
+    await require_row(session, Subject, subject_id, "subject_id")
+    await require_row(session, Institution, institution_id, "institution_id")
+    await require_row(session, ServiceType, service_type_id, "service_type_id")
+
+    parsed = await parser.parse(session, text, lang.value)
+
+    subject_id = subject_id or (parsed.subject.id if parsed.subject else None)
+    institution_id = institution_id or (
+        parsed.institution.id if parsed.institution else None
+    )
+    if service_type_id is None and parsed.service_type:
+        service_type_id = await session.scalar(
+            select(ServiceType.id).where(ServiceType.code == parsed.service_type)
+        )
+    deadline = deadline_on or parsed.deadline
+
+    request = HelpRequest(
+        author_id=user.id,
+        raw_text=text,
+        lang=ContentLang(lang.value),
+        subject_id=subject_id,
+        institution_id=institution_id,
+        service_type_id=service_type_id,
+        deadline_on=deadline,
+        budget_max=budget_max or parsed.budget_max,
+        langs=langs or list(user.spoken_langs),
+        status=RequestStatus.OPEN,
+        expires_at=(
+            datetime.combine(deadline, time.max, tzinfo=UTC)
+            if deadline
+            else datetime.now(UTC) + timedelta(days=30)
+        ),
+    )
+    session.add(request)
+    await log_event(
+        session,
+        user.id,
+        UserEventKind.REQUEST_CREATED,
+        subject_id=subject_id,
+        institution_id=institution_id,
+    )
+    # flush, not commit: the row has to exist for `refresh` to read the
+    # defaults the database fills in, but the transaction belongs to the
+    # request and ends when the request does.
+    await session.flush()
+    await session.refresh(request)
+    return request
+
+
+# Nobody is reading their five-hundredth request, and an unbounded list is a
+# query that gets slower for exactly the people who use the product most.
+MY_REQUESTS_LIMIT = 50
+
+
+async def mine(session: AsyncSession, *, user: User) -> list[HelpRequest]:
+    """Your own, newest first."""
+    return list(
+        (
+            await session.scalars(
+                select(HelpRequest)
+                .where(HelpRequest.author_id == user.id)
+                # id as a tiebreaker: created_at comes from now(), which is the
+                # transaction's clock, so two rows written together share it.
+                .order_by(HelpRequest.created_at.desc(), HelpRequest.id.desc())
+                .limit(MY_REQUESTS_LIMIT)
+            )
+        ).all()
+    )
+
+
+# ── the lifecycle ───────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class Answered:
+    """A new answer, and who has to be told about it."""
+
+    response: RequestResponse
+    request: HelpRequest
+    author: User | None
+
+
+@dataclass(frozen=True, slots=True)
+class Accepted:
+    """An acceptance, and whether it is the one that changed anything.
+
+    `notify` is false on a repeat. Accepting is idempotent, so the second tap
+    must not send the helper a second "you were picked".
+    """
+
+    response: RequestResponse
+    request: HelpRequest
+    helper: User | None
+    notify: bool
+
+
+async def respond(
+    session: AsyncSession,
+    *,
+    user: User,
+    request_id: int,
+    message: str,
+    price_amount: float | None = None,
+    price_unit: PriceUnit | None = None,
+) -> Answered:
+    """Answer someone's request.
+
+    Published profiles only, unlike the feed: an answer is an invitation to
+    look at a profile, and a draft is not there to be looked at.
+    """
+    helper = await session.get(HelperProfile, user.id)
+    if helper is None or helper.status is not PublishStatus.PUBLISHED:
+        raise Forbidden("publish your profile before answering requests")
+    # The same rule contacting a helper enforces, for the same reason: we do
+    # not host the conversation, so a public username is the only way the
+    # author can answer back. Without it an accepted answer is a dead end —
+    # both sides told a deal happened and neither able to reach the other.
+    if not user.tg_username:
+        raise Conflict("set a public @username in Telegram so people can write back")
+
+    request = await session.get(HelpRequest, request_id)
+    if request is None:
+        raise NotFound("no such request")
+    if request.author_id == user.id:
+        raise BadRequest("this is your own request")
+    expired = request.expires_at is not None and request.expires_at <= datetime.now(UTC)
+    if request.status is not RequestStatus.OPEN or expired:
+        raise Conflict("this request is closed")
+
+    # ON CONFLICT rather than a select first: two taps on a slow connection
+    # are two concurrent inserts, and the unique constraint would surface the
+    # second as a 500 instead of "you already answered this".
+    inserted = await session.scalar(
+        pg_insert(RequestResponse)
+        .values(
+            request_id=request.id,
+            helper_id=user.id,
+            message=message.strip(),
+            price_amount=price_amount,
+            price_unit=price_unit,
+        )
+        .on_conflict_do_nothing(constraint="uq_request_responses_pair")
+        .returning(RequestResponse)
+    )
+    if inserted is None:
+        raise Conflict("you have already answered this request")
+
+    await log_event(
+        session,
+        user.id,
+        UserEventKind.REQUEST_RESPONDED,
+        request_id=request.id,
+        subject_id=request.subject_id,
+    )
+    return Answered(
+        response=inserted,
+        request=request,
+        author=await session.get(User, request.author_id),
+    )
+
+
+async def responses_for_author(
+    session: AsyncSession, *, user: User, request_id: int
+) -> list[RequestResponse]:
+    """Who answered. The author only — this is not a public bid list."""
+    request = await session.get(HelpRequest, request_id)
+    if request is None or request.author_id != user.id:
+        raise NotFound("no such request")
+
+    return list(
+        (
+            await session.scalars(
+                select(RequestResponse)
+                .where(RequestResponse.request_id == request.id)
+                .order_by(RequestResponse.created_at.asc(), RequestResponse.id.asc())
+            )
+        ).all()
+    )
+
+
+def mark_read(responses: list[RequestResponse]) -> None:
+    """Separate from reading them, because the order matters.
+
+    The caller renders first: marking before the answer goes out means the
+    author receives them already read and never gets to badge the new ones.
+    Only the ones still unread change, so an accepted or declined answer is
+    not quietly walked backwards.
+    """
+    for response in responses:
+        if response.status is ResponseStatus.SENT:
+            response.status = ResponseStatus.READ
+
+
+async def accept(session: AsyncSession, *, user: User, response_id: int) -> Accepted:
+    """Pick someone.
+
+    Does not close the request: needing two people for two subjects is
+    ordinary, and closing on the first acceptance would make the common case
+    the destructive one.
+    """
+    response, request = await _own_response(session, response_id, user)
+
+    # Idempotent. A double tap, or a retry after a dropped response, would
+    # otherwise write a second `contacts` row — which is the basis for deal
+    # counts and response times — and send the helper a second "you were
+    # picked". `contacts` has no unique index to catch it, and should not:
+    # contacting the same person twice about two different requests is real.
+    if response.status is ResponseStatus.ACCEPTED:
+        return Accepted(response=response, request=request, helper=None, notify=False)
+
+    response.status = ResponseStatus.ACCEPTED
+
+    # The same row the catalog writes when someone taps "write" on a profile,
+    # so response times and deal counts count both routes to a conversation.
+    session.add(
+        Contact(
+            student_id=user.id,
+            helper_id=response.helper_id,
+            request_id=request.id,
+        )
+    )
+    await log_event(
+        session,
+        user.id,
+        UserEventKind.RESPONSE_ACCEPTED,
+        request_id=request.id,
+        helper_id=response.helper_id,
+    )
+    return Accepted(
+        response=response,
+        request=request,
+        helper=await session.get(User, response.helper_id),
+        notify=True,
+    )
+
+
+async def decline(
+    session: AsyncSession, *, user: User, response_id: int
+) -> RequestResponse:
+    """Turn one down. Deliberately silent — nobody needs a rejection push."""
+    response, _ = await _own_response(session, response_id, user)
+
+    # An accepted answer cannot be walked back. The helper has already been
+    # told they were picked and a `contacts` row exists; flipping the status
+    # would leave the author reading "you declined" while the other side reads
+    # "you were chosen", with a recorded deal between them.
+    if response.status is ResponseStatus.ACCEPTED:
+        raise Conflict("you already chose this person")
+
+    response.status = ResponseStatus.DECLINED
+    return response
+
+
+async def close(session: AsyncSession, *, user: User, request_id: int) -> HelpRequest:
+    """Stop taking answers."""
+    request = await session.get(HelpRequest, request_id)
+    if request is None or request.author_id != user.id:
+        raise NotFound("no such request")
+    request.status = RequestStatus.CLOSED
+    return request
+
+
+async def _own_response(
+    session: AsyncSession, response_id: int, user: User
+) -> tuple[RequestResponse, HelpRequest]:
+    """Load a response the caller is entitled to act on.
+
+    404 rather than 403 for someone else's: whether a given id exists is not
+    something a stranger should be able to probe.
+    """
+    response = await session.get(RequestResponse, response_id)
+    if response is None:
+        raise NotFound("no such response")
+    request = await session.get(HelpRequest, response.request_id)
+    if request is None or request.author_id != user.id:
+        raise NotFound("no such response")
+    return response, request

--- a/apps/api/tests/test_requests_service.py
+++ b/apps/api/tests/test_requests_service.py
@@ -7,10 +7,11 @@ reach directly.
 """
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from konnekt.db.models import (
+    Contact,
     HelperProfile,
     HelpRequest,
     Institution,
@@ -19,7 +20,12 @@ from konnekt.db.models import (
     Subject,
     User,
 )
-from konnekt.db.models.enums import PublishStatus, RequestStatus, UiLang
+from konnekt.db.models.enums import (
+    PublishStatus,
+    RequestStatus,
+    ResponseStatus,
+    UiLang,
+)
 from konnekt.services import errors
 from konnekt.services import requests as requests_service
 
@@ -29,6 +35,15 @@ pytestmark = pytest.mark.asyncio
 async def _person(session: AsyncSession, tg_id: int) -> User:
     user = User(tg_id=tg_id, first_name="Marek", ui_lang=UiLang.RU)
     session.add(user)
+    await session.flush()
+    return user
+
+
+async def _publisher(session: AsyncSession, tg_id: int) -> User:
+    """A helper who is allowed to answer: published, and reachable."""
+    user = await _person(session, tg_id)
+    user.tg_username = f"helper{tg_id}"
+    session.add(HelperProfile(user_id=user.id, status=PublishStatus.PUBLISHED))
     await session.flush()
     return user
 
@@ -180,3 +195,220 @@ async def test_your_own_faculty_counts_even_without_an_offer_for_it(
     rows = await requests_service.feed_for(session, user=helper, limit=50)
     [row] = [item for item in rows if item.request.id == asked.id]
     assert row.on_institution is True
+
+
+# ── the lifecycle, without an HTTP client ───────────────────────────────
+
+
+async def test_answering_needs_a_published_profile(session: AsyncSession) -> None:
+    """A draft may look at the feed but not answer from it.
+
+    An answer is an invitation to look at a profile, and a draft is not there
+    to be looked at.
+    """
+    student = await _person(session, 91301)
+    helper = await _person(session, 91302)
+    helper.tg_username = "helper91302"
+    session.add(HelperProfile(user_id=helper.id, status=PublishStatus.DRAFT))
+    await session.flush()
+    asked = await _ask(session, student, "матан")
+
+    with pytest.raises(errors.Forbidden):
+        await requests_service.respond(
+            session, user=helper, request_id=asked.id, message="могу помочь"
+        )
+
+
+async def test_answering_needs_a_public_username(session: AsyncSession) -> None:
+    """We do not host the conversation, so a handle is the only way back.
+
+    Without one an accepted answer is a dead end: both sides told a deal
+    happened, and neither able to reach the other.
+    """
+    student = await _person(session, 91303)
+    helper = await _person(session, 91304)
+    session.add(HelperProfile(user_id=helper.id, status=PublishStatus.PUBLISHED))
+    await session.flush()
+    asked = await _ask(session, student, "матан")
+
+    with pytest.raises(errors.Conflict):
+        await requests_service.respond(
+            session, user=helper, request_id=asked.id, message="могу помочь"
+        )
+
+
+async def test_answering_the_same_request_twice_is_refused(
+    session: AsyncSession,
+) -> None:
+    """Two taps on a slow connection are two concurrent inserts.
+
+    The unique constraint would surface the second as a 500; this says what
+    happened instead.
+    """
+    student = await _person(session, 91305)
+    helper = await _publisher(session, 91306)
+    asked = await _ask(session, student, "матан")
+
+    await requests_service.respond(
+        session, user=helper, request_id=asked.id, message="могу помочь"
+    )
+    with pytest.raises(errors.Conflict):
+        await requests_service.respond(
+            session, user=helper, request_id=asked.id, message="и ещё раз"
+        )
+
+
+async def test_answering_your_own_request_is_refused(session: AsyncSession) -> None:
+    helper = await _publisher(session, 91307)
+    mine = await _ask(session, helper, "сам себя")
+
+    with pytest.raises(errors.BadRequest):
+        await requests_service.respond(
+            session, user=helper, request_id=mine.id, message="сам себе помогу"
+        )
+
+
+async def test_accepting_is_idempotent(session: AsyncSession) -> None:
+    """A double tap must not write a second contact or send a second push.
+
+    `contacts` has no unique index and should not have one — contacting the
+    same person about two different requests is real.
+    """
+    student = await _person(session, 91308)
+    helper = await _publisher(session, 91309)
+    asked = await _ask(session, student, "матан")
+    answered = await requests_service.respond(
+        session, user=helper, request_id=asked.id, message="могу помочь"
+    )
+
+    first = await requests_service.accept(
+        session, user=student, response_id=answered.response.id
+    )
+    second = await requests_service.accept(
+        session, user=student, response_id=answered.response.id
+    )
+
+    assert first.notify is True
+    assert second.notify is False, "the second acceptance told the helper again"
+
+    contacts = await session.scalar(
+        select(func.count()).select_from(Contact).where(Contact.request_id == asked.id)
+    )
+    assert contacts == 1
+
+
+async def test_an_accepted_answer_cannot_be_declined(session: AsyncSession) -> None:
+    """Otherwise the author reads "you declined" and the helper "you were
+    chosen", with a recorded deal between them."""
+    student = await _person(session, 91310)
+    helper = await _publisher(session, 91311)
+    asked = await _ask(session, student, "матан")
+    answered = await requests_service.respond(
+        session, user=helper, request_id=asked.id, message="могу помочь"
+    )
+    await requests_service.accept(session, user=student, response_id=answered.response.id)
+
+    with pytest.raises(errors.Conflict):
+        await requests_service.decline(
+            session, user=student, response_id=answered.response.id
+        )
+
+
+async def test_somebody_else_s_response_reads_as_missing(session: AsyncSession) -> None:
+    """404 rather than 403: whether an id exists is not a stranger's business."""
+    student = await _person(session, 91312)
+    helper = await _publisher(session, 91313)
+    stranger = await _person(session, 91314)
+    asked = await _ask(session, student, "матан")
+    answered = await requests_service.respond(
+        session, user=helper, request_id=asked.id, message="могу помочь"
+    )
+
+    with pytest.raises(errors.NotFound):
+        await requests_service.accept(
+            session, user=stranger, response_id=answered.response.id
+        )
+
+
+async def test_closing_someone_else_s_request_reads_as_missing(
+    session: AsyncSession,
+) -> None:
+    student = await _person(session, 91315)
+    stranger = await _person(session, 91316)
+    asked = await _ask(session, student, "матан")
+
+    with pytest.raises(errors.NotFound):
+        await requests_service.close(session, user=stranger, request_id=asked.id)
+
+
+async def test_answers_are_only_marked_read_once_the_author_has_them(
+    session: AsyncSession,
+) -> None:
+    """Reading the list is what marks it, and only what was still unread.
+
+    An accepted or declined answer must not be walked backwards to "read".
+    """
+    student = await _person(session, 91317)
+    helper = await _publisher(session, 91318)
+    asked = await _ask(session, student, "матан")
+    await requests_service.respond(
+        session, user=helper, request_id=asked.id, message="могу помочь"
+    )
+
+    rows = await requests_service.responses_for_author(
+        session, user=student, request_id=asked.id
+    )
+    assert [row.status for row in rows] == [ResponseStatus.SENT]
+
+    requests_service.mark_read(rows)
+    again = await requests_service.responses_for_author(
+        session, user=student, request_id=asked.id
+    )
+    assert [row.status for row in again] == [ResponseStatus.READ]
+
+
+async def test_reading_the_answers_does_not_walk_a_decided_one_backwards(
+    session: AsyncSession,
+) -> None:
+    """Only what is still unread changes.
+
+    An accepted or declined answer has already been acted on; flipping it to
+    "read" would lose that.
+    """
+    student = await _person(session, 91319)
+    keen = await _publisher(session, 91320)
+    other = await _publisher(session, 91321)
+    asked = await _ask(session, student, "матан")
+
+    chosen = await requests_service.respond(
+        session, user=keen, request_id=asked.id, message="могу помочь"
+    )
+    await requests_service.respond(
+        session, user=other, request_id=asked.id, message="я тоже могу"
+    )
+    await requests_service.accept(session, user=student, response_id=chosen.response.id)
+
+    rows = await requests_service.responses_for_author(
+        session, user=student, request_id=asked.id
+    )
+    requests_service.mark_read(rows)
+
+    statuses = {
+        row.helper_id: row.status
+        for row in await requests_service.responses_for_author(
+            session, user=student, request_id=asked.id
+        )
+    }
+    assert statuses[keen.id] is ResponseStatus.ACCEPTED
+    assert statuses[other.id] is ResponseStatus.READ
+
+
+async def test_your_own_requests_are_capped(session: AsyncSession) -> None:
+    """An unbounded list gets slower for exactly the heaviest users."""
+    student = await _person(session, 91322)
+    for index in range(requests_service.MY_REQUESTS_LIMIT + 3):
+        await _ask(session, student, f"вопрос {index}")
+
+    assert len(await requests_service.mine(session, user=student)) == (
+        requests_service.MY_REQUESTS_LIMIT
+    )

--- a/apps/api/tests/test_service_errors.py
+++ b/apps/api/tests/test_service_errors.py
@@ -30,3 +30,9 @@ def test_a_subclass_keeps_the_status_of_the_family_it_extends() -> None:
 def test_the_base_class_is_not_quietly_given_a_plausible_status() -> None:
     """Raising `ServiceError` itself is a programming error, and says so."""
     assert status_for(errors.ServiceError("raised by mistake")) == 500
+
+
+def test_the_two_input_errors_keep_the_statuses_the_api_already_answered() -> None:
+    """400 and 422 both existed before any of this moved into services."""
+    assert status_for(errors.BadRequest("this is your own request")) == 400
+    assert status_for(errors.Invalid("unknown subject_id: 9")) == 422

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,8 +58,10 @@ raise `HTTPException`: an HTTP status is a fact about a protocol, and a
 service that knows about protocols cannot be called by the bot.
 
 What it raises instead lives in `services/errors.py` — `NotFound`,
-`Forbidden`, `Conflict`, `Invalid` — and one handler in `main.py` turns each
-into its status code. The bot can catch the same four and answer in words.
+`Forbidden`, `Conflict`, `Invalid`, `BadRequest` — and one handler in
+`main.py` turns each into its status code, walking the class hierarchy so a
+subclass keeps its family's answer. The bot can catch them and answer in
+words.
 
 **A schema** is a leaf. `api/schemas.py` describes what goes over the wire.
 Screens are assembled server-side — the client renders what it is given rather
@@ -136,12 +138,11 @@ hides the bugs this rule exists to prevent.
 Written down because an agent greps this tree and builds against what it
 finds, and a rule with silent exceptions is worse than no rule.
 
-- **Most writes still happen in route bodies**, without a service: the whole
-  request lifecycle (`create`, `respond`, `accept`, `decline`, `close`, and
-  marking answers read), `browse.start_contact`, `me.update_me`, and the event
-  logging behind `home`, `helper_detail` and `search.parse`. Named rather than
-  counted — a number here is one nobody remembers to decrement, and this one
-  had already drifted twice.
+- **Some endpoints still write in the route body**: `browse.start_contact`,
+  `me.update_me`, and the event logging behind `browse.home`,
+  `browse.helper_detail` and `search.parse`. Named rather than counted — a
+  number here is one nobody remembers to correct, and the last three attempts
+  at one were all wrong.
 - **`services/` imports `api/schemas`,** which points the domain layer at the
   HTTP layer. Moving `schemas.py` to the package root fixes it.
 - **`services/catalog._localised` is imported across the package boundary** by


### PR DESCRIPTION
Step 4. The last of the big handlers.

Posting a request, listing your own, answering one, reading the answers, accepting, declining and closing were all written in route bodies. They are now `services/requests.py`, and the endpoints parse, delegate, render, and send the notifications each step owes somebody.

| | `api/v1/requests.py` | `services/requests.py` |
| --- | --- | --- |
| before | 649 | 158 |
| after | 466 | 470 |

## What the service now guards

Nineteen tests call it directly, with no HTTP anywhere:

- answering needs a **published** profile — a draft may read the feed but not answer from it
- answering needs a **public username** — we do not host the conversation, so a handle is the only way the author can reply
- answering twice is refused by the unique constraint, not a select-then-insert: two taps on a slow connection are two concurrent inserts
- **accepting is idempotent** and says so with a flag, so a second acceptance writes no second `contacts` row and sends no second notification
- an accepted answer cannot be declined afterwards
- somebody else's response reads as 404, not 403 — whether an id exists is not a stranger's business

Marking answers read stays a separate call. The order is a rendering constraint rather than a rule: the author has to receive the statuses they have not seen yet, so the route renders first and marks afterwards.

## Behaviour

Unchanged. The generated OpenAPI schema differs from `main` in **exactly eight lines, all `description` fields** — the reasoning moved into the service and took its docstrings with it. No path, method, parameter or response model moved.

## Two near misses, both caught by review

**`mine()` lost the `.limit(50)`.** I rewrote that one function from memory instead of moving it, so `GET /requests` would have returned an author's entire history. The suite was green without the limit; a reviewer diffed against `main` function-by-function and found it.

**"This is your own request" answered 400**, and routing it through `Invalid` would have quietly made it 422. It now has its own class — documented as *a preserved status, not a category*, because the first version of that docstring would have led the next person to change it back.

## Review

Three rounds. Round 1: the missing limit (blocking) plus four advisories. Round 2: two stale docstrings, one of which steered toward reclassifying an existing 422. Round 3: nothing.

## Checks

- 216 tests pass, recorded through `stdd verify`
- Every rule the new tests name was verified to go red when removed
- `ruff`, `ty`, `biome`, `tsc` clean

Docs updated first: docs/architecture.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL