### PR TITLE
Stop the app scrolling when there is nothing to scroll

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "typecheck": "tsc -b",
+    "check:scroll": "node scripts/check-scroll.mjs",
     "i18n:extract": "lingui extract",
     "i18n:compile": "lingui compile",
     "api:generate": "openapi-ts"

--- a/apps/web/scripts/check-scroll.mjs
+++ b/apps/web/scripts/check-scroll.mjs
@@ -1,5 +1,5 @@
 /*
- * When you reach the bottom, there has to be something there.
+ * Nothing should be scrollable to a stretch of nothing.
  *
  * The contract is in docs/architecture.md: the Mini App is a screen, not a
  * document. The bug this guards against is not "the page scrolls" — a list is
@@ -13,19 +13,29 @@
  * pointless. What separates the bug from an ordinary short list is what is
  * waiting at the end of the scroll.
  *
- * So: scroll to the bottom, then ask where the lowest content sits. It should
- * be against the bottom edge — above the tab bar where there is one, a
- * screen's padding above the edge where there is not. Anything more is dead
- * space that was scrolled through for nothing.
+ * So the measurement is geometric and needs no scrolling at all: how far is
+ * the lowest thing that paints from the bottom of the screen's content box?
+ * The screen's own `padding-bottom` is by design and is subtracted, which is
+ * also what keeps the number honest on a phone with a home indicator, where
+ * that padding includes the inset. Anything left over is dead space.
+ *
+ * A container does not paint on behalf of its children: a spacer nested inside
+ * a card list is the same bug as one at the foot of the screen, and an earlier
+ * version of this check — which took any element with children as content —
+ * could see the second and not the first.
  *
  * Measured at several viewport sizes, because a screen that fits on a tall
  * phone is not the question.
  *
- * Needs the dev server (`make web`) with the API behind it: an empty state and
- * a failed request are different heights, so a screen measured against a dead
- * API proves nothing. Both are checked rather than assumed — a blank page has
- * nothing to scroll either, and that is the one way a check like this could
- * congratulate itself on a screen that never came up.
+ * What it cannot do: the mock in `src/mockEnv.ts` reports `tdesktop`, where the
+ * SDK synthesises the viewport from `window.innerHeight`, so `--app-height`
+ * here is always the same number as the `100dvh` fallback. The iOS and Android
+ * path that variable exists for is not exercised by anything on this machine.
+ *
+ * Needs the dev server (`make web`) and the API behind it, with a signed
+ * `VITE_MOCK_INIT_DATA` in `apps/web/.env.local` — the API answers 401 to the
+ * unsigned mock, and a screen full of error states is not the screen being
+ * measured. All three are checked before anything is measured.
  *
  * `make web` serves https through mkcert, which needs sudo once. Where it
  * cannot have it, run the server with VITE_NO_HTTPS=1 and pass
@@ -43,35 +53,50 @@ const VIEWPORTS = [
   { width: 390, height: 568 },
 ];
 
+/**
+ * The detail screens are behind an id this script cannot know, so they are
+ * reached the way a person reaches them: by tapping the first row of the list
+ * that leads there.
+ */
 const ROUTES = [
-  '/',
-  '/ask',
-  '/results',
-  '/mine',
-  '/life',
-  '/profile',
-  '/become-helper',
-  '/my-helper',
-  '/nope',
+  { path: '/' },
+  { path: '/ask' },
+  { path: '/results', into: { name: 'helper detail', click: '[class*="card"]' } },
+  { path: '/mine', into: { name: 'request detail', click: '[class*="card"]' } },
+  { path: '/life' },
+  { path: '/profile' },
+  { path: '/become-helper' },
+  { path: '/my-helper' },
+  { path: '/nope' },
 ];
 
 /**
- * How much emptiness under the last row is by design.
+ * Sub-pixel layout leaves fractions behind; a spacer never weighs four.
  *
- * A screen keeps 16px clear at its foot — see `.screen` in ui.module.css,
- * which is the one place that number lives — and a few pixels of rounding sit
- * on top of that. Past this, the space is not clearance, it is a spacer nobody
- * meant to leave.
+ * Everything a screen keeps clear on purpose is already subtracted — it is
+ * `.screen`'s own `padding-bottom` in ui.module.css, home indicator included —
+ * so this is a tolerance and not an allowance.
  */
-const BY_DESIGN = 20;
+const ROUNDING = 4;
 
 const browser = await chromium.launch();
 const failures = [];
+const skipped = new Set();
 
 /** Stop before measuring anything if the thing being measured is not there. */
 async function preflight() {
-  const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 664 },
+    ignoreHTTPSErrors: true,
+  });
   const page = await context.newPage();
+  const fail = async (why, hint) => {
+    console.error(`Cannot measure against ${BASE}: ${why}`);
+    console.error(hint);
+    await browser.close();
+    process.exit(2);
+  };
+
   try {
     const health = await page.goto(`${BASE}/healthz`, { timeout: 15000 });
     if (!health?.ok()) throw new Error(`/healthz answered ${health?.status()}`);
@@ -80,74 +105,75 @@ async function preflight() {
       throw new Error(`/healthz says ${body.trim().slice(0, 120)}`);
     }
   } catch (error) {
-    console.error(`Cannot measure against ${BASE}: ${error.message}`);
-    console.error('Start the dev server (make web) and the API (make api) first,');
-    console.error('or point BASE at a running one.');
-    await browser.close();
-    process.exit(2);
+    await fail(
+      error.message,
+      'Start the dev server (make web) and the API (make api) first.',
+    );
+  }
+
+  // The home screen's category grid only exists once an authenticated request
+  // has come back. Without it every data screen renders an error state, which
+  // has a height of its own and would be measured as if it were the screen.
+  await page.goto(BASE, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(1200);
+  const gotData = await page.evaluate(() =>
+    Boolean(document.querySelector('[class*="grid"]')),
+  );
+  if (!gotData) {
+    await fail(
+      'the home screen came up without its categories',
+      'The API is rejecting this init data. Put a signed VITE_MOCK_INIT_DATA in apps/web/.env.local.',
+    );
   }
   await context.close();
 }
 
 /**
- * Everything the page has to say about its own bottom edge.
+ * How much emptiness the screen has under its lowest visible thing.
  *
- * Runs in the browser twice — before and after scrolling — because the
- * question is what the scroll changed.
+ * Runs in the browser. Declared as a plain function so `page.evaluate` can
+ * serialise it, inner helper and all.
  */
 function look() {
   /**
-   * Does this element put anything on the screen?
+   * Does this element put anything on the screen *itself*?
    *
-   * A spacer is an element with a height and nothing in it, and it is exactly
-   * what this check exists to find. Counting it as content would let the
-   * scroll end "on" it and report the screen as fine — which is how the
-   * 24-pixel block at the foot of /life stayed invisible.
+   * Its children do not count for it: a container's box is only as meaningful
+   * as what is inside it, and a spacer wrapped in a div is still a spacer.
+   * What counts is text of its own, a box it fills or outlines, or being one
+   * of the elements that draws by nature.
    */
   function paints(el) {
-    if (el.childElementCount > 0 || el.textContent.trim()) return true;
+    if (/^(svg|img|canvas|video|input|textarea|select|hr)$/i.test(el.tagName))
+      return true;
+    for (const node of el.childNodes) {
+      if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) return true;
+    }
     const style = getComputedStyle(el);
-    const filled =
-      style.backgroundImage !== 'none' ||
-      !['transparent', 'rgba(0, 0, 0, 0)'].includes(style.backgroundColor);
-    const bordered =
-      ['Top', 'Right', 'Bottom', 'Left'].some(
-        (side) => Number.parseFloat(style[`border${side}Width`]) > 0,
-      ) || style.boxShadow !== 'none';
-    return filled || bordered;
+    if (style.visibility === 'hidden' || style.opacity === '0') return false;
+    if (style.backgroundImage !== 'none') return true;
+    if (!['transparent', 'rgba(0, 0, 0, 0)'].includes(style.backgroundColor)) return true;
+    if (style.boxShadow !== 'none') return true;
+    return ['Top', 'Right', 'Bottom', 'Left'].some(
+      (side) => Number.parseFloat(style[`border${side}Width`]) > 0,
+    );
   }
 
   const doc = document.documentElement;
   const root = document.getElementById('root');
-  if (!root?.firstElementChild) return { rendered: false };
+  const screen = root?.firstElementChild;
+  if (!screen) return { rendered: false };
 
-  // The tab bar is fixed and overlays the foot of the screen, so the content
-  // it covers is not visible content and its own bottom edge is not the
-  // page's. Same for the sheet and its scrim when one is open.
-  const floating = new Set();
-  for (const el of root.querySelectorAll('*')) {
-    if (getComputedStyle(el).position === 'fixed') {
-      floating.add(el);
-      for (const child of el.querySelectorAll('*')) floating.add(child);
-    }
-  }
+  const style = getComputedStyle(screen);
+  const floor =
+    screen.getBoundingClientRect().bottom - Number.parseFloat(style.paddingBottom);
 
   let lowest = Number.NEGATIVE_INFINITY;
-  let cover = 0;
-  for (const el of root.querySelectorAll('*')) {
+  for (const el of screen.querySelectorAll('*')) {
+    // A sheet is fixed to the viewport and is not part of the screen's flow.
+    if (getComputedStyle(el).position === 'fixed') continue;
     const box = el.getBoundingClientRect();
     if (box.height <= 0 || box.width <= 0) continue;
-    if (floating.has(el)) {
-      if (box.bottom >= window.innerHeight - 1) {
-        cover = Math.max(cover, box.height);
-      }
-      continue;
-    }
-    // The screen itself is skipped: its bottom edge is its own reserve for
-    // the tab bar, which is the very padding this check is trying to look
-    // past. Everything inside it counts, cards and their padding included —
-    // a card's own foot is part of the card.
-    if (el.parentElement === root) continue;
     if (!paints(el)) continue;
     lowest = Math.max(lowest, box.bottom);
   }
@@ -155,9 +181,34 @@ function look() {
   return {
     rendered: true,
     travel: doc.scrollHeight - doc.clientHeight + (root.scrollHeight - root.clientHeight),
-    // How far the lowest content sits above the lowest place it could be.
-    slack: window.innerHeight - cover - lowest,
+    // Everything between the last visible thing and where the screen's own
+    // designed clearance begins.
+    dead: lowest === Number.NEGATIVE_INFINITY ? 0 : floor - lowest,
   };
+}
+
+async function measure(page, name, label) {
+  await page.waitForTimeout(900);
+  // The development console is a floating panel of its own and would otherwise
+  // count as content.
+  await page.addStyleTag({ content: '#eruda{display:none !important}' });
+  await page.waitForTimeout(100);
+
+  const seen = await page.evaluate(look);
+  if (!seen.rendered) {
+    console.error(`\n${name} rendered nothing at ${label}.`);
+    await browser.close();
+    process.exit(2);
+  }
+
+  // Dead space nobody can reach is just whitespace at the foot of a page.
+  const dead = seen.travel > 0 ? Math.round(seen.dead) : 0;
+  const pointless = dead > ROUNDING;
+  console.log(
+    `  ${pointless ? 'FAIL' : 'ok  '} ${name.padEnd(20)}` +
+      ` travel=${Math.round(seen.travel)}px  empty=${dead}px`,
+  );
+  if (pointless) failures.push(`${name} at ${label}: ${dead}px of nothing`);
 }
 
 await preflight();
@@ -178,43 +229,42 @@ for (const viewport of VIEWPORTS) {
   for (const route of ROUTES) {
     const page = await context.newPage();
     try {
-      const response = await page.goto(`${BASE}${route}`, { waitUntil: 'networkidle' });
+      const response = await page.goto(`${BASE}${route.path}`, {
+        waitUntil: 'networkidle',
+      });
       if (response && !response.ok()) throw new Error(`HTTP ${response.status()}`);
     } catch (error) {
-      console.error(`\nCannot reach ${BASE}${route}: ${error.message}`);
-      await browser.close();
-      process.exit(2);
-    }
-    await page.waitForTimeout(900);
-    // The development console is a floating panel of its own and would
-    // otherwise count as content.
-    await page.addStyleTag({ content: '#eruda{display:none !important}' });
-    await page.waitForTimeout(100);
-
-    const before = await page.evaluate(look);
-    if (!before.rendered) {
-      console.error(`\n${route} rendered nothing at ${label}.`);
+      console.error(`\nCannot reach ${BASE}${route.path}: ${error.message}`);
       await browser.close();
       process.exit(2);
     }
 
-    // To the end of whichever box turns out to be the scrolling one.
-    await page.evaluate(() => {
-      const root = document.getElementById('root');
-      if (root) root.scrollTop = root.scrollHeight;
-      document.documentElement.scrollTop = document.documentElement.scrollHeight;
-    });
-    await page.waitForTimeout(200);
-    const after = await page.evaluate(look);
+    await measure(page, route.path, label);
+
+    if (route.into) {
+      let opened = true;
+      try {
+        await page.locator(route.into.click).first().click({ timeout: 5000 });
+        await page.waitForURL((url) => url.pathname !== route.path, { timeout: 5000 });
+      } catch {
+        opened = false;
+      }
+      if (opened) {
+        await measure(page, route.into.name, label);
+      } else {
+        // An empty list is a seeding problem rather than a layout one, so it
+        // does not fail the run — but it does mean a screen went unmeasured,
+        // and an unmeasured screen reported as nothing at all is how a check
+        // like this quietly stops being one. Nothing seeds a help request
+        // today, so `request detail` skips on every machine.
+        console.log(
+          `  SKIP ${route.into.name.padEnd(20)} nothing in ${route.path} to open`,
+        );
+        skipped.add(route.into.name);
+      }
+    }
+
     await page.close();
-
-    const dead = before.travel > 0 ? Math.round(after.slack) : 0;
-    const pointless = dead > BY_DESIGN;
-    console.log(
-      `  ${pointless ? 'FAIL' : 'ok  '} ${route.padEnd(16)}` +
-        ` travel=${Math.round(before.travel)}px  empty at the end=${dead}px`,
-    );
-    if (pointless) failures.push(`${route} at ${label}: ${dead}px of nothing`);
   }
 
   await context.close();
@@ -228,4 +278,7 @@ if (failures.length) {
   );
   process.exit(1);
 }
-console.log(`\nEvery scroll ends on content, at all ${VIEWPORTS.length} sizes.`);
+if (skipped.size) {
+  console.log(`\nNot measured, nothing to open: ${[...skipped].join(', ')}.`);
+}
+console.log(`Every screen measured ends on content, at all ${VIEWPORTS.length} sizes.`);

--- a/apps/web/scripts/check-scroll.mjs
+++ b/apps/web/scripts/check-scroll.mjs
@@ -1,0 +1,75 @@
+/*
+ * A screen that fits must not scroll.
+ *
+ * The contract is in docs/architecture.md: the Mini App is a screen, not a
+ * document, and the few pixels of travel a screen with nothing on it used to
+ * offer are a layout bug rather than a rounding error. This is that check,
+ * because the bug is invisible on a desktop window and obvious on a phone.
+ *
+ * Travel is measured as the document's overflow plus #root's, added together
+ * on purpose: which of the two boxes scrolls is an implementation detail, and
+ * a check that watched only one would go quiet the moment the overflow moved.
+ *
+ * The routes below are the ones that hold a screenful at most. A list screen
+ * is expected to scroll and is not listed; it is not that its travel is fine,
+ * it is that the right number for it is "however long the list is".
+ *
+ * Needs the dev server (`make web`) and the API behind it, because an empty
+ * state and a failed request are different heights. Run it as
+ * `pnpm check:scroll`, or against another origin with BASE=…
+ */
+
+import { chromium } from 'playwright';
+
+const BASE = process.env.BASE || 'http://localhost:5173';
+
+/** A small phone in Telegram, which is where the pixels are tightest. */
+const VIEWPORT = { width: 390, height: 664 };
+
+const SHORT_SCREENS = ['/', '/ask', '/mine', '/life', '/profile', '/become-helper'];
+
+const browser = await chromium.launch();
+const context = await browser.newContext({
+  viewport: VIEWPORT,
+  deviceScaleFactor: 2,
+  isMobile: true,
+  hasTouch: true,
+});
+
+const failures = [];
+
+for (const route of SHORT_SCREENS) {
+  const page = await context.newPage();
+  await page.goto(`${BASE}${route}`, { waitUntil: 'networkidle' }).catch(() => {});
+  await page.waitForTimeout(900);
+  // The development console is a floating panel of its own and would otherwise
+  // count as content.
+  await page.addStyleTag({ content: '#eruda{display:none !important}' });
+  await page.waitForTimeout(100);
+
+  const travel = await page.evaluate(() => {
+    const doc = document.documentElement;
+    const root = document.getElementById('root');
+    return (
+      doc.scrollHeight -
+      doc.clientHeight +
+      (root ? root.scrollHeight - root.clientHeight : 0)
+    );
+  });
+
+  console.log(`${travel === 0 ? 'ok  ' : 'FAIL'} ${route.padEnd(16)} travel=${travel}px`);
+  if (travel !== 0) failures.push(`${route}: ${travel}px`);
+  await page.close();
+}
+
+await browser.close();
+
+if (failures.length) {
+  console.error(
+    `\n${failures.length} screen(s) scroll with nothing to scroll to:\n  ${failures.join('\n  ')}`,
+  );
+  process.exit(1);
+}
+console.log(
+  `\nAll ${SHORT_SCREENS.length} screens fit at ${VIEWPORT.width}x${VIEWPORT.height}.`,
+);

--- a/apps/web/scripts/check-scroll.mjs
+++ b/apps/web/scripts/check-scroll.mjs
@@ -61,8 +61,8 @@ const VIEWPORTS = [
 const ROUTES = [
   { path: '/' },
   { path: '/ask' },
-  { path: '/results', into: { name: 'helper detail', click: '[class*="card"]' } },
-  { path: '/mine', into: { name: 'request detail', click: '[class*="card"]' } },
+  { path: '/results', into: { name: 'helper detail', click: 'button[class*="card"]' } },
+  { path: '/mine', into: { name: 'request detail', click: 'button[class*="card"]' } },
   { path: '/life' },
   { path: '/profile' },
   { path: '/become-helper' },
@@ -144,25 +144,65 @@ function look() {
    * of the elements that draws by nature.
    */
   function paints(el) {
+    // Asked first, and of the whole ancestor chain: an element with text in it
+    // is still invisible under a hidden or fully transparent parent, and text
+    // was the one test that used to answer before anything looked at style.
+    if (
+      !el.checkVisibility({
+        opacityProperty: true,
+        visibilityProperty: true,
+        contentVisibilityAuto: true,
+      })
+    ) {
+      return false;
+    }
     if (/^(svg|img|canvas|video|input|textarea|select|hr)$/i.test(el.tagName))
       return true;
     for (const node of el.childNodes) {
       if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) return true;
     }
+    for (const pseudo of ['::before', '::after']) {
+      const drawn = getComputedStyle(el, pseudo);
+      if (drawn.content !== 'none' && drawn.content !== 'normal') return true;
+    }
     const style = getComputedStyle(el);
-    if (style.visibility === 'hidden' || style.opacity === '0') return false;
     if (style.backgroundImage !== 'none') return true;
     if (!['transparent', 'rgba(0, 0, 0, 0)'].includes(style.backgroundColor)) return true;
     if (style.boxShadow !== 'none') return true;
+    if (Number.parseFloat(style.outlineWidth) > 0 && style.outlineStyle !== 'none') {
+      return true;
+    }
     return ['Top', 'Right', 'Bottom', 'Left'].some(
       (side) => Number.parseFloat(style[`border${side}Width`]) > 0,
     );
   }
 
+  /**
+   * Where this element's paint actually stops.
+   *
+   * `getBoundingClientRect` does not know about clipping, so a tall child of a
+   * short `overflow: hidden` box reports a bottom edge nobody can see. Left
+   * alone that reads as content below the floor, and one negative number is
+   * enough to hide every real spacer above it.
+   */
+  function visibleBottom(el, screen) {
+    let bottom = el.getBoundingClientRect().bottom;
+    for (
+      let node = el.parentElement;
+      node && node !== screen;
+      node = node.parentElement
+    ) {
+      if (getComputedStyle(node).overflowY !== 'visible') {
+        bottom = Math.min(bottom, node.getBoundingClientRect().bottom);
+      }
+    }
+    return bottom;
+  }
+
   const doc = document.documentElement;
   const root = document.getElementById('root');
   const screen = root?.firstElementChild;
-  if (!screen) return { rendered: false };
+  if (!screen) return { verdict: 'nothing rendered' };
 
   const style = getComputedStyle(screen);
   const floor =
@@ -175,15 +215,23 @@ function look() {
     const box = el.getBoundingClientRect();
     if (box.height <= 0 || box.width <= 0) continue;
     if (!paints(el)) continue;
-    lowest = Math.max(lowest, box.bottom);
+    lowest = Math.max(lowest, visibleBottom(el, screen));
+  }
+
+  // Not "clean": unmeasurable. A page whose root is not a `<Screen>` — which
+  // is how the 404 was written — has no content box to measure against, and
+  // calling that zero is how a mistyped route reports as spotless. It is the
+  // shape of the bug this check twice had to be rescued from, so it is loud.
+  if (lowest === Number.NEGATIVE_INFINITY) {
+    return { verdict: 'no screen: nothing in the page paints anything' };
   }
 
   return {
-    rendered: true,
+    verdict: 'measured',
     travel: doc.scrollHeight - doc.clientHeight + (root.scrollHeight - root.clientHeight),
     // Everything between the last visible thing and where the screen's own
     // designed clearance begins.
-    dead: lowest === Number.NEGATIVE_INFINITY ? 0 : floor - lowest,
+    dead: floor - lowest,
   };
 }
 
@@ -195,8 +243,8 @@ async function measure(page, name, label) {
   await page.waitForTimeout(100);
 
   const seen = await page.evaluate(look);
-  if (!seen.rendered) {
-    console.error(`\n${name} rendered nothing at ${label}.`);
+  if (seen.verdict !== 'measured') {
+    console.error(`\n${name} at ${label}: ${seen.verdict}.`);
     await browser.close();
     process.exit(2);
   }
@@ -255,8 +303,7 @@ for (const viewport of VIEWPORTS) {
         // An empty list is a seeding problem rather than a layout one, so it
         // does not fail the run — but it does mean a screen went unmeasured,
         // and an unmeasured screen reported as nothing at all is how a check
-        // like this quietly stops being one. Nothing seeds a help request
-        // today, so `request detail` skips on every machine.
+        // like this quietly stops being one.
         console.log(
           `  SKIP ${route.into.name.padEnd(20)} nothing in ${route.path} to open`,
         );

--- a/apps/web/scripts/check-scroll.mjs
+++ b/apps/web/scripts/check-scroll.mjs
@@ -1,75 +1,231 @@
 /*
- * A screen that fits must not scroll.
+ * When you reach the bottom, there has to be something there.
  *
  * The contract is in docs/architecture.md: the Mini App is a screen, not a
- * document, and the few pixels of travel a screen with nothing on it used to
- * offer are a layout bug rather than a rounding error. This is that check,
- * because the bug is invisible on a desktop window and obvious on a phone.
+ * document. The bug this guards against is not "the page scrolls" — a list is
+ * supposed to — it is travel that reveals nothing, which reads as a broken
+ * screen and is invisible on a desktop window.
  *
- * Travel is measured as the document's overflow plus #root's, added together
- * on purpose: which of the two boxes scrolls is an implementation detail, and
- * a check that watched only one would go quiet the moment the overflow moved.
+ * "A screen that fits must not scroll" was the obvious rule and it is the
+ * wrong one. For any layout there is a band of viewport heights where the
+ * content is a handful of pixels too tall, so a threshold on travel only moves
+ * the failing size around; it says nothing about whether the travel was
+ * pointless. What separates the bug from an ordinary short list is what is
+ * waiting at the end of the scroll.
  *
- * The routes below are the ones that hold a screenful at most. A list screen
- * is expected to scroll and is not listed; it is not that its travel is fine,
- * it is that the right number for it is "however long the list is".
+ * So: scroll to the bottom, then ask where the lowest content sits. It should
+ * be against the bottom edge — above the tab bar where there is one, a
+ * screen's padding above the edge where there is not. Anything more is dead
+ * space that was scrolled through for nothing.
  *
- * Needs the dev server (`make web`) and the API behind it, because an empty
- * state and a failed request are different heights. Run it as
- * `pnpm check:scroll`, or against another origin with BASE=…
+ * Measured at several viewport sizes, because a screen that fits on a tall
+ * phone is not the question.
+ *
+ * Needs the dev server (`make web`) with the API behind it: an empty state and
+ * a failed request are different heights, so a screen measured against a dead
+ * API proves nothing. Both are checked rather than assumed — a blank page has
+ * nothing to scroll either, and that is the one way a check like this could
+ * congratulate itself on a screen that never came up.
+ *
+ * `make web` serves https through mkcert, which needs sudo once. Where it
+ * cannot have it, run the server with VITE_NO_HTTPS=1 and pass
+ * BASE=http://localhost:5173.
  */
 
 import { chromium } from 'playwright';
 
-const BASE = process.env.BASE || 'http://localhost:5173';
+const BASE = process.env.BASE || 'https://localhost:5173';
 
-/** A small phone in Telegram, which is where the pixels are tightest. */
-const VIEWPORT = { width: 390, height: 664 };
+/** Real phones. The short ones are where the last few pixels appear. */
+const VIEWPORTS = [
+  { width: 390, height: 664 },
+  { width: 360, height: 640 },
+  { width: 390, height: 568 },
+];
 
-const SHORT_SCREENS = ['/', '/ask', '/mine', '/life', '/profile', '/become-helper'];
+const ROUTES = [
+  '/',
+  '/ask',
+  '/results',
+  '/mine',
+  '/life',
+  '/profile',
+  '/become-helper',
+  '/my-helper',
+  '/nope',
+];
+
+/**
+ * How much emptiness under the last row is by design.
+ *
+ * A screen keeps 16px clear at its foot — see `.screen` in ui.module.css,
+ * which is the one place that number lives — and a few pixels of rounding sit
+ * on top of that. Past this, the space is not clearance, it is a spacer nobody
+ * meant to leave.
+ */
+const BY_DESIGN = 20;
 
 const browser = await chromium.launch();
-const context = await browser.newContext({
-  viewport: VIEWPORT,
-  deviceScaleFactor: 2,
-  isMobile: true,
-  hasTouch: true,
-});
-
 const failures = [];
 
-for (const route of SHORT_SCREENS) {
+/** Stop before measuring anything if the thing being measured is not there. */
+async function preflight() {
+  const context = await browser.newContext({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
-  await page.goto(`${BASE}${route}`, { waitUntil: 'networkidle' }).catch(() => {});
-  await page.waitForTimeout(900);
-  // The development console is a floating panel of its own and would otherwise
-  // count as content.
-  await page.addStyleTag({ content: '#eruda{display:none !important}' });
-  await page.waitForTimeout(100);
+  try {
+    const health = await page.goto(`${BASE}/healthz`, { timeout: 15000 });
+    if (!health?.ok()) throw new Error(`/healthz answered ${health?.status()}`);
+    const body = await page.evaluate(() => document.body.innerText);
+    if (!body.includes('"database":"ok"')) {
+      throw new Error(`/healthz says ${body.trim().slice(0, 120)}`);
+    }
+  } catch (error) {
+    console.error(`Cannot measure against ${BASE}: ${error.message}`);
+    console.error('Start the dev server (make web) and the API (make api) first,');
+    console.error('or point BASE at a running one.');
+    await browser.close();
+    process.exit(2);
+  }
+  await context.close();
+}
 
-  const travel = await page.evaluate(() => {
-    const doc = document.documentElement;
-    const root = document.getElementById('root');
-    return (
-      doc.scrollHeight -
-      doc.clientHeight +
-      (root ? root.scrollHeight - root.clientHeight : 0)
-    );
+/**
+ * Everything the page has to say about its own bottom edge.
+ *
+ * Runs in the browser twice — before and after scrolling — because the
+ * question is what the scroll changed.
+ */
+function look() {
+  /**
+   * Does this element put anything on the screen?
+   *
+   * A spacer is an element with a height and nothing in it, and it is exactly
+   * what this check exists to find. Counting it as content would let the
+   * scroll end "on" it and report the screen as fine — which is how the
+   * 24-pixel block at the foot of /life stayed invisible.
+   */
+  function paints(el) {
+    if (el.childElementCount > 0 || el.textContent.trim()) return true;
+    const style = getComputedStyle(el);
+    const filled =
+      style.backgroundImage !== 'none' ||
+      !['transparent', 'rgba(0, 0, 0, 0)'].includes(style.backgroundColor);
+    const bordered =
+      ['Top', 'Right', 'Bottom', 'Left'].some(
+        (side) => Number.parseFloat(style[`border${side}Width`]) > 0,
+      ) || style.boxShadow !== 'none';
+    return filled || bordered;
+  }
+
+  const doc = document.documentElement;
+  const root = document.getElementById('root');
+  if (!root?.firstElementChild) return { rendered: false };
+
+  // The tab bar is fixed and overlays the foot of the screen, so the content
+  // it covers is not visible content and its own bottom edge is not the
+  // page's. Same for the sheet and its scrim when one is open.
+  const floating = new Set();
+  for (const el of root.querySelectorAll('*')) {
+    if (getComputedStyle(el).position === 'fixed') {
+      floating.add(el);
+      for (const child of el.querySelectorAll('*')) floating.add(child);
+    }
+  }
+
+  let lowest = Number.NEGATIVE_INFINITY;
+  let cover = 0;
+  for (const el of root.querySelectorAll('*')) {
+    const box = el.getBoundingClientRect();
+    if (box.height <= 0 || box.width <= 0) continue;
+    if (floating.has(el)) {
+      if (box.bottom >= window.innerHeight - 1) {
+        cover = Math.max(cover, box.height);
+      }
+      continue;
+    }
+    // The screen itself is skipped: its bottom edge is its own reserve for
+    // the tab bar, which is the very padding this check is trying to look
+    // past. Everything inside it counts, cards and their padding included —
+    // a card's own foot is part of the card.
+    if (el.parentElement === root) continue;
+    if (!paints(el)) continue;
+    lowest = Math.max(lowest, box.bottom);
+  }
+
+  return {
+    rendered: true,
+    travel: doc.scrollHeight - doc.clientHeight + (root.scrollHeight - root.clientHeight),
+    // How far the lowest content sits above the lowest place it could be.
+    slack: window.innerHeight - cover - lowest,
+  };
+}
+
+await preflight();
+
+for (const viewport of VIEWPORTS) {
+  const label = `${viewport.width}x${viewport.height}`;
+  // mkcert's certificate is not in this process's trust store, and a TLS error
+  // here would otherwise look exactly like a screen that fits.
+  const context = await browser.newContext({
+    viewport,
+    deviceScaleFactor: 2,
+    isMobile: true,
+    hasTouch: true,
+    ignoreHTTPSErrors: true,
   });
 
-  console.log(`${travel === 0 ? 'ok  ' : 'FAIL'} ${route.padEnd(16)} travel=${travel}px`);
-  if (travel !== 0) failures.push(`${route}: ${travel}px`);
-  await page.close();
+  console.log(`\n${label}`);
+  for (const route of ROUTES) {
+    const page = await context.newPage();
+    try {
+      const response = await page.goto(`${BASE}${route}`, { waitUntil: 'networkidle' });
+      if (response && !response.ok()) throw new Error(`HTTP ${response.status()}`);
+    } catch (error) {
+      console.error(`\nCannot reach ${BASE}${route}: ${error.message}`);
+      await browser.close();
+      process.exit(2);
+    }
+    await page.waitForTimeout(900);
+    // The development console is a floating panel of its own and would
+    // otherwise count as content.
+    await page.addStyleTag({ content: '#eruda{display:none !important}' });
+    await page.waitForTimeout(100);
+
+    const before = await page.evaluate(look);
+    if (!before.rendered) {
+      console.error(`\n${route} rendered nothing at ${label}.`);
+      await browser.close();
+      process.exit(2);
+    }
+
+    // To the end of whichever box turns out to be the scrolling one.
+    await page.evaluate(() => {
+      const root = document.getElementById('root');
+      if (root) root.scrollTop = root.scrollHeight;
+      document.documentElement.scrollTop = document.documentElement.scrollHeight;
+    });
+    await page.waitForTimeout(200);
+    const after = await page.evaluate(look);
+    await page.close();
+
+    const dead = before.travel > 0 ? Math.round(after.slack) : 0;
+    const pointless = dead > BY_DESIGN;
+    console.log(
+      `  ${pointless ? 'FAIL' : 'ok  '} ${route.padEnd(16)}` +
+        ` travel=${Math.round(before.travel)}px  empty at the end=${dead}px`,
+    );
+    if (pointless) failures.push(`${route} at ${label}: ${dead}px of nothing`);
+  }
+
+  await context.close();
 }
 
 await browser.close();
 
 if (failures.length) {
   console.error(
-    `\n${failures.length} screen(s) scroll with nothing to scroll to:\n  ${failures.join('\n  ')}`,
+    `\n${failures.length} screen(s) scroll to nothing:\n  ${failures.join('\n  ')}`,
   );
   process.exit(1);
 }
-console.log(
-  `\nAll ${SHORT_SCREENS.length} screens fit at ${VIEWPORT.width}x${VIEWPORT.height}.`,
-);
+console.log(`\nEvery scroll ends on content, at all ${VIEWPORTS.length} sizes.`);

--- a/apps/web/src/components/ui.module.css
+++ b/apps/web/src/components/ui.module.css
@@ -15,14 +15,20 @@
      rather than a design. */
   padding-top: calc(var(--top-clearance) + 8px);
   /* Nothing above #root pads the bottom any more, so a screen without a tab
-     bar clears the home indicator itself. */
-  padding-bottom: calc(12px + var(--tg-viewport-safe-area-inset-bottom, 0px));
+     bar clears the home indicator itself.
+
+     This is also the *only* breathing room at the foot of a screen. Six pages
+     each ended in a spacer div of its own — 20px here, 32px there — and every
+     one of them was a stretch of nothing at the end of a scroll, which is the
+     bug `scripts/check-scroll.mjs` exists to catch. One number, in one place,
+     is both easier to look at and the thing that check can hold us to. */
+  padding-bottom: calc(16px + var(--tg-viewport-safe-area-inset-bottom, 0px));
 }
 
 /* Room for the tab bar, which is fixed. Without it the last row hides behind.
    --h-tab already includes the home indicator, so this does not add it again. */
 .screen.withTabs {
-  padding-bottom: calc(var(--h-tab) + 8px);
+  padding-bottom: calc(var(--h-tab) + 16px);
 }
 
 /* ── header ─────────────────────────────────────────────────────────── */

--- a/apps/web/src/components/ui.module.css
+++ b/apps/web/src/components/ui.module.css
@@ -17,11 +17,11 @@
   /* Nothing above #root pads the bottom any more, so a screen without a tab
      bar clears the home indicator itself.
 
-     This is also the *only* breathing room at the foot of a screen. Six pages
-     each ended in a spacer div of its own — 20px here, 32px there — and every
-     one of them was a stretch of nothing at the end of a scroll, which is the
-     bug `scripts/check-scroll.mjs` exists to catch. One number, in one place,
-     is both easier to look at and the thing that check can hold us to. */
+     This is also the *only* breathing room at the foot of a screen. Seven
+     pages each ended in a spacer div of its own — 20px here, 32px there — and
+     every one was a stretch of nothing at the end of a scroll, which is the
+     bug `scripts/check-scroll.mjs` exists to catch. One number here and one
+     below is both easier to look at and the thing that check can hold us to. */
   padding-bottom: calc(16px + var(--tg-viewport-safe-area-inset-bottom, 0px));
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -33,10 +33,12 @@ html {
   /* Telegram clients may hand the page a text-size override. */
   -webkit-text-size-adjust: 100%;
 
-  /* Locked to one screenful, with `body` below it, so the document has nothing
-     to scroll. The app is a screen and #root is that screen; see the note on
-     #root for what scrolls instead. */
-  height: 100%;
+  /* Overscroll on the root element is the viewport's overscroll, and the
+     viewport is what Telegram drags when the gesture reaches it. Declared here
+     as well as on `body` because whether the body's value propagates is a
+     question with different answers per engine, and the answer we need is
+     "the app does not move". */
+  overscroll-behavior-y: none;
 }
 
 body {
@@ -54,10 +56,14 @@ body {
   color: var(--ink);
   background-color: var(--bg);
 
-  height: 100%;
-  /* With `html` at `visible`, this is what the viewport takes its overflow
-     from: the document scrolls nowhere, and #root does all of it. */
+  /* With `html` at `visible`, this is where the viewport takes its overflow
+     from: the document scrolls nowhere, and #root does all of it. No height
+     to go with it — #root already has a definite one, and a second definition
+     of "one screenful" here is a second thing to keep in agreement. */
   overflow: hidden;
+
+  /* Vertical overscroll would drag the whole Mini App down and close it. */
+  overscroll-behavior-y: none;
 }
 
 /*
@@ -70,10 +76,16 @@ body {
  * that fits cannot scroll at all, and a screen that does not fit scrolls
  * inside the app box where a list is supposed to.
  *
- * 100dvh and not `--tg-viewport-stable-height`: the webview is sized by
- * Telegram to what is visible, so its own dynamic viewport is the same number
- * without the round trip, without the mount to wait for, and without the frame
- * where the signal reads zero. dvh and not vh, because in a plain mobile
+ * `--app-height` is Telegram's own number for what is visible, published by
+ * `bindAppHeight` in main.tsx. It has to be Telegram's: on iOS and Android the
+ * SDK will not trust `window.innerHeight` either — it asks the client and waits
+ * for `viewport_changed` — and 100dvh is precisely that untrusted number. Where
+ * the two disagree, a box sized to the webview puts content below the visible
+ * area with nothing left able to scroll to it, which is a worse bug than the
+ * one this file is fixing.
+ *
+ * 100dvh is the fallback, for the moment before the client answers and for
+ * every browser that is not Telegram. dvh and not vh, because in a plain mobile
  * browser vh counts the space behind the toolbar, and a page built to fill one
  * screen would then be exactly one toolbar too tall to fit.
  *
@@ -94,10 +106,11 @@ body {
 #root {
   display: flex;
   flex-direction: column;
-  height: 100dvh;
+  height: var(--app-height, 100dvh);
   overflow-y: auto;
   /* A list that reaches its end should stop there, not hand the gesture on to
-     Telegram, which reads it as "drag the app down". */
+     the viewport. `none` there is what actually stops Telegram; this only
+     keeps a long list from asking it to. */
   overscroll-behavior-y: contain;
   padding-top: var(--tg-viewport-safe-area-inset-top, 0px);
   padding-left: var(--tg-viewport-safe-area-inset-left, 0px);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -32,6 +32,11 @@
 html {
   /* Telegram clients may hand the page a text-size override. */
   -webkit-text-size-adjust: 100%;
+
+  /* Locked to one screenful, with `body` below it, so the document has nothing
+     to scroll. The app is a screen and #root is that screen; see the note on
+     #root for what scrolls instead. */
+  height: 100%;
 }
 
 body {
@@ -49,23 +54,33 @@ body {
   color: var(--ink);
   background-color: var(--bg);
 
-  /* Vertical overscroll would drag the whole Mini App down and close it. */
-  overscroll-behavior-y: none;
+  height: 100%;
+  /* With `html` at `visible`, this is what the viewport takes its overflow
+     from: the document scrolls nowhere, and #root does all of it. */
+  overflow: hidden;
 }
 
 /*
- * One screenful, and the device notch — but not the home indicator.
+ * The app itself: exactly one screenful, and the only thing that scrolls.
  *
- * stable-height, not height: the plain one follows the drag gesture and makes
- * anything pinned to the bottom jitter. Falls back to 100dvh until the SDK has
- * mounted the viewport — dvh and not vh, because in a plain mobile browser vh
- * counts the space behind the toolbar, and a page built to fill one screen
- * would then be exactly one toolbar too tall to fit.
+ * `height`, not `min-height`. A box that can grow past the viewport hands its
+ * overflow to the document, and the document's scroll is the one nobody asked
+ * for: a screen with a trailing spacer or a notch's worth of padding offered a
+ * few pixels of travel with nothing at the end of them. Bounded here, a screen
+ * that fits cannot scroll at all, and a screen that does not fit scrolls
+ * inside the app box where a list is supposed to.
  *
- * The height lives here rather than on `body` because `box-sizing: border-box`
- * then counts the insets *inside* the screenful instead of adding them to it.
- * With it on `body`, a page whose content came within a notch of a full screen
- * scrolled by exactly the height of the notch, with nothing down there to see.
+ * 100dvh and not `--tg-viewport-stable-height`: the webview is sized by
+ * Telegram to what is visible, so its own dynamic viewport is the same number
+ * without the round trip, without the mount to wait for, and without the frame
+ * where the signal reads zero. dvh and not vh, because in a plain mobile
+ * browser vh counts the space behind the toolbar, and a page built to fill one
+ * screen would then be exactly one toolbar too tall to fit.
+ *
+ * The insets live here rather than on `body` because `box-sizing: border-box`
+ * then counts them *inside* the screenful instead of adding them to it. With
+ * them on `body`, a page whose content came within a notch of a full screen
+ * scrolled by exactly the height of the notch.
  *
  * The bottom inset is deliberately absent: whatever sits at the bottom of a
  * screen owns it. For a screen with tabs that is the fixed tab bar, which has
@@ -73,13 +88,17 @@ body {
  * them it is `.screen`. Setting it here as well is what counted it twice.
  *
  * A flex column, because `min-height: 100%` on a child of an auto-height parent
- * resolves to `auto` and does nothing — which is why screens used to sit in the
+ * resolves to `auto` and does nothing — which is why screens once sat in the
  * top half of the viewport no matter what they declared.
  */
 #root {
   display: flex;
   flex-direction: column;
-  min-height: var(--tg-viewport-stable-height, 100dvh);
+  height: 100dvh;
+  overflow-y: auto;
+  /* A list that reaches its end should stop there, not hand the gesture on to
+     Telegram, which reads it as "drag the app down". */
+  overscroll-behavior-y: contain;
   padding-top: var(--tg-viewport-safe-area-inset-top, 0px);
   padding-left: var(--tg-viewport-safe-area-inset-left, 0px);
   padding-right: var(--tg-viewport-safe-area-inset-right, 0px);

--- a/apps/web/src/locales/cs/messages.po
+++ b/apps/web/src/locales/cs/messages.po
@@ -493,6 +493,10 @@ msgstr "Chybí"
 msgid "черновик — не видна в каталоге"
 msgstr "koncept — v katalogu není vidět"
 
+#: src/pages/NotFound.tsx
+msgid "Ссылка устарела или в ней опечатка."
+msgstr "Odkaz je starý nebo je v něm překlep."
+
 #: src/pages/Results.tsx
 msgid "Дешевле"
 msgstr "Levnější"
@@ -608,6 +612,10 @@ msgstr "{0, plural, one {Připravil na tuhle zkoušku # člověka} few {Připrav
 #: src/pages/MyHelper.tsx
 msgid "ČVUT FEL, 3 курс"
 msgstr "ČVUT FEL, 3. ročník"
+
+#: src/pages/NotFound.tsx
+msgid "Такой страницы нет"
+msgstr "Taková stránka neexistuje"
 
 #: src/components/Phrase.tsx
 msgid "С твоего факультета"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -493,6 +493,10 @@ msgstr "Missing"
 msgid "черновик — не видна в каталоге"
 msgstr "draft — not visible in the catalog"
 
+#: src/pages/NotFound.tsx
+msgid "Ссылка устарела или в ней опечатка."
+msgstr "The link is out of date, or has a typo in it."
+
 #: src/pages/Results.tsx
 msgid "Дешевле"
 msgstr "Cheaper"
@@ -608,6 +612,10 @@ msgstr "{0, plural, one {Prepared # person for this exam} other {Prepared # peop
 #: src/pages/MyHelper.tsx
 msgid "ČVUT FEL, 3 курс"
 msgstr "ČVUT FEL, third year"
+
+#: src/pages/NotFound.tsx
+msgid "Такой страницы нет"
+msgstr "There is no such page"
 
 #: src/components/Phrase.tsx
 msgid "С твоего факультета"

--- a/apps/web/src/locales/ru/messages.po
+++ b/apps/web/src/locales/ru/messages.po
@@ -493,6 +493,10 @@ msgstr "Не хватает"
 msgid "черновик — не видна в каталоге"
 msgstr "черновик — не видна в каталоге"
 
+#: src/pages/NotFound.tsx
+msgid "Ссылка устарела или в ней опечатка."
+msgstr "Ссылка устарела или в ней опечатка."
+
 #: src/pages/Results.tsx
 msgid "Дешевле"
 msgstr "Дешевле"
@@ -608,6 +612,10 @@ msgstr "{0, plural, one {Готовил к этому же экзамену # ч
 #: src/pages/MyHelper.tsx
 msgid "ČVUT FEL, 3 курс"
 msgstr "ČVUT FEL, 3 курс"
+
+#: src/pages/NotFound.tsx
+msgid "Такой страницы нет"
+msgstr "Такой страницы нет"
 
 #: src/components/Phrase.tsx
 msgid "С твоего факультета"

--- a/apps/web/src/locales/uk/messages.po
+++ b/apps/web/src/locales/uk/messages.po
@@ -493,6 +493,10 @@ msgstr "Не вистачає"
 msgid "черновик — не видна в каталоге"
 msgstr "чернетка — не видно в каталозі"
 
+#: src/pages/NotFound.tsx
+msgid "Ссылка устарела или в ней опечатка."
+msgstr "Посилання застаріле або в ньому одрук."
+
 #: src/pages/Results.tsx
 msgid "Дешевле"
 msgstr "Дешевше"
@@ -608,6 +612,10 @@ msgstr "{0, plural, one {Готував до цього ж іспиту # люд
 #: src/pages/MyHelper.tsx
 msgid "ČVUT FEL, 3 курс"
 msgstr "ČVUT FEL, 3 курс"
+
+#: src/pages/NotFound.tsx
+msgid "Такой страницы нет"
+msgstr "Такої сторінки немає"
 
 #: src/components/Phrase.tsx
 msgid "С твоего факультета"

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,6 +7,7 @@ import {
   isTMA,
   mainButton,
   miniApp,
+  swipeBehavior,
   themeParams,
   viewport,
 } from '@tma.js/sdk-react';
@@ -113,6 +114,15 @@ function initSdk(): void {
       .catch((error: unknown) => {
         console.error('[tma] viewport failed to mount', error);
       });
+  }
+
+  // Telegram reads a downward drag as "dismiss this app". On a screen with
+  // nothing to scroll that drag and a scroll are the same movement, so the app
+  // appeared to scroll where there was nothing to see. Off, then — Telegram's
+  // own close button is still there, and it is the unambiguous one.
+  // `ifAvailable` because this is Mini Apps 7.7; older clients keep the swipe.
+  if (swipeBehavior.mount.ifAvailable().ok) {
+    swipeBehavior.disableVertical.ifAvailable();
   }
 
   // Mounted here, driven from components via the hooks in @/hooks/useTelegram.

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -102,6 +102,20 @@ function initSdk(): void {
   themeParams.mount.ifAvailable();
   themeParams.bindCssVars.ifAvailable();
 
+  // A Mini App opens as a part-height sheet on a phone, and the gesture that
+  // grows it is the one disabled below. Ask for the whole screen rather than
+  // leaving someone in a half sheet with no way out of it. Before the mount
+  // and outside its promise, deliberately: `web_app_expand` needs neither, and
+  // a client that never answers the viewport request must not be able to take
+  // the swipe away without giving the height back.
+  viewport.expand.ifAvailable();
+
+  // Also outside the promise. Subscribing to a signal does not require the
+  // mount to have settled, and the subscriber fires when the client answers —
+  // so a request that never comes back costs a fallback height rather than a
+  // page with no height at all.
+  bindAppHeight();
+
   // Async: the viewport has to ask the client for its dimensions. Nothing
   // downstream waits on it, so the promise is deliberately not awaited — the
   // signals simply start out at zero and fill in.
@@ -110,11 +124,6 @@ function initSdk(): void {
     void Promise.resolve(mounted.data)
       .then(() => {
         viewport.bindCssVars.ifAvailable();
-        // A Mini App opens as a part-height sheet on a phone, and the gesture
-        // that grows it is the one disabled below. Ask for the whole screen
-        // rather than leaving someone in a half sheet with no way out of it.
-        viewport.expand.ifAvailable();
-        bindAppHeight();
       })
       .catch((error: unknown) => {
         console.error('[tma] viewport failed to mount', error);
@@ -157,6 +166,11 @@ function initSdk(): void {
  *
  * `stableHeight` and not `height`: the plain one follows the drag gesture and
  * would make everything pinned to the bottom jitter.
+ *
+ * Subscribed rather than read once, and subscribed without waiting for the
+ * mount: the signal exists before it, and this way a client that never answers
+ * `web_app_request_viewport` leaves the page on its `100dvh` fallback instead
+ * of on nothing at all.
  *
  * Zero is not an answer, and skipping it is the whole reason this is not left
  * to `bindCssVars`. The signal reads 0 until the client has reported a stable

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -110,6 +110,11 @@ function initSdk(): void {
     void Promise.resolve(mounted.data)
       .then(() => {
         viewport.bindCssVars.ifAvailable();
+        // A Mini App opens as a part-height sheet on a phone, and the gesture
+        // that grows it is the one disabled below. Ask for the whole screen
+        // rather than leaving someone in a half sheet with no way out of it.
+        viewport.expand.ifAvailable();
+        bindAppHeight();
       })
       .catch((error: unknown) => {
         console.error('[tma] viewport failed to mount', error);
@@ -138,6 +143,35 @@ function initSdk(): void {
   subscribeTheme(paintChrome);
 
   initData.restore();
+}
+
+/**
+ * Publish the height the app is allowed to occupy, as `--app-height`.
+ *
+ * Telegram's number rather than the webview's. On iOS and Android the SDK does
+ * not trust `window.innerHeight` either — it asks the client and waits for
+ * `viewport_changed` — so `100dvh`, which is that same untrusted number, can
+ * be taller than what the person can actually see. An app sized to the webview
+ * then puts its last rows below the visible edge with nothing able to scroll
+ * to them, and `index.css` has deliberately left the document unable to.
+ *
+ * `stableHeight` and not `height`: the plain one follows the drag gesture and
+ * would make everything pinned to the bottom jitter.
+ *
+ * Zero is not an answer, and skipping it is the whole reason this is not left
+ * to `bindCssVars`. The signal reads 0 until the client has reported a stable
+ * state, and a variable set to `0px` is *defined* — `var(--app-height, 100dvh)`
+ * would resolve to zero rather than fall back, and the app would be one frame
+ * of nothing.
+ */
+function bindAppHeight(): void {
+  const publish = (height: number): void => {
+    if (height > 0) {
+      document.documentElement.style.setProperty('--app-height', `${height}px`);
+    }
+  };
+  publish(viewport.stableHeight());
+  viewport.stableHeight.sub(publish);
 }
 
 /** Load the one catalog we need before the first paint, to avoid a flash. */

--- a/apps/web/src/pages/BecomeHelper.tsx
+++ b/apps/web/src/pages/BecomeHelper.tsx
@@ -214,8 +214,6 @@ export default function BecomeHelperPage() {
           </Hint>
         </div>
       )}
-
-      <div style={{ height: 24 }} />
     </Screen>
   );
 }

--- a/apps/web/src/pages/Helper.tsx
+++ b/apps/web/src/pages/Helper.tsx
@@ -244,8 +244,6 @@ export default function HelperPage() {
           </Hint>
         </div>
       ) : null}
-
-      <div style={{ height: 24 }} />
     </Screen>
   );
 }

--- a/apps/web/src/pages/Life.tsx
+++ b/apps/web/src/pages/Life.tsx
@@ -73,7 +73,6 @@ export default function LifePage() {
           </Trans>
         </Hint>
       </div>
-      <div style={{ height: 24 }} />
     </Screen>
   );
 }

--- a/apps/web/src/pages/Mine.tsx
+++ b/apps/web/src/pages/Mine.tsx
@@ -119,7 +119,6 @@ export default function MinePage() {
             ))}
           </Cards>
         )}
-        <div style={{ height: 20 }} />
       </Screen>
       <TabBar />
     </>

--- a/apps/web/src/pages/MyHelper.tsx
+++ b/apps/web/src/pages/MyHelper.tsx
@@ -296,7 +296,6 @@ export default function MyHelperPage() {
           ) : null}
         </>
       )}
-      <div style={{ height: 32 }} />
     </Screen>
   );
 }

--- a/apps/web/src/pages/NotFound.tsx
+++ b/apps/web/src/pages/NotFound.tsx
@@ -1,3 +1,29 @@
+import { Trans } from '@lingui/react/macro';
+
+import { AppHeader } from '@/components/AppHeader';
+import { Screen, Sub, Title } from '@/components/Ui';
+
+/**
+ * The catch-all.
+ *
+ * A `<Screen>` like every other page, and not a bare div: the header, the
+ * insets and the clearance at the foot are what every screen is entitled to,
+ * and a page shaped unlike all the others is a page that every tool walking
+ * them has to special-case — `scripts/check-scroll.mjs` measured this one as
+ * spotless because it could not find a screen in it at all.
+ */
 export default function NotFoundPage() {
-  return <div data-page="not-found">Not found</div>;
+  return (
+    <Screen>
+      <AppHeader />
+      <Title>
+        <Trans>Такой страницы нет</Trans>
+      </Title>
+      <div style={{ marginTop: 6 }}>
+        <Sub>
+          <Trans>Ссылка устарела или в ней опечатка.</Trans>
+        </Sub>
+      </div>
+    </Screen>
+  );
 }

--- a/apps/web/src/pages/Request.tsx
+++ b/apps/web/src/pages/Request.tsx
@@ -106,7 +106,6 @@ export default function RequestPage() {
           ))}
         </Cards>
       )}
-      <div style={{ height: 20 }} />
     </Screen>
   );
 }

--- a/apps/web/src/pages/Results.tsx
+++ b/apps/web/src/pages/Results.tsx
@@ -142,7 +142,6 @@ export default function ResultsPage() {
             </Cards>
           </>
         )}
-        <div style={{ height: 20 }} />
       </Screen>
       <TabBar />
     </>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,28 +138,49 @@ hides the bugs this rule exists to prevent.
 
 ## The web shell scrolls in exactly one place
 
-The Mini App is a screen, not a document. `#root` is the app: it is one
-screenful tall, it holds every pixel the app draws, and it is the only element
-that scrolls. `html` and `body` are locked to that screenful, so the document
-itself has nothing to scroll and cannot offer a few pixels of travel on a
-screen whose content fits.
+The Mini App is a screen, not a document. `#root` is the app: it is exactly one
+screenful tall and it is the only element that scrolls. `body` carries
+`overflow: hidden`, which the viewport takes its own overflow from, so the
+document has nothing to scroll and cannot invent travel of its own.
 
-Two consequences worth knowing before touching layout:
+**One screenful is Telegram's number, not the webview's.** `--app-height`,
+published by `bindAppHeight` in `main.tsx` from the viewport's stable height,
+with `100dvh` only as the fallback. On iOS and Android the SDK does not trust
+`window.innerHeight` either — it asks the client and waits for
+`viewport_changed` — and `100dvh` is that same untrusted number. Where they
+disagree, an app sized to the webview puts its last rows below the visible edge
+with nothing able to scroll to them. Zero is not an answer and is skipped: the
+signal reads `0` until the client replies, and a CSS variable set to `0px` is
+defined, so the fallback would not fire.
 
-- **A screen that fits must not overflow.** Padding, trailing spacers and
-  empty states all count toward the screenful; a page showing "nothing here"
-  that still scrolls is a layout bug, not a rounding error. `pnpm check:scroll`
-  in `apps/web` is that check — it adds up the travel on both boxes across the
-  screens that hold a screenful at most, and needs the dev server running.
-- **Anything pinned to an edge is `position: fixed`** — the tab bar, the
-  sheet, the scrim. A scroll container is not a containing block for fixed
-  elements, so they stay against the viewport rather than against the app box.
+Three rules follow, and they are what to check before changing layout:
 
-Telegram's own vertical swipe is disabled at startup (`swipeBehavior`,
-Mini Apps 7.7). The gesture drags the whole app down towards dismissal, and on
-a screen with nothing to scroll a drag and a scroll are the same movement, so
-the app appears to scroll where there is nothing to see. The app is dismissed
-with Telegram's close button instead.
+- **A scroll must end on content.** Not "a screen that fits must not scroll" —
+  for any layout there is a band of viewport heights where the content is a
+  few pixels too tall, so that rule only moves the failing size around. What
+  makes it a bug is emptiness at the end of the travel. The screen's own
+  `padding-bottom` is the only breathing room at the foot of a page; a spacer
+  under the last element is a stretch of nothing that someone has to scroll
+  through to reach.
+- **Anything pinned to an edge is `position: fixed`** — the tab bar, the sheet,
+  the scrim. They are descendants of `#root` but are laid out against the
+  viewport: a scroll container is not a containing block for fixed elements.
+  That is what lets the tab bar stay put while the screen behind it moves.
+- **Telegram's vertical swipe is off** (`swipeBehavior`, Mini Apps 7.7). The
+  gesture drags the whole app towards dismissal, and on a screen with nothing
+  to scroll a drag and a scroll are the same movement, so the app appears to
+  scroll where there is nothing to see. Because that same gesture is how a
+  part-height Mini App is grown, the app asks for the whole screen with
+  `viewport.expand()` at startup rather than leaving someone in a half sheet
+  with no way out of it. It is dismissed with Telegram's close button.
+
+`pnpm check:scroll` in `apps/web` is the first rule, executable: it scrolls
+each screen to its end at three phone sizes and measures how much emptiness is
+left under the lowest thing that paints. It needs the dev server **and** the
+API — an empty state and a failed request are different heights — and it checks
+both before measuring, because a blank page has nothing to scroll either.
+Nothing runs it automatically; it wants a browser and a database, which CI
+here does not give it.
 
 ## Where the code does not follow this yet
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,8 +148,9 @@ Two consequences worth knowing before touching layout:
 
 - **A screen that fits must not overflow.** Padding, trailing spacers and
   empty states all count toward the screenful; a page showing "nothing here"
-  that still scrolls is a layout bug, not a rounding error. The check is
-  `scrollHeight - clientHeight` on `#root` at a phone viewport.
+  that still scrolls is a layout bug, not a rounding error. `pnpm check:scroll`
+  in `apps/web` is that check — it adds up the travel on both boxes across the
+  screens that hold a screenful at most, and needs the dev server running.
 - **Anything pinned to an edge is `position: fixed`** — the tab bar, the
   sheet, the scrim. A scroll container is not a containing block for fixed
   elements, so they stay against the viewport rather than against the app box.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,12 +181,17 @@ which is also what keeps the number right on a phone with a home indicator. A
 container does not count as painting on behalf of its children, so a spacer
 nested inside a card list is as visible to it as one at the foot of the page.
 
-It needs the dev server, the API and signed init data, and it says so and stops
-rather than measuring error states — a blank page has nothing to scroll either,
-which is how a check like this quietly stops being one. Screens it could not
-reach are named in its output for the same reason. Nothing runs it
-automatically; it wants a browser and a database, which CI here does not give
-it.
+It needs the dev server, the API and signed init data, and it stops rather than
+measuring a home screen that came back without its categories, because that
+means the API is rejecting the init data and every screen behind it is an error
+state. A page it cannot recognise as a screen at all is a hard stop too, and a
+screen it could not reach is named in the summary: a check that reports an
+unmeasured screen as a clean one has stopped being a check.
+
+What it takes on trust is the screen's own `padding-bottom` — that is the
+number it subtracts, so a screen that reserves room for a tab bar it does not
+render will pass with a blank strip at its foot. Nothing runs it automatically;
+it wants a browser and a database, which CI here does not give it.
 
 ## Where the code does not follow this yet
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,6 +136,30 @@ Tests share one session per test, rolled back at the end, and the override in
 does. A test fixture that is more forgiving than production is a fixture that
 hides the bugs this rule exists to prevent.
 
+## The web shell scrolls in exactly one place
+
+The Mini App is a screen, not a document. `#root` is the app: it is one
+screenful tall, it holds every pixel the app draws, and it is the only element
+that scrolls. `html` and `body` are locked to that screenful, so the document
+itself has nothing to scroll and cannot offer a few pixels of travel on a
+screen whose content fits.
+
+Two consequences worth knowing before touching layout:
+
+- **A screen that fits must not overflow.** Padding, trailing spacers and
+  empty states all count toward the screenful; a page showing "nothing here"
+  that still scrolls is a layout bug, not a rounding error. The check is
+  `scrollHeight - clientHeight` on `#root` at a phone viewport.
+- **Anything pinned to an edge is `position: fixed`** — the tab bar, the
+  sheet, the scrim. A scroll container is not a containing block for fixed
+  elements, so they stay against the viewport rather than against the app box.
+
+Telegram's own vertical swipe is disabled at startup (`swipeBehavior`,
+Mini Apps 7.7). The gesture drags the whole app down towards dismissal, and on
+a screen with nothing to scroll a drag and a scroll are the same movement, so
+the app appears to scroll where there is nothing to see. The app is dismissed
+with Telegram's close button instead.
+
 ## Where the code does not follow this yet
 
 Written down because an agent greps this tree and builds against what it

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,13 +174,19 @@ Three rules follow, and they are what to check before changing layout:
   `viewport.expand()` at startup rather than leaving someone in a half sheet
   with no way out of it. It is dismissed with Telegram's close button.
 
-`pnpm check:scroll` in `apps/web` is the first rule, executable: it scrolls
-each screen to its end at three phone sizes and measures how much emptiness is
-left under the lowest thing that paints. It needs the dev server **and** the
-API — an empty state and a failed request are different heights — and it checks
-both before measuring, because a blank page has nothing to scroll either.
-Nothing runs it automatically; it wants a browser and a database, which CI
-here does not give it.
+`pnpm check:scroll` in `apps/web` is the first rule, executable. At three phone
+sizes it measures the gap between the lowest thing that paints and the bottom
+of the screen's content box — the screen's own `padding-bottom` is subtracted,
+which is also what keeps the number right on a phone with a home indicator. A
+container does not count as painting on behalf of its children, so a spacer
+nested inside a card list is as visible to it as one at the foot of the page.
+
+It needs the dev server, the API and signed init data, and it says so and stops
+rather than measuring error states — a blank page has nothing to scroll either,
+which is how a check like this quietly stops being one. Screens it could not
+reach are named in its output for the same reason. Nothing runs it
+automatically; it wants a browser and a database, which CI here does not give
+it.
 
 ## Where the code does not follow this yet
 


### PR DESCRIPTION
Some screens still scrolled downward on a phone with nothing below the fold. Several separate things caused it.

**The document could scroll.** `#root` declared `min-height`, so any screen whose padding or trailing spacer came to a few pixels more than a screenful handed that overflow to the document — travel with nothing at the end of it. It is `height` now, with `overflow-y` on the same box, and `overflow: hidden` on `body` is what the viewport takes its own overflow from: the document scrolls nowhere and `#root` does all of it.

**One screenful is Telegram's number, not the webview's.** `--app-height`, published from the viewport's stable height, with `100dvh` only as the fallback. `100dvh` is `window.innerHeight`, which the SDK itself refuses to trust on iOS and Android — it asks the client and waits for `viewport_changed`. Where the two disagree, an app sized to the webview puts its last rows below the visible edge with nothing able to scroll to them, which is worse than the bug being fixed. Zero is skipped: the signal reads zero until the client answers, and a variable set to `0px` is *defined*, so the fallback would not fire.

**Telegram's own vertical swipe drags the whole app towards dismissal.** On a screen with nothing to scroll, that gesture and a scroll are the same movement — which is the part `overscroll-behavior` cannot help with, because it is not a scroll. Off at startup via `swipeBehavior` (Mini Apps 7.7, guarded by `ifAvailable`). That same gesture is how a part-height Mini App is grown, so startup asks for the whole screen with `expand()` first — before the mount and outside its promise, because that request has no timeout and a client that never answers it must not be able to take the swipe away without giving the height back.

**Seven pages each ended in a spacer of their own** — 20px here, 32px there, 24px on three more — and every one was a stretch of nothing at the end of a scroll. One `padding-bottom` on `.screen` replaces all seven.

**The 404 was not a screen at all** — a bare div with an English string in a four-language app. It is a `<Screen>` like the other twelve now, which is also what let it be measured.

## The check

`pnpm check:scroll` in `apps/web`. The obvious rule — "a screen that fits must not scroll" — is the wrong one: for any layout there is a band of viewport heights where the content is a few pixels too tall, so a threshold on travel only moves the failing size around. At 360x664 both `/` and `/life` still scrolled 9–11px after the first commit here, and a check pinned to 390x664 called that green.

What makes it a bug is emptiness at the end. So the measurement is geometric: the gap between the lowest thing that *paints* and the bottom of the screen's content box, at three phone sizes. The screen's own `padding-bottom` is subtracted rather than compared against a literal, which keeps the number right on a phone with a home indicator.

| | `62b9098` | here |
| --- | --- | --- |
| `/life` | 24px of nothing | 0 |
| `/results` | 20px | 0 |
| `/my-helper` | 32px | 0 |
| helper detail | 24px | 0 |
| everything else | 0 | 0 |

Three review rounds went into the check being able to fail, and each one found a way it could not:

- It swallowed navigation errors and defaulted to `http` where `make web` serves `https`, so it passed six screens with the server switched off.
- It took anything with element children as content, so it found a spacer only where the spacer was a direct child of the screen. Nesting the same div one level in put the bug back, green.
- It measured `/request` and `/helper`, which are `request/:id` and `helper/:id` — both hit the catch-all, so two pages went unmeasured while appearing to pass. Detail screens are reached by tapping the first row of the list that leads there now.
- A page whose root was not a `<Screen>` had nothing to measure against, and that was reported as clean rather than as unmeasurable.

So it refuses to run rather than report all-clear: `/healthz` must answer, the home screen must come back with its categories (otherwise the API is rejecting the init data and every screen behind it is an error state), every page must be recognisable as a screen, and one it could not reach is named in the summary. What it still takes on trust is the screen's declared `padding-bottom`.

Not in CI: it wants a browser and a database, which the workflows here do not give it.

The landing page keeps its escape hatch — at 320x300 it scrolls to its button rather than hiding it above the top edge.

Docs updated first: docs/architecture.md