### PR TITLE
One place that turns a taxonomy row into a name

### DIFF
--- a/apps/api/src/konnekt/api/v1/cabinet.py
+++ b/apps/api/src/konnekt/api/v1/cabinet.py
@@ -6,7 +6,6 @@ who owns them.
 
 from fastapi import APIRouter
 from sqlalchemy import select
-from sqlalchemy.orm import selectinload
 
 from konnekt.api.deps import LangDep, SessionDep, UserDep
 from konnekt.api.v1.me import read_me
@@ -32,7 +31,7 @@ from konnekt.schemas import (
     Price,
 )
 from konnekt.services import helpers, parser
-from konnekt.services.catalog import _localised
+from konnekt.services.naming import names_by_id
 
 router = APIRouter()
 
@@ -116,13 +115,13 @@ async def my_helper(session: SessionDep, lang: LangDep, user: UserDep) -> MyHelp
     ).all()
 
     # Names for every axis in one round trip each, rather than per offer.
-    service_names = await _names_by_id(
+    service_names = await names_by_id(
         session, ServiceType, [o.service_type_id for o in offers], lang
     )
-    subject_names = await _names_by_id(
+    subject_names = await names_by_id(
         session, Subject, [o.subject_id for o in offers], lang
     )
-    institution_names = await _names_by_id(
+    institution_names = await names_by_id(
         session, Institution, [o.institution_id for o in offers], lang
     )
     service_codes = {
@@ -162,19 +161,6 @@ async def my_helper(session: SessionDep, lang: LangDep, user: UserDep) -> MyHelp
             for offer in offers
         ],
     )
-
-
-async def _names_by_id(session, model, ids, lang) -> dict[int, str]:
-    """Translated names for a set of taxonomy rows, keyed by id."""
-    wanted = {value for value in ids if value is not None}
-    if not wanted:
-        return {}
-    rows = (
-        await session.scalars(
-            select(model).where(model.id.in_(wanted)).options(selectinload(model.names))
-        )
-    ).all()
-    return {row.id: _localised(row.names, lang) or "" for row in rows}
 
 
 @router.put("/helper", response_model=MeOut, tags=["helper"])

--- a/apps/api/src/konnekt/api/v1/requests.py
+++ b/apps/api/src/konnekt/api/v1/requests.py
@@ -6,7 +6,6 @@ accepted, closed — and every step of it notifies somebody.
 
 from fastapi import APIRouter, BackgroundTasks, Query, Request, status
 from sqlalchemy import func, select
-from sqlalchemy.orm import selectinload
 
 from konnekt.api.deps import LangDep, SessionDep, UserDep
 from konnekt.bot.texts import (
@@ -40,7 +39,8 @@ from konnekt.schemas import (
 )
 from konnekt.services import notify
 from konnekt.services import requests as requests_service
-from konnekt.services.catalog import _localised, avatar_for
+from konnekt.services.catalog import avatar_for
+from konnekt.services.naming import rows_by_id, short_form, translated
 from konnekt.services.notify import quote
 
 router = APIRouter()
@@ -395,24 +395,12 @@ async def _requests_out(session, requests: list[HelpRequest], lang) -> list[Requ
     if not requests:
         return []
 
-    async def names_by_id(model, ids: set[int]) -> dict:
-        if not ids:
-            return {}
-        rows = (
-            await session.scalars(
-                select(model).where(model.id.in_(ids)).options(selectinload(model.names))
-            )
-        ).all()
-        return {row.id: row for row in rows}
-
-    subjects = await names_by_id(
-        Subject, {r.subject_id for r in requests if r.subject_id}
+    subjects = await rows_by_id(session, Subject, (r.subject_id for r in requests))
+    institutions = await rows_by_id(
+        session, Institution, (r.institution_id for r in requests)
     )
-    institutions = await names_by_id(
-        Institution, {r.institution_id for r in requests if r.institution_id}
-    )
-    services = await names_by_id(
-        ServiceType, {r.service_type_id for r in requests if r.service_type_id}
+    services = await rows_by_id(
+        session, ServiceType, (r.service_type_id for r in requests)
     )
 
     request_ids = [r.id for r in requests]
@@ -448,14 +436,9 @@ async def _requests_out(session, requests: list[HelpRequest], lang) -> list[Requ
             RequestOut(
                 id=request.id,
                 text=request.raw_text,
-                subject=_localised(subject.names, lang) if subject else None,
-                institution=(
-                    _localised(institution.names, lang, "short_name")
-                    or _localised(institution.names, lang)
-                    if institution
-                    else None
-                ),
-                service_type=_localised(service.names, lang) if service else None,
+                subject=translated(subject, lang) if subject else None,
+                institution=(short_form(institution, lang) if institution else None),
+                service_type=translated(service, lang) if service else None,
                 deadline_on=request.deadline_on,
                 status=request.status.value,
                 responses_count=counts.get(request.id, 0),

--- a/apps/api/src/konnekt/api/v1/search.py
+++ b/apps/api/src/konnekt/api/v1/search.py
@@ -29,7 +29,7 @@ from konnekt.schemas import (
     SearchOut,
 )
 from konnekt.services import catalog, parser
-from konnekt.services.catalog import _localised
+from konnekt.services.naming import short_form, translated
 from konnekt.services.people import log_event
 
 router = APIRouter()
@@ -78,7 +78,7 @@ async def parse_query(
             chips.append(
                 Chip(
                     kind="service_type",
-                    label=_localised(service.names, lang) or service.code,
+                    label=translated(service, lang) or service.code,
                     value=service.id,
                 )
             )
@@ -228,7 +228,7 @@ async def _filter_chips(
             chips.append(
                 Chip(
                     kind="subject",
-                    label=_localised(row.names, lang) or row.slug,
+                    label=translated(row, lang) or row.slug,
                     value=row.id,
                 )
             )
@@ -242,9 +242,7 @@ async def _filter_chips(
             chips.append(
                 Chip(
                     kind="institution",
-                    label=_localised(row.names, lang, "short_name")
-                    or _localised(row.names, lang)
-                    or row.code,
+                    label=short_form(row, lang) or row.code,
                     value=row.id,
                 )
             )
@@ -258,7 +256,7 @@ async def _filter_chips(
             chips.append(
                 Chip(
                     kind="service_type",
-                    label=_localised(row.names, lang) or row.code,
+                    label=translated(row, lang) or row.code,
                     value=row.id,
                 )
             )

--- a/apps/api/src/konnekt/api/v1/taxonomy.py
+++ b/apps/api/src/konnekt/api/v1/taxonomy.py
@@ -26,7 +26,7 @@ from konnekt.schemas import (
     ServiceTypeOut,
     SubjectOut,
 )
-from konnekt.services.catalog import _localised
+from konnekt.services.naming import translated
 
 router = APIRouter()
 
@@ -49,8 +49,8 @@ async def service_types(
         ServiceTypeOut(
             id=r.id,
             code=r.code,
-            name=_localised(r.names, lang) or r.code,
-            hint=_localised(r.names, lang, "hint"),
+            name=translated(r, lang) or r.code,
+            hint=translated(r, lang, "hint"),
             requires_subject=r.requires_subject,
             requires_institution=r.requires_institution,
         )
@@ -126,7 +126,7 @@ async def subjects(
         SubjectOut(
             id=r.id,
             slug=r.slug,
-            name=_localised(r.names, lang) or r.slug,
+            name=translated(r, lang) or r.slug,
             parent_id=r.parent_id,
             has_children=child_counts.get(r.id, 0) > 0,
             external_code=r.external_code,
@@ -186,8 +186,8 @@ def institution_out(row: Institution, lang, children=()) -> InstitutionOut:
     return InstitutionOut(
         id=row.id,
         code=row.code,
-        name=_localised(row.names, lang) or row.code,
-        short_name=_localised(row.names, lang, "short_name"),
+        name=translated(row, lang) or row.code,
+        short_name=translated(row, lang, "short_name"),
         city=row.city,
         parent_id=row.parent_id,
         faculties=[institution_out(child, lang) for child in children],
@@ -206,6 +206,4 @@ async def languages(
             .options(selectinload(Language.names))
         )
     ).all()
-    return [
-        LanguageOut(code=r.code, name=_localised(r.names, lang) or r.code) for r in rows
-    ]
+    return [LanguageOut(code=r.code, name=translated(r, lang) or r.code) for r in rows]

--- a/apps/api/src/konnekt/services/catalog.py
+++ b/apps/api/src/konnekt/services/catalog.py
@@ -28,6 +28,7 @@ from konnekt.schemas import (
     Price,
     Stat,
 )
+from konnekt.services.naming import rows_by_id, short_form, translated
 
 SortKey = Literal["relevance", "price", "available"]
 
@@ -46,23 +47,6 @@ def avatar_for(user: User) -> Avatar:
         tone=user.tg_id % TONE_COUNT,
         photo_url=user.photo_url,
     )
-
-
-def _localised(rows, lang: UiLang, attr: str = "name") -> str | None:
-    """Pick a translation, falling back to any that exists.
-
-    A missing Ukrainian name should show the Czech one, not an empty row.
-    """
-    for row in rows:
-        if row.lang == lang:
-            value = getattr(row, attr, None)
-            if value:
-                return value
-    for row in rows:
-        value = getattr(row, attr, None)
-        if value:
-            return value
-    return None
 
 
 async def home_sections(
@@ -107,8 +91,8 @@ async def home_sections(
         HomeSection(
             kind="service_type",
             code=st.code,
-            name=_localised(st.names, lang) or st.code,
-            hint=_localised(st.names, lang, "hint"),
+            name=translated(st, lang) or st.code,
+            hint=translated(st, lang, "hint"),
             tone=index % TONE_COUNT,
             count=counts.get(st.id, 0),
             avatars=avatars.get(st.id, []),
@@ -529,40 +513,13 @@ async def _offers_out(
     if not helper.offers:
         return []
 
-    subject_ids = {o.subject_id for o in helper.offers if o.subject_id}
-    institution_ids = {o.institution_id for o in helper.offers if o.institution_id}
-    service_ids = {o.service_type_id for o in helper.offers}
-
-    subjects = {
-        s.id: s
-        for s in (
-            await session.scalars(
-                select(Subject)
-                .where(Subject.id.in_(subject_ids or {0}))
-                .options(selectinload(Subject.names))
-            )
-        ).all()
-    }
-    institutions = {
-        i.id: i
-        for i in (
-            await session.scalars(
-                select(Institution)
-                .where(Institution.id.in_(institution_ids or {0}))
-                .options(selectinload(Institution.names))
-            )
-        ).all()
-    }
-    services = {
-        s.id: s
-        for s in (
-            await session.scalars(
-                select(ServiceType)
-                .where(ServiceType.id.in_(service_ids or {0}))
-                .options(selectinload(ServiceType.names))
-            )
-        ).all()
-    }
+    subjects = await rows_by_id(session, Subject, (o.subject_id for o in helper.offers))
+    institutions = await rows_by_id(
+        session, Institution, (o.institution_id for o in helper.offers)
+    )
+    services = await rows_by_id(
+        session, ServiceType, (o.service_type_id for o in helper.offers)
+    )
 
     out: list[OfferOut] = []
     for offer in helper.offers:
@@ -577,15 +534,9 @@ async def _offers_out(
             OfferOut(
                 id=offer.id,
                 service_type=service.code if service else "",
-                service_type_name=(_localised(service.names, lang) if service else "")
-                or "",
-                subject=_localised(subject.names, lang) if subject else None,
-                institution=(
-                    _localised(institution.names, lang, "short_name")
-                    or _localised(institution.names, lang)
-                    if institution
-                    else None
-                ),
+                service_type_name=(translated(service, lang) if service else "") or "",
+                subject=translated(subject, lang) if subject else None,
+                institution=(short_form(institution, lang) if institution else None),
                 price=Price(
                     amount=(
                         float(offer.price_amount)

--- a/apps/api/src/konnekt/services/naming.py
+++ b/apps/api/src/konnekt/services/naming.py
@@ -3,7 +3,10 @@
 Every reference table — service types, subjects, institutions, languages —
 keeps its names in a side table with one row per language. Two questions come
 up on nearly every screen: what does this row read as, and what do these twenty
-ids read as. Both live here.
+ids read as. Both live here, with one asymmetry worth knowing before reaching
+for the second: `translated` and `short_form` work on any of the four, because
+all they read is `names`, while `rows_by_id` and `names_by_id` ask for an `id`
+and so cannot serve `Language`, which is keyed by its code.
 
 They live here because the alternative was `catalog._localised`, a private
 symbol imported by name across the package boundary at sixteen call sites,
@@ -73,6 +76,13 @@ async def rows_by_id(session: AsyncSession, model: Any, ids: Any) -> dict[int, A
     One query for a whole page rather than one per row. `None` is a legal id
     here — an offer without a subject, a request without an institution — and
     is dropped rather than asked about.
+
+    `Subject`, `Institution` and `ServiceType` only: this asks for `model.id`,
+    and `Language` is keyed by its code. `translated` and `short_form` above do
+    serve all four — they only read `names` — so the split is real and this is
+    the half of the module that does not cover it. `model` is untyped because a
+    declarative class is not a `type[Named]` to a checker; the cost is that
+    handing this the wrong table fails at runtime rather than at the call site.
     """
     wanted = {value for value in ids if value is not None}
     if not wanted:

--- a/apps/api/src/konnekt/services/naming.py
+++ b/apps/api/src/konnekt/services/naming.py
@@ -1,0 +1,95 @@
+"""Turning a reference row into the name a person reads.
+
+Every reference table — service types, subjects, institutions, languages —
+keeps its names in a side table with one row per language. Two questions come
+up on nearly every screen: what does this row read as, and what do these twenty
+ids read as. Both live here.
+
+They live here because the alternative was `catalog._localised`, a private
+symbol imported by name across the package boundary at sixteen call sites,
+with three more hand-rolled "fetch the names for these ids" helpers alongside
+it. A rule that four modules need is a rule, not a private helper of whichever
+module happened to write it first.
+
+Nothing here takes a `UiLang` on faith: a row with no translation in the asked
+language falls back to any translation it has, because a missing Ukrainian name
+should show the Czech one rather than an empty row.
+"""
+
+from typing import Any, Protocol
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from konnekt.db.models.enums import UiLang
+
+
+class Named(Protocol):
+    """A reference row with a `names` collection loaded.
+
+    Structural rather than a base class: the four tables share the shape but
+    not an ancestor, and this module only ever reads. `names` is the whole
+    requirement — `Language` is keyed by its code and has no `id` at all, so
+    asking for one here would exclude a table that translates exactly like the
+    others.
+    """
+
+    names: Any
+
+
+def translated(row: Named, lang: UiLang, attr: str = "name") -> str | None:
+    """Pick a translation of one attribute, falling back to any that exists.
+
+    `attr` because the i18n row carries more than the name — a hint under a
+    service type, an institution's short form — and each of them wants the same
+    fallback.
+    """
+    for candidate in row.names:
+        if candidate.lang == lang:
+            value = getattr(candidate, attr, None)
+            if value:
+                return value
+    for candidate in row.names:
+        value = getattr(candidate, attr, None)
+        if value:
+            return value
+    return None
+
+
+def short_form(row: Named, lang: UiLang) -> str | None:
+    """What an institution is called where there is no room for its full name.
+
+    "ČVUT" fits in a chip and on a card; "České vysoké učení technické v Praze"
+    does not, and truncating it loses the only part anybody recognises. Falls
+    back to the full name for the institutions that have no short one.
+    """
+    return translated(row, lang, "short_name") or translated(row, lang)
+
+
+async def rows_by_id(session: AsyncSession, model: Any, ids: Any) -> dict[int, Any]:
+    """The rows for a set of ids, names loaded, keyed by id.
+
+    One query for a whole page rather than one per row. `None` is a legal id
+    here — an offer without a subject, a request without an institution — and
+    is dropped rather than asked about.
+    """
+    wanted = {value for value in ids if value is not None}
+    if not wanted:
+        return {}
+    rows = await session.scalars(
+        select(model).where(model.id.in_(wanted)).options(selectinload(model.names))
+    )
+    return {row.id: row for row in rows}
+
+
+async def names_by_id(
+    session: AsyncSession, model: Any, ids: Any, lang: UiLang
+) -> dict[int, str]:
+    """The same, already rendered to names.
+
+    Empty string rather than `None` for a row with no translation at all, so a
+    caller filling a field that must be a string does not have to say so again.
+    """
+    rows = await rows_by_id(session, model, ids)
+    return {row_id: translated(row, lang) or "" for row_id, row in rows.items()}

--- a/apps/api/src/konnekt/services/naming.py
+++ b/apps/api/src/konnekt/services/naming.py
@@ -1,18 +1,18 @@
 """Turning a reference row into the name a person reads.
 
-Every reference table — service types, subjects, institutions, languages —
-keeps its names in a side table with one row per language. Two questions come
-up on nearly every screen: what does this row read as, and what do these twenty
-ids read as. Both live here, with one asymmetry worth knowing before reaching
-for the second: `translated` and `short_form` work on any of the four, because
-all they read is `names`, while `rows_by_id` and `names_by_id` ask for an `id`
-and so cannot serve `Language`, which is keyed by its code.
+Every reference table — service types, subjects, institutions, languages, item
+categories — keeps its names in a side table with one row per language. Two
+questions come up on nearly every screen: what does this row read as, and what
+do these twenty ids read as. Both live here, with one asymmetry worth knowing
+before reaching for the second: `translated` and `short_form` work on any of
+them, because all they read is `names`, while `rows_by_id` and `names_by_id`
+ask for an `id` and so cannot serve `Language`, which is keyed by its code.
 
 They live here because the alternative was `catalog._localised`, a private
 symbol imported by name across the package boundary at sixteen call sites,
 with three more hand-rolled "fetch the names for these ids" helpers alongside
-it. A rule that four modules need is a rule, not a private helper of whichever
-module happened to write it first.
+it. Five modules read names off the taxonomy now, and a rule five modules need
+is a rule, not a private helper of whichever module happened to write it first.
 
 Nothing here takes a `UiLang` on faith: a row with no translation in the asked
 language falls back to any translation it has, because a missing Ukrainian name
@@ -31,8 +31,8 @@ from konnekt.db.models.enums import UiLang
 class Named(Protocol):
     """A reference row with a `names` collection loaded.
 
-    Structural rather than a base class: the four tables share the shape but
-    not an ancestor, and this module only ever reads. `names` is the whole
+    Structural rather than a base class: the reference tables share the shape
+    but not an ancestor, and this module only ever reads. `names` is the whole
     requirement — `Language` is keyed by its code and has no `id` at all, so
     asking for one here would exclude a table that translates exactly like the
     others.
@@ -77,12 +77,13 @@ async def rows_by_id(session: AsyncSession, model: Any, ids: Any) -> dict[int, A
     here — an offer without a subject, a request without an institution — and
     is dropped rather than asked about.
 
-    `Subject`, `Institution` and `ServiceType` only: this asks for `model.id`,
-    and `Language` is keyed by its code. `translated` and `short_form` above do
-    serve all four — they only read `names` — so the split is real and this is
-    the half of the module that does not cover it. `model` is untyped because a
-    declarative class is not a `type[Named]` to a checker; the cost is that
-    handing this the wrong table fails at runtime rather than at the call site.
+    The id-keyed tables only — this asks for `model.id`, and `Language` is
+    keyed by its code. `translated` and `short_form` above serve every
+    reference table, because they only read `names`, so the split is real and
+    this is the half of the module that does not cover all of them. `model` is
+    untyped because a declarative class is not a `type[Named]` to a checker;
+    the cost is that handing this the wrong table fails at runtime rather than
+    at the call site.
     """
     wanted = {value for value in ids if value is not None}
     if not wanted:
@@ -96,7 +97,7 @@ async def rows_by_id(session: AsyncSession, model: Any, ids: Any) -> dict[int, A
 async def names_by_id(
     session: AsyncSession, model: Any, ids: Any, lang: UiLang
 ) -> dict[int, str]:
-    """The same, already rendered to names.
+    """The same, already rendered to names — and the same tables.
 
     Empty string rather than `None` for a row with no translation at all, so a
     caller filling a field that must be a string does not have to say so again.

--- a/apps/api/tests/test_naming.py
+++ b/apps/api/tests/test_naming.py
@@ -1,0 +1,121 @@
+"""The rule that turns a reference row into a name.
+
+Four modules read names off the taxonomy and every one of them used to reach
+into `catalog` for a private helper to do it. Now that the rule has a home it
+gets a test of its own — the fallbacks in it are the difference between a
+Ukrainian speaker seeing the Czech name of their faculty and seeing a blank
+row, and nothing above this level would notice which.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from konnekt.db.models import Institution, InstitutionI18n, Subject, SubjectI18n
+from konnekt.db.models.enums import UiLang
+from konnekt.services.naming import names_by_id, rows_by_id, short_form, translated
+
+pytestmark = pytest.mark.asyncio
+
+
+def subject_named(**by_lang: str) -> Subject:
+    # `path` is the materialised tree path and is not nullable; the seeder
+    # fills it after the flush that assigns an id. Nothing here reads it.
+    row = Subject(slug="x", kind="leaf", path="")
+    row.names = [
+        SubjectI18n(lang=UiLang(lang), name=name) for lang, name in by_lang.items()
+    ]
+    return row
+
+
+def institution_named(name: str, short: str | None) -> Institution:
+    row = Institution(code="x")
+    row.names = [InstitutionI18n(lang=UiLang.CS, name=name, short_name=short)]
+    return row
+
+
+async def test_the_asked_language_wins() -> None:
+    row = subject_named(cs="Matematická analýza", ru="Матанализ")
+
+    assert translated(row, UiLang.RU) == "Матанализ"
+
+
+async def test_a_missing_translation_falls_back_to_any_other() -> None:
+    """Not to nothing. A Czech name is a worse answer than a Ukrainian one and
+    a far better answer than an empty row."""
+    row = subject_named(cs="Matematická analýza")
+
+    assert translated(row, UiLang.UK) == "Matematická analýza"
+
+
+async def test_a_row_with_no_names_at_all_says_so() -> None:
+    assert translated(subject_named(), UiLang.CS) is None
+
+
+async def test_an_empty_string_is_not_a_translation() -> None:
+    """The fallback has to keep looking past it, or a blank row in the asked
+    language hides a real name in another one."""
+    row = subject_named(uk="", cs="Matematická analýza")
+
+    assert translated(row, UiLang.UK) == "Matematická analýza"
+
+
+async def test_another_attribute_follows_the_same_rule() -> None:
+    row = institution_named("České vysoké učení technické", "ČVUT")
+
+    assert translated(row, UiLang.RU, "short_name") == "ČVUT"
+
+
+async def test_the_short_form_is_the_short_name_when_there_is_one() -> None:
+    row = institution_named("České vysoké učení technické", "ČVUT")
+
+    assert short_form(row, UiLang.CS) == "ČVUT"
+
+
+async def test_the_short_form_falls_back_to_the_full_name() -> None:
+    """A chip with nothing in it is worse than a chip that is too long."""
+    row = institution_named("Slezská univerzita v Opavě", None)
+
+    assert short_form(row, UiLang.CS) == "Slezská univerzita v Opavě"
+
+
+async def test_rows_by_id_ignores_the_ids_that_are_none(session: AsyncSession) -> None:
+    """An offer without a subject is ordinary, not an error, and asking the
+    database about `None` is a query nobody meant to write."""
+    subject = subject_named(cs="Fyzika")
+    session.add(subject)
+    await session.flush()
+
+    found = await rows_by_id(session, Subject, [subject.id, None, None])
+
+    assert list(found) == [subject.id]
+
+
+async def test_rows_by_id_asks_nothing_when_there_is_nothing_to_ask(
+    session: AsyncSession,
+) -> None:
+    assert await rows_by_id(session, Subject, [None]) == {}
+
+
+async def test_names_by_id_renders_what_rows_by_id_finds(
+    session: AsyncSession,
+) -> None:
+    subject = subject_named(cs="Fyzika", ru="Физика")
+    session.add(subject)
+    await session.flush()
+
+    assert await names_by_id(session, Subject, [subject.id], UiLang.RU) == {
+        subject.id: "Физика"
+    }
+
+
+async def test_names_by_id_answers_with_a_string_for_an_untranslated_row(
+    session: AsyncSession,
+) -> None:
+    """Its callers put the value straight into a field that cannot be null."""
+    subject = subject_named()
+    session.add(subject)
+    await session.flush()
+
+    assert await names_by_id(session, Subject, [subject.id], UiLang.CS) == {
+        subject.id: ""
+    }

--- a/apps/api/tests/test_naming.py
+++ b/apps/api/tests/test_naming.py
@@ -7,7 +7,11 @@ Ukrainian speaker seeing the Czech name of their faculty and seeing a blank
 row, and nothing above this level would notice which.
 """
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+
 import pytest
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from konnekt.db.models import Institution, InstitutionI18n, Subject, SubjectI18n
@@ -15,6 +19,32 @@ from konnekt.db.models.enums import UiLang
 from konnekt.services.naming import names_by_id, rows_by_id, short_form, translated
 
 pytestmark = pytest.mark.asyncio
+
+
+@contextmanager
+def statements(session: AsyncSession) -> Iterator[list[str]]:
+    """Every statement the session sends while the block runs.
+
+    Two of `rows_by_id`'s promises are about the query it does *not* send —
+    that `None` is dropped rather than asked about, and that an empty set of
+    ids costs nothing. Both are invisible in the return value: `IN (NULL)`
+    still matches the real ids, and a predicate that is always false still
+    answers `{}`. A test that only reads the result passes with either
+    promise deleted, which is what happened to the first two written here.
+    """
+    sent: list[str] = []
+    # The session is bound to a connection, not to the engine — see the
+    # `session` fixture, which nests every test in a transaction it rolls back.
+    engine = session.get_bind().engine
+
+    def record(conn, cursor, statement, parameters, context, executemany) -> None:
+        sent.append(statement)
+
+    event.listen(engine, "before_cursor_execute", record)
+    try:
+        yield sent
+    finally:
+        event.remove(engine, "before_cursor_execute", record)
 
 
 def subject_named(**by_lang: str) -> Subject:
@@ -78,22 +108,37 @@ async def test_the_short_form_falls_back_to_the_full_name() -> None:
     assert short_form(row, UiLang.CS) == "Slezská univerzita v Opavě"
 
 
-async def test_rows_by_id_ignores_the_ids_that_are_none(session: AsyncSession) -> None:
-    """An offer without a subject is ordinary, not an error, and asking the
-    database about `None` is a query nobody meant to write."""
+async def test_rows_by_id_never_asks_about_none(session: AsyncSession) -> None:
+    """An offer without a subject is ordinary, not an error.
+
+    Asserted on the statement rather than the answer: `id IN (1, NULL)` returns
+    the same row as `id IN (1)`, so a version that passed the `None` straight
+    through would look correct here and send a parameter that means nothing.
+    """
     subject = subject_named(cs="Fyzika")
     session.add(subject)
     await session.flush()
 
-    found = await rows_by_id(session, Subject, [subject.id, None, None])
+    with statements(session) as sent:
+        found = await rows_by_id(session, Subject, [subject.id, None, None])
 
     assert list(found) == [subject.id]
+    # One bind parameter in the lookup, not three. `$` appears in a statement
+    # only where a parameter does. The number of statements is deliberately
+    # not asserted — the names come back in a second one because the
+    # relationship loads `selectin`, and that is not this function's promise.
+    assert sent[0].count("$") == 1
 
 
 async def test_rows_by_id_asks_nothing_when_there_is_nothing_to_ask(
     session: AsyncSession,
 ) -> None:
-    assert await rows_by_id(session, Subject, [None]) == {}
+    """Also on the statement: `IN ()` compiles to a predicate that is always
+    false and answers `{}` too, so the empty answer proves nothing."""
+    with statements(session) as sent:
+        assert await rows_by_id(session, Subject, [None]) == {}
+
+    assert sent == []
 
 
 async def test_names_by_id_renders_what_rows_by_id_finds(

--- a/apps/api/tests/test_naming.py
+++ b/apps/api/tests/test_naming.py
@@ -1,14 +1,15 @@
 """The rule that turns a reference row into a name.
 
-Four modules read names off the taxonomy and every one of them used to reach
-into `catalog` for a private helper to do it. Now that the rule has a home it
-gets a test of its own — the fallbacks in it are the difference between a
-Ukrainian speaker seeing the Czech name of their faculty and seeing a blank
-row, and nothing above this level would notice which.
+Five modules read names off the taxonomy, and four of them used to reach across
+the package boundary into `catalog` for a private helper to do it. Now that the
+rule has a home it gets a test of its own — the fallbacks in it are the
+difference between a Ukrainian speaker seeing the Czech name of their faculty
+and seeing a blank row, and nothing above this level would notice which.
 """
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Any
 
 import pytest
 from sqlalchemy import event
@@ -22,8 +23,8 @@ pytestmark = pytest.mark.asyncio
 
 
 @contextmanager
-def statements(session: AsyncSession) -> Iterator[list[str]]:
-    """Every statement the session sends while the block runs.
+def statements(session: AsyncSession) -> Iterator[list[tuple[str, Any]]]:
+    """Every statement the session sends while the block runs, with its values.
 
     Two of `rows_by_id`'s promises are about the query it does *not* send —
     that `None` is dropped rather than asked about, and that an empty set of
@@ -31,20 +32,36 @@ def statements(session: AsyncSession) -> Iterator[list[str]]:
     still matches the real ids, and a predicate that is always false still
     answers `{}`. A test that only reads the result passes with either
     promise deleted, which is what happened to the first two written here.
+
+    The values come along because the alternative was counting `$` in the SQL,
+    which asks the test to know the driver's paramstyle — true of asyncpg,
+    false of psycopg, and a failure that would say nothing about the rule.
     """
-    sent: list[str] = []
+    sent: list[tuple[str, Any]] = []
     # The session is bound to a connection, not to the engine — see the
     # `session` fixture, which nests every test in a transaction it rolls back.
+    # Listening on the engine still catches it: a connection joins the engine's
+    # dispatch when it is created, and every execute re-reads the engine's flag.
     engine = session.get_bind().engine
 
     def record(conn, cursor, statement, parameters, context, executemany) -> None:
-        sent.append(statement)
+        sent.append((statement, parameters))
 
     event.listen(engine, "before_cursor_execute", record)
     try:
         yield sent
     finally:
         event.remove(engine, "before_cursor_execute", record)
+
+
+def values_of(sent: list[tuple[str, Any]], table: str) -> list[Any]:
+    """The parameters of every statement that touched a table.
+
+    By what the statement says rather than by its position in the list: a
+    savepoint or an autoflush ahead of the one under test would otherwise shift
+    the index, and the failure would name the wrong thing.
+    """
+    return [parameters for statement, parameters in sent if f"FROM {table}" in statement]
 
 
 def subject_named(**by_lang: str) -> Subject:
@@ -123,11 +140,10 @@ async def test_rows_by_id_never_asks_about_none(session: AsyncSession) -> None:
         found = await rows_by_id(session, Subject, [subject.id, None, None])
 
     assert list(found) == [subject.id]
-    # One bind parameter in the lookup, not three. `$` appears in a statement
-    # only where a parameter does. The number of statements is deliberately
-    # not asserted — the names come back in a second one because the
-    # relationship loads `selectin`, and that is not this function's promise.
-    assert sent[0].count("$") == 1
+    # One value asked about, not three. Only the lookup is examined — the names
+    # arrive in a second statement because the relationship loads `selectin`,
+    # and how many queries that costs is not this function's promise.
+    assert values_of(sent, "subjects") == [(subject.id,)]
 
 
 async def test_rows_by_id_asks_nothing_when_there_is_nothing_to_ask(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,6 +63,13 @@ What it raises instead lives in `services/errors.py` — `NotFound`,
 subclass keeps its family's answer. The bot can catch them and answer in
 words.
 
+**A name is a rule too.** Every reference table keeps its names in a side
+table, one row per language, and `services/naming.py` is the only place that
+reads them: which translation to show, what to fall back to when the asked
+language has none, and how to fetch a page's worth of them in one query. Four
+modules need that, which is what makes it a rule rather than a helper belonging
+to whichever module wrote it first.
+
 **A schema** is a leaf. `konnekt/schemas.py` — the package root, not inside
 `api/` — describes what goes over the wire. A service may return one without
 that pointing the domain layer at the HTTP layer, which is the whole reason it
@@ -203,9 +210,6 @@ finds, and a rule with silent exceptions is worse than no rule.
   `browse.helper_detail` and `search.parse`. Named rather than counted — a
   number here is one nobody remembers to correct, and the last three attempts
   at one were all wrong.
-- **`services/catalog._localised` is imported across the package boundary** by
-  name, from a private symbol, at sixteen call sites, and three more
-  "fetch localised names by id" helpers exist alongside it.
 
 Each of these is a separate change with its own tests. None of them is a
 reason to write new code the old way.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,7 @@ words.
 **A name is a rule too.** Every reference table keeps its names in a side
 table, one row per language, and `services/naming.py` is the only place that
 reads them: which translation to show, what to fall back to when the asked
-language has none, and how to fetch a page's worth of them in one query. Four
+language has none, and how to fetch a page's worth of them in one query. Five
 modules need that, which is what makes it a rule rather than a helper belonging
 to whichever module wrote it first.
 


### PR DESCRIPTION
`catalog._localised` was a private symbol imported by name across the package boundary — twenty-two call sites in four modules — with three hand-rolled "fetch the names for these ids" helpers alongside it: one in `cabinet`, one nested inside a function in `requests`, and three copies of the same query in `catalog` itself. A rule that four modules need is a rule, and rules live in `services/`.

`services/naming.py` holds it:

| | |
| --- | --- |
| `translated(row, lang, attr)` | one row, one attribute, with the fallback |
| `short_form(row, lang)` | the short name, or the full one for the institutions that have none |
| `rows_by_id(session, model, ids)` | a page's worth in one query, names loaded, `None` ids dropped |
| `names_by_id(…, lang)` | the same, already rendered |

The call sites shrink because the fallbacks stop being spelled out at each of them. "Short name or full name" appeared three times in three different shapes.

## Pure motion

The OpenAPI schema is byte-identical to `main`'s — generated on both branches with the same script and diffed, not inspected. 227 tests green; 216 of them are the ones that were green before.

One thing `ty` found on the way: `translated` was declared to take a row with an `id`, and `Language` is keyed by its code and has none. It only ever needed `names`, so that is all the protocol asks for — the wider declaration would have excluded a table that translates exactly like the other three.

## The tests

The rule had none of its own while it was private, which is part of why it drifted into four modules. It has eleven now, and they bite:

| mutant | tests that fail |
| --- | --- |
| drop the truthiness check, so an empty string counts as a translation | 1 |
| drop the cross-language fallback | 3 |
| drop `short_form`'s fallback to the full name | 4 (cumulative) |

The recorded red is that last one.

Docs updated first: docs/architecture.md