### PR TITLE
A Notifier the route is given, instead of app.state it reaches into

### DIFF
--- a/apps/api/src/konnekt/api/deps.py
+++ b/apps/api/src/konnekt/api/deps.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import Depends, Header, HTTPException, status
+from fastapi import Depends, Header, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from konnekt.core.config import Settings, get_settings
@@ -8,6 +8,7 @@ from konnekt.core.security import InitDataError, TelegramIdentity, parse_init_da
 from konnekt.db.models import User
 from konnekt.db.models.enums import UiLang
 from konnekt.db.session import session_scope
+from konnekt.services.notify import Notifier
 from konnekt.services.people import remember
 
 SettingsDep = Annotated[Settings, Depends(get_settings)]
@@ -87,3 +88,21 @@ async def current_lang(user: UserDep) -> UiLang:
 
 
 LangDep = Annotated[UiLang, Depends(current_lang)]
+
+
+def current_notifier(http: Request, settings: SettingsDep) -> Notifier:
+    """Assemble the notifier from what the process was started with.
+
+    The one place that reaches into `app.state`. The bot is put there by the
+    lifespan, which is also the reason for the default: a test builds the app
+    without running it, and so does a session that never got a token. Both are
+    "no bot", which a `Notifier` already answers for — but only if the reach
+    happens somewhere that can decide it once, rather than in each route that
+    happens to send a message.
+    """
+    return Notifier(
+        getattr(http.app.state, "bot", None), settings.public_base_url or None
+    )
+
+
+NotifierDep = Annotated[Notifier, Depends(current_notifier)]

--- a/apps/api/src/konnekt/api/deps.py
+++ b/apps/api/src/konnekt/api/deps.py
@@ -90,15 +90,18 @@ async def current_lang(user: UserDep) -> UiLang:
 LangDep = Annotated[UiLang, Depends(current_lang)]
 
 
-def current_notifier(http: Request, settings: SettingsDep) -> Notifier:
-    """Assemble the notifier from what the process was started with.
+async def current_notifier(http: Request, settings: SettingsDep) -> Notifier:
+    """Assemble a notifier from what the process was started with.
 
-    The one place that reaches into `app.state`. The bot is put there by the
-    lifespan, which is also the reason for the default: a test builds the app
-    without running it, and so does a session that never got a token. Both are
-    "no bot", which a `Notifier` already answers for — but only if the reach
-    happens somewhere that can decide it once, rather than in each route that
-    happens to send a message.
+    The bot is put on `app.state` by the lifespan, which is also the reason for
+    the default: a test builds the app without running it, and so does a
+    session that never got a token. Both are "no bot", which a `Notifier`
+    already answers for — but only if the reach happens somewhere that can
+    decide it once, rather than in each route that happens to send a message.
+
+    Per request, and cheap: two attribute reads and a cached `Settings`. It
+    reads state fixed at startup but is not itself a singleton, and the only
+    other places that reach for `app.state` are named in docs/architecture.md.
     """
     return Notifier(
         getattr(http.app.state, "bot", None), settings.public_base_url or None

--- a/apps/api/src/konnekt/api/v1/requests.py
+++ b/apps/api/src/konnekt/api/v1/requests.py
@@ -4,10 +4,10 @@ The largest domain here, because a request has a life — posted, seen, answered
 accepted, closed — and every step of it notifies somebody.
 """
 
-from fastapi import APIRouter, BackgroundTasks, Query, Request, status
+from fastapi import APIRouter, BackgroundTasks, Query, status
 from sqlalchemy import func, select
 
-from konnekt.api.deps import LangDep, SessionDep, UserDep
+from konnekt.api.deps import LangDep, NotifierDep, SessionDep, UserDep
 from konnekt.bot.texts import (
     FOR_PRICE,
     NEW_RESPONSE,
@@ -37,7 +37,6 @@ from konnekt.schemas import (
     ResponseCreate,
     ResponseOut,
 )
-from konnekt.services import notify
 from konnekt.services import requests as requests_service
 from konnekt.services.catalog import avatar_for
 from konnekt.services.naming import rows_by_id, short_form, translated
@@ -150,7 +149,7 @@ async def respond_to_request(
     request_id: int,
     payload: ResponseCreate,
     background: BackgroundTasks,
-    http: Request,
+    notifier: NotifierDep,
     session: SessionDep,
     lang: LangDep,
     user: UserDep,
@@ -168,11 +167,13 @@ async def respond_to_request(
     [rendered] = await _responses_out(session, [answered.response], lang)
     author = answered.author
     if author is not None:
-        _queue_notification(
-            background,
-            http,
-            recipient=author,
-            text=pick(NEW_RESPONSE, author.ui_lang).format(
+        # After the response goes out, not before: Telegram is a network call
+        # to a third party in the middle of a request somebody is waiting on,
+        # and the action is already committed.
+        background.add_task(
+            notifier.tell,
+            author,
+            pick(NEW_RESPONSE, author.ui_lang).format(
                 topic=quote(_topic_of(rendered_request=answered.request), 120),
                 helper=quote(rendered.name, 64),
                 price=(
@@ -217,7 +218,7 @@ async def request_responses(
 async def accept_response(
     response_id: int,
     background: BackgroundTasks,
-    http: Request,
+    notifier: NotifierDep,
     session: SessionDep,
     lang: LangDep,
     user: UserDep,
@@ -227,11 +228,10 @@ async def accept_response(
 
     helper_user = accepted.helper
     if accepted.notify and helper_user is not None:
-        _queue_notification(
-            background,
-            http,
-            recipient=helper_user,
-            text=pick(RESPONSE_ACCEPTED, helper_user.ui_lang).format(
+        background.add_task(
+            notifier.tell,
+            helper_user,
+            pick(RESPONSE_ACCEPTED, helper_user.ui_lang).format(
                 topic=quote(_topic_of(rendered_request=accepted.request), 120),
                 student=quote(user.first_name, 64),
                 contact=(
@@ -276,42 +276,6 @@ def _price_line(price: Price | None) -> str:
         return ""
     amount = int(price.amount) if float(price.amount).is_integer() else price.amount
     return f"{amount} {price.currency}"
-
-
-def _queue_notification(
-    background: BackgroundTasks, http: Request, *, recipient: User, text: str
-) -> None:
-    """Send after the response goes out, not before.
-
-    Telegram is a network call to a third party in the middle of a request the
-    user is waiting on. The action is already committed; the message can take
-    its time.
-    """
-    # `bot_started_at`, not only `bot_can_message`: the latter defaults to true
-    # for every row including someone who reached the app through a direct link
-    # and never messaged the bot. Telegram answers that send with a 403, which
-    # `tell` reads as "blocked" — so the notification is lost *and* the person
-    # is recorded as having blocked a bot they never met.
-    #
-    # `unsubscribed_at` is deliberately not consulted. /stop opts out of us
-    # writing unprompted; this is the answer to something they set in motion.
-    if recipient.bot_started_at is None or not recipient.bot_can_message:
-        return
-    # getattr, because app.state is populated by the lifespan hook and nothing
-    # here should turn "the app was mounted without one" into a 500 on an
-    # action that has already succeeded.
-    bot = getattr(http.app.state, "bot", None)
-    if bot is None:
-        return
-    settings = getattr(http.app.state, "settings", None)
-    background.add_task(
-        notify.tell,
-        bot,
-        tg_id=recipient.tg_id,
-        text=text,
-        lang=recipient.ui_lang,
-        app_url=(settings.public_base_url or None) if settings else None,
-    )
 
 
 async def _responses_out(

--- a/apps/api/src/konnekt/api/v1/requests.py
+++ b/apps/api/src/konnekt/api/v1/requests.py
@@ -40,7 +40,7 @@ from konnekt.schemas import (
 from konnekt.services import requests as requests_service
 from konnekt.services.catalog import avatar_for
 from konnekt.services.naming import rows_by_id, short_form, translated
-from konnekt.services.notify import quote
+from konnekt.services.notify import Recipient, quote
 
 router = APIRouter()
 
@@ -172,7 +172,7 @@ async def respond_to_request(
         # and the action is already committed.
         background.add_task(
             notifier.tell,
-            author,
+            Recipient.of(author),
             pick(NEW_RESPONSE, author.ui_lang).format(
                 topic=quote(_topic_of(rendered_request=answered.request), 120),
                 helper=quote(rendered.name, 64),
@@ -230,7 +230,7 @@ async def accept_response(
     if accepted.notify and helper_user is not None:
         background.add_task(
             notifier.tell,
-            helper_user,
+            Recipient.of(helper_user),
             pick(RESPONSE_ACCEPTED, helper_user.ui_lang).format(
                 topic=quote(_topic_of(rendered_request=accepted.request), 120),
                 student=quote(user.first_name, 64),

--- a/apps/api/src/konnekt/services/notify.py
+++ b/apps/api/src/konnekt/services/notify.py
@@ -24,6 +24,7 @@ from aiogram.types import (
 )
 
 from konnekt.bot.texts import OPEN_APP, pick
+from konnekt.db.models import User
 from konnekt.db.models.enums import UiLang
 from konnekt.db.session import get_sessionmaker
 from konnekt.services.people import mark_unreachable
@@ -53,6 +54,48 @@ def _keyboard(lang: UiLang, app_url: str | None) -> InlineKeyboardMarkup | None:
             ]
         ]
     )
+
+
+class Notifier:
+    """Whether a person can be written to, and the writing.
+
+    A dependency rather than something a handler assembles for itself. What a
+    route needs in order to notify — a bot, and the address the app lives at —
+    is decided once when the process starts, and a route that reaches into
+    `app.state` for it is a route that has to decide what to do when it is not
+    there. There is one answer to that and it belongs here.
+
+    A notifier with no bot is a working notifier that delivers nothing. That is
+    how the API runs locally and under test, and it must not be a branch every
+    caller remembers separately.
+    """
+
+    def __init__(self, bot: Bot | None, app_url: str | None = None) -> None:
+        self._bot = bot
+        self._app_url = app_url
+
+    async def tell(self, recipient: User, text: str) -> bool:
+        """Send, if this person can be sent to. Returns whether it arrived.
+
+        `bot_started_at`, not only `bot_can_message`: the latter defaults to
+        true for every row including someone who reached the app through a
+        direct link and never messaged the bot. Telegram answers that send with
+        a 403, which `tell` reads as "blocked" — so the notification is lost
+        *and* the person is recorded as having blocked a bot they never met.
+
+        `unsubscribed_at` is deliberately not consulted. /stop opts out of us
+        writing unprompted; every message that comes through here is the answer
+        to something the recipient set in motion.
+        """
+        if recipient.bot_started_at is None or not recipient.bot_can_message:
+            return False
+        return await tell(
+            self._bot,
+            tg_id=recipient.tg_id,
+            text=text,
+            lang=recipient.ui_lang,
+            app_url=self._app_url,
+        )
 
 
 async def tell(

--- a/apps/api/src/konnekt/services/notify.py
+++ b/apps/api/src/konnekt/services/notify.py
@@ -12,6 +12,7 @@ the person will see it in the app.
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from html import escape
 
 from aiogram import Bot
@@ -56,6 +57,47 @@ def _keyboard(lang: UiLang, app_url: str | None) -> InlineKeyboardMarkup | None:
     )
 
 
+@dataclass(frozen=True)
+class Recipient:
+    """Everything a notification needs to know about a person.
+
+    A snapshot, taken while the session that loaded them is still open. The
+    send happens in a background task, which runs after the response and
+    therefore after the request's transaction has closed — so a task holding
+    the ORM row itself would be reading a detached object, and works only for
+    as long as nothing expires it. That is a dependency on
+    `expire_on_commit=False` that nothing states and a `MissingGreenlet` at the
+    end of it.
+
+    `reachable` is decided here rather than at the send, for the same reason:
+    it is a fact about the row, and the row is only trustworthy now.
+    """
+
+    tg_id: int
+    lang: UiLang
+    reachable: bool
+
+    @classmethod
+    def of(cls, user: User) -> "Recipient":
+        """Take the snapshot, and with it the decision about writing at all.
+
+        `bot_started_at`, not only `bot_can_message`: the latter defaults to
+        true for every row including someone who reached the app through a
+        direct link and never messaged the bot. Telegram answers that send with
+        a 403, which `tell` reads as "blocked" — so the notification is lost
+        *and* the person is recorded as having blocked a bot they never met.
+
+        `unsubscribed_at` is deliberately not consulted. /stop opts out of us
+        writing unprompted; every message that goes through here is the answer
+        to something the recipient set in motion.
+        """
+        return cls(
+            tg_id=user.tg_id,
+            lang=user.ui_lang,
+            reachable=user.bot_started_at is not None and user.bot_can_message,
+        )
+
+
 class Notifier:
     """Whether a person can be written to, and the writing.
 
@@ -74,26 +116,20 @@ class Notifier:
         self._bot = bot
         self._app_url = app_url
 
-    async def tell(self, recipient: User, text: str) -> bool:
+    async def tell(self, recipient: Recipient, text: str) -> bool:
         """Send, if this person can be sent to. Returns whether it arrived.
 
-        `bot_started_at`, not only `bot_can_message`: the latter defaults to
-        true for every row including someone who reached the app through a
-        direct link and never messaged the bot. Telegram answers that send with
-        a 403, which `tell` reads as "blocked" — so the notification is lost
-        *and* the person is recorded as having blocked a bot they never met.
-
-        `unsubscribed_at` is deliberately not consulted. /stop opts out of us
-        writing unprompted; every message that comes through here is the answer
-        to something the recipient set in motion.
+        A `Recipient` and not a `User`: this runs after the response, when the
+        session is gone. Whoever queues it takes the snapshot first, which is
+        also where the decision about writing at all was made.
         """
-        if recipient.bot_started_at is None or not recipient.bot_can_message:
+        if not recipient.reachable:
             return False
         return await tell(
             self._bot,
             tg_id=recipient.tg_id,
             text=text,
-            lang=recipient.ui_lang,
+            lang=recipient.lang,
             app_url=self._app_url,
         )
 

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -66,13 +66,22 @@ async def session(engine) -> AsyncIterator[AsyncSession]:
         await transaction.rollback()
 
 
-@pytest_asyncio.fixture
-async def client(session: AsyncSession) -> AsyncIterator[AsyncClient]:
-    """An HTTP client whose requests share the test's rolled-back session."""
+def app_for(session: AsyncSession, *, bot: object | None = None):
+    """The application, wired to this test's session.
+
+    One place, because a test that builds its own app also builds its own idea
+    of what a request commits — and the point of the override is that it
+    commits and rolls back exactly where `session_scope` does. A fixture that
+    is more forgiving than production hides the bugs that rule exists to
+    prevent.
+
+    `bot` goes on `app.state` the way the lifespan puts it there, for the tests
+    that need the app to have one. Absent by default: the lifespan does not run
+    under `ASGITransport`, so "no bot" is what a test sees unless it says
+    otherwise, and that is also how the API runs locally.
+    """
     from konnekt.db.session import session_scope, unit_of_work
     from konnekt.main import create_app
-
-    app = create_app()
 
     # The same rule the real scope applies, not a copy of it. The whole test
     # still disappears: this session is joined to an outer transaction as a
@@ -81,9 +90,17 @@ async def client(session: AsyncSession) -> AsyncIterator[AsyncClient]:
         async with unit_of_work(session):
             yield session
 
+    app = create_app()
     app.dependency_overrides[session_scope] = scope
+    if bot is not None:
+        app.state.bot = bot
+    return app
 
-    transport = ASGITransport(app=app)
+
+@pytest_asyncio.fixture
+async def client(session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    """An HTTP client whose requests share the test's rolled-back session."""
+    transport = ASGITransport(app=app_for(session))
     async with AsyncClient(transport=transport, base_url="http://test") as http:
         yield http
 

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -13,6 +13,11 @@ import os
 # aiogram's HMAC. Signature handling has its own tests.
 os.environ["ALLOW_UNSIGNED_INIT_DATA"] = "true"
 os.environ["BOT_TOKEN"] = ""
+# Pinned for the same reason, one step further on: `get_settings` walks up to
+# the repository's own `.env`, so without this a notification carries a
+# web_app button on a machine that has PUBLIC_BASE_URL set and no button in CI.
+# A suite that exercises different code on different machines is not a suite.
+os.environ["PUBLIC_BASE_URL"] = "https://tests.example"
 
 from collections.abc import AsyncIterator
 

--- a/apps/api/tests/test_landing.py
+++ b/apps/api/tests/test_landing.py
@@ -14,6 +14,8 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from .conftest import app_for
+
 pytestmark = pytest.mark.asyncio
 
 
@@ -37,18 +39,9 @@ class BrokenBot:
 @pytest_asyncio.fixture
 async def app_with(session: AsyncSession):
     """An app with a bot of the caller's choosing on its state."""
-    from konnekt.db.session import session_scope, unit_of_work
-    from konnekt.main import create_app
-
-    async def scope():
-        async with unit_of_work(session):
-            yield session
 
     async def build(bot) -> FastAPI:
-        app = create_app()
-        app.dependency_overrides[session_scope] = scope
-        app.state.bot = bot
-        return app
+        return app_for(session, bot=bot)
 
     return build
 

--- a/apps/api/tests/test_notify.py
+++ b/apps/api/tests/test_notify.py
@@ -19,7 +19,7 @@ from konnekt.bot.texts import (
     pick,
 )
 from konnekt.db.models.enums import UiLang
-from konnekt.services.notify import Notifier, _keyboard, quote, tell
+from konnekt.services.notify import Notifier, Recipient, _keyboard, quote, tell
 
 
 def test_quote_escapes_html() -> None:
@@ -149,7 +149,9 @@ async def test_nobody_is_written_to_who_never_started_the_bot() -> None:
     bot = _Bot()
     notifier = Notifier(cast(Bot, bot))
 
-    assert await notifier.tell(_person(bot_started_at=None), "привет") is False
+    assert (
+        await notifier.tell(Recipient.of(_person(bot_started_at=None)), "привет") is False
+    )
     assert bot.sent == []
 
 
@@ -158,14 +160,17 @@ async def test_nobody_is_written_to_who_blocked_the_bot() -> None:
     bot = _Bot()
     notifier = Notifier(cast(Bot, bot))
 
-    assert await notifier.tell(_person(bot_can_message=False), "привет") is False
+    assert (
+        await notifier.tell(Recipient.of(_person(bot_can_message=False)), "привет")
+        is False
+    )
     assert bot.sent == []
 
 
 @pytest.mark.asyncio
 async def test_a_notifier_without_a_bot_delivers_nothing_and_says_so() -> None:
     """The API runs without a token locally; the action must still succeed."""
-    assert await Notifier(None).tell(_person(), "привет") is False
+    assert await Notifier(None).tell(Recipient.of(_person()), "привет") is False
 
 
 @pytest.mark.asyncio
@@ -178,6 +183,6 @@ async def test_a_reachable_person_is_written_to() -> None:
     """
     bot = _Bot()
 
-    assert await Notifier(cast(Bot, bot)).tell(_person(), "привет") is True
+    assert await Notifier(cast(Bot, bot)).tell(Recipient.of(_person()), "привет") is True
     assert bot.sent[0]["chat_id"] == 42
     assert bot.sent[0]["text"] == "привет"

--- a/apps/api/tests/test_notify.py
+++ b/apps/api/tests/test_notify.py
@@ -8,7 +8,7 @@ because the bot speaks HTML and the text comes from strangers.
 from typing import cast
 
 import pytest
-from fastapi import BackgroundTasks, Request
+from aiogram import Bot
 
 from konnekt.bot.texts import (
     NEW_RESPONSE,
@@ -19,7 +19,7 @@ from konnekt.bot.texts import (
     pick,
 )
 from konnekt.db.models.enums import UiLang
-from konnekt.services.notify import _keyboard, quote, tell
+from konnekt.services.notify import Notifier, _keyboard, quote, tell
 
 
 def test_quote_escapes_html() -> None:
@@ -107,42 +107,19 @@ async def test_telling_nobody_is_not_an_error() -> None:
     assert await tell(None, tg_id=1, text="привет", lang=UiLang.RU, app_url=None) is False
 
 
-class _Bag:
-    """An attribute bag, which is all `app.state` is.
+class _Bot:
+    """Just enough of aiogram's `Bot` to say whether a send happened.
 
-    The two attributes are declared rather than only assigned, so that reading
-    them is something a type checker can follow.
+    A fake rather than a mock: the assertion below is about what reached
+    Telegram, and a recorded call is the closest this can get to that without
+    a token.
     """
 
-    state: "_Bag"
-    app: "_Bag"
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
 
-
-def _http(**state) -> Request:
-    """Just enough of a FastAPI request for the reachability guard.
-
-    Deliberately without a `bot` unless one is passed: that is how the API
-    runs locally, and every caller has to work that way.
-
-    Cast rather than constructed: `_queue_notification` reaches for exactly
-    two attributes, and building a real `Request` would mean inventing an ASGI
-    scope that says nothing about what is under test.
-    """
-    request, app = _Bag(), _Bag()
-    app.state = _Bag()
-    for key, value in state.items():
-        setattr(app.state, key, value)
-    request.app = app
-    return cast(Request, request)
-
-
-class _Recorder(BackgroundTasks):
-    """A real `BackgroundTasks` that is simply never run.
-
-    Subclassed rather than duck-typed: `add_task` is FastAPI's own, so what
-    lands in `self.tasks` is what would have landed there in production, and
-    the assertions below read the same fields the framework would.
-    """
+    async def send_message(self, **kwargs) -> None:
+        self.sent.append(kwargs)
 
 
 def _person(**overrides):
@@ -160,7 +137,8 @@ def _person(**overrides):
     return User(**{**defaults, **overrides})
 
 
-def test_nobody_is_written_to_who_never_started_the_bot() -> None:
+@pytest.mark.asyncio
+async def test_nobody_is_written_to_who_never_started_the_bot() -> None:
     """`bot_can_message` defaults to true for everyone, including them.
 
     Someone who opened the mini app from a direct link and never messaged the
@@ -168,48 +146,38 @@ def test_nobody_is_written_to_who_never_started_the_bot() -> None:
     block — losing the notification *and* recording them as having blocked a
     bot they never met.
     """
-    from konnekt.api.v1.requests import _queue_notification
+    bot = _Bot()
+    notifier = Notifier(cast(Bot, bot))
 
-    recorder = _Recorder()
-    _queue_notification(
-        recorder, _http(), recipient=_person(bot_started_at=None), text="привет"
-    )
-    assert recorder.tasks == []
+    assert await notifier.tell(_person(bot_started_at=None), "привет") is False
+    assert bot.sent == []
 
 
-def test_nobody_is_written_to_who_blocked_the_bot() -> None:
-    from konnekt.api.v1.requests import _queue_notification
+@pytest.mark.asyncio
+async def test_nobody_is_written_to_who_blocked_the_bot() -> None:
+    bot = _Bot()
+    notifier = Notifier(cast(Bot, bot))
 
-    recorder = _Recorder()
-    _queue_notification(
-        recorder, _http(), recipient=_person(bot_can_message=False), text="привет"
-    )
-    assert recorder.tasks == []
+    assert await notifier.tell(_person(bot_can_message=False), "привет") is False
+    assert bot.sent == []
 
 
-def test_no_task_is_queued_when_there_is_no_bot() -> None:
+@pytest.mark.asyncio
+async def test_a_notifier_without_a_bot_delivers_nothing_and_says_so() -> None:
     """The API runs without a token locally; the action must still succeed."""
-    from konnekt.api.v1.requests import _queue_notification
-
-    recorder = _Recorder()
-    _queue_notification(recorder, _http(), recipient=_person(), text="привет")
-    assert recorder.tasks == []
+    assert await Notifier(None).tell(_person(), "привет") is False
 
 
-def test_a_reachable_person_with_a_bot_is_written_to() -> None:
+@pytest.mark.asyncio
+async def test_a_reachable_person_is_written_to() -> None:
     """The positive control.
 
-    Without it the three tests above pass for the wrong reason — there is no
-    bot in any of them, so they would still pass with the guard deleted.
+    Without it the three above pass for the wrong reason — nothing is sent in
+    any of them, so they would all still pass with the guard deleted and the
+    bot removed.
     """
-    from konnekt.api.v1.requests import _queue_notification
+    bot = _Bot()
 
-    recorder = _Recorder()
-    _queue_notification(
-        recorder,
-        _http(bot=object(), settings=None),
-        recipient=_person(),
-        text="привет",
-    )
-    assert len(recorder.tasks) == 1
-    assert recorder.tasks[0].kwargs["tg_id"] == 42
+    assert await Notifier(cast(Bot, bot)).tell(_person(), "привет") is True
+    assert bot.sent[0]["chat_id"] == 42
+    assert bot.sent[0]["text"] == "привет"

--- a/apps/api/tests/test_requests.py
+++ b/apps/api/tests/test_requests.py
@@ -511,9 +511,14 @@ class RecordingBot:
     """A bot that keeps what it was asked to send.
 
     Enough of aiogram's `Bot` for `notify.tell`, which calls exactly one
-    method on it. The point of the test below is the wiring between the route
+    method on it. The point of the tests below is the wiring between the route
     and the person, so what matters is that a message arrived and who it was
     addressed to.
+
+    Do not teach it to raise `TelegramForbiddenError`: `tell` answers that by
+    opening a session of its own and updating the row, and the row is inside
+    this test's uncommitted transaction — so it would wait on the lock until
+    the suite is killed rather than fail.
     """
 
     def __init__(self) -> None:
@@ -555,6 +560,13 @@ async def test_the_author_hears_about_an_answer(
     assert response.status_code == 201, response.text
     assert [message["chat_id"] for message in bot.sent] == [STUDENT]
     assert "могу помочь с этим" in bot.sent[0]["text"]
+    # The button is the one thing whose source this refactor moved: it used to
+    # come off `app.state.settings`, which the test client never has, so it was
+    # silently absent from every test. `PUBLIC_BASE_URL` is pinned in conftest
+    # for exactly this assertion.
+    [[button]] = bot.sent[0]["reply_markup"].inline_keyboard
+    assert button.web_app is not None
+    assert button.web_app.url == "https://tests.example"
 
 
 async def test_nobody_hears_about_it_who_never_started_the_bot(

--- a/apps/api/tests/test_requests.py
+++ b/apps/api/tests/test_requests.py
@@ -5,8 +5,10 @@ once someone can reply — who may see incoming requests, who may answer them,
 and what the author sees afterwards.
 """
 
+from datetime import UTC, datetime
+
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,7 +21,7 @@ from konnekt.db.models import (
 )
 from konnekt.db.models.enums import PublishStatus, RequestStatus
 
-from .conftest import auth_header
+from .conftest import app_for, auth_header
 
 STUDENT = 90501
 HELPER = 90502
@@ -483,7 +485,9 @@ async def test_a_failure_after_the_write_leaves_nothing_behind(
     def explode(*args, **kwargs):
         raise RuntimeError("rendering the notification blew up")
 
-    monkeypatch.setattr(requests_api, "_queue_notification", explode)
+    # Rendering the answer, which happens after the row is written and before
+    # the notification is composed from it — the window the rule is about.
+    monkeypatch.setattr(requests_api, "_responses_out", explode)
 
     with pytest.raises(RuntimeError):
         await client.post(
@@ -498,3 +502,81 @@ async def test_a_failure_after_the_write_leaves_nothing_behind(
         .where(RequestResponse.request_id == created["id"])
     )
     assert answered == 0
+
+
+# ── the notification ────────────────────────────────────────────────────
+
+
+class RecordingBot:
+    """A bot that keeps what it was asked to send.
+
+    Enough of aiogram's `Bot` for `notify.tell`, which calls exactly one
+    method on it. The point of the test below is the wiring between the route
+    and the person, so what matters is that a message arrived and who it was
+    addressed to.
+    """
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send_message(self, **kwargs) -> None:
+        self.sent.append(kwargs)
+
+
+async def test_the_author_hears_about_an_answer(
+    session: AsyncSession, helper_factory
+) -> None:
+    """End to end through the dependency, not through a helper function.
+
+    The route asks for a notifier and the notifier reaches for the bot the
+    process was started with. Nothing between the two is mocked here, so this
+    is the test that fails if the wiring is wrong — the unit tests around
+    `Notifier` would all still pass with the route never calling it.
+    """
+    bot = RecordingBot()
+    transport = ASGITransport(app=app_for(session, bot=bot))
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await helper_factory(tg_id=HELPER)
+        created = await post_request(client, "матан")
+
+        # Somebody who reached the app through a link has never messaged the
+        # bot, and Telegram would answer 403. Say they have.
+        author = await session.scalar(select(User).where(User.tg_id == STUDENT))
+        assert author is not None
+        author.bot_started_at = datetime.now(UTC)
+        await session.flush()
+
+        response = await client.post(
+            f"/api/v1/requests/{created['id']}/respond",
+            json={"message": "могу помочь с этим"},
+            headers=helper_header(),
+        )
+
+    assert response.status_code == 201, response.text
+    assert [message["chat_id"] for message in bot.sent] == [STUDENT]
+    assert "могу помочь с этим" in bot.sent[0]["text"]
+
+
+async def test_nobody_hears_about_it_who_never_started_the_bot(
+    session: AsyncSession, helper_factory
+) -> None:
+    """The control, at the same level.
+
+    Without it the test above passes for any wiring that sends to everybody,
+    and the reachability rule is exactly the one that keeps somebody from
+    being recorded as having blocked a bot they never met.
+    """
+    bot = RecordingBot()
+    transport = ASGITransport(app=app_for(session, bot=bot))
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await helper_factory(tg_id=HELPER)
+        created = await post_request(client, "матан")
+
+        response = await client.post(
+            f"/api/v1/requests/{created['id']}/respond",
+            json={"message": "могу помочь с этим"},
+            headers=helper_header(),
+        )
+
+    assert response.status_code == 201, response.text
+    assert bot.sent == []

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,7 +81,10 @@ one answer to that question per thing, it belongs where the thing is built, and
 a dependency is also the only shape a test can substitute.
 
 `api/v1/health.py` is the exception and stays one: it reports on `app.state`
-itself, so reaching for it is the job rather than a shortcut.
+itself, so reaching for it is the job rather than a shortcut. So is the webhook
+route in `main.py`, which is defined inside `create_app` and hands the update
+to the dispatcher the lifespan put there — it is the seam between the two
+runtimes rather than a handler.
 
 **A schema** is a leaf. `konnekt/schemas.py` — the package root, not inside
 `api/` — describes what goes over the wire. A service may return one without
@@ -141,7 +144,12 @@ Everything that commits outside it:
   runs, so that first sight of someone — and the `source` that says where they
   came from — survives whatever the handler goes on to do.
 - `services/notify.py` opens its own session: it runs in a background task,
-  after the response, and therefore after this transaction has closed.
+  after the response, and therefore after this transaction has closed. Nothing
+  is handed an ORM row across that line — a background task gets a
+  `notify.Recipient`, a snapshot taken while the session was still open.
+  Passing the row itself works only for as long as nothing expires it, and the
+  thing that would notice is a `MissingGreenlet` inside a task whose exception
+  nobody is waiting for.
 - The bot has no request to hang a transaction on, so `bot/middleware.py` and
   the `/stop` handler open and commit their own sessions. The middleware
   commits the person's record before the handler runs, for the same reason

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,6 +70,19 @@ language has none, and how to fetch a page's worth of them in one query. Five
 modules need that, which is what makes it a rule rather than a helper belonging
 to whichever module wrote it first.
 
+**What a handler needs arrives as a dependency.** A route does not reach into
+`app.state`. What the process was started with — the bot, the settings — is
+composed into something usable in `api/deps.py` and asked for by type:
+`SessionDep`, `UserDep`, `LangDep`, `NotifierDep`. The reason is not tidiness.
+`app.state` is populated by the lifespan, which does not run under the test
+client, so every route reaching for it had to decide what "it is not there"
+means — and each of them decided quietly, with a `getattr` default. There is
+one answer to that question per thing, it belongs where the thing is built, and
+a dependency is also the only shape a test can substitute.
+
+`api/v1/health.py` is the exception and stays one: it reports on `app.state`
+itself, so reaching for it is the job rather than a shortcut.
+
 **A schema** is a leaf. `konnekt/schemas.py` — the package root, not inside
 `api/` — describes what goes over the wire. A service may return one without
 that pointing the domain layer at the HTTP layer, which is the whole reason it
@@ -210,6 +223,10 @@ finds, and a rule with silent exceptions is worse than no rule.
   `browse.helper_detail` and `search.parse`. Named rather than counted — a
   number here is one nobody remembers to correct, and the last three attempts
   at one were all wrong.
+- **`public.py` still reaches into `app.state`** — for the bot, and for the
+  per-process cache of its username. The cache is genuinely app-scoped, so
+  this one needs somewhere for that state to live before it can become a
+  dependency; it is not simply an unconverted call site.
 
 Each of these is a separate change with its own tests. None of them is a
 reason to write new code the old way.


### PR DESCRIPTION
Answering a request and accepting an answer both notified through a private helper in the route module that pulled the bot and the settings off `app.state` with `getattr` defaults. Three things were wrong with that, and one of them was invisible.

**The rule lived in the wrong layer.** Who may be written to — `bot_started_at`, not only `bot_can_message`, because Telegram answers a send to someone who never started the bot with a 403 and `tell` reads that as a block — sat in `api/v1/`, where the bot cannot reach it.

**The `getattr` defaults were load-bearing and unexplained.** `app.state.bot` is set by the lifespan, and the lifespan does not run under the test client, so "no bot" is the normal state of every test. Each route reaching for it decided what that meant quietly and separately.

**Nothing tested the wiring.** There was no way to substitute a notifier, so every test called the private helper directly — and each of them would have gone on passing if the route had stopped calling it.

`services.notify.Notifier` holds the rule and the sending. `api/deps.py` composes it from `app.state` and the settings. The two routes ask for `NotifierDep` and queue `notifier.tell`.

## What a background task may be handed

Not an ORM row. `session_scope` is `scope="function"`, so it commits and closes before the response is sent, and Starlette runs background tasks after — so a task holding the `User` reads a detached instance, and works only for as long as nothing expires it. `expire_on_commit=False` is what was holding it up, and that setting is there for an unrelated reason.

`notify.Recipient` is a snapshot: tg_id, language, and whether we may write at all, taken by the route while the row is still live. The reachability rule moved into it, so it stays in the service and stays unforgettable — a `Notifier` cannot be given anything that has not already been through it.

## The tests

Two at the level that was missing: a bot on `app.state`, a real request answered over HTTP, and an assertion about what reached Telegram.

| mutation | tests that fail |
| --- | --- |
| the route stops queuing the notification | 1 — the new positive test, and only it |
| the reachability rule is deleted | 3 |
| `current_notifier` stops reaching for `app.state.bot` | 1 |

`app_url` is the one wire this actually reroutes, and it had no coverage — and had quietly become machine-dependent, since `get_settings` walks up to the repository's `.env`. `PUBLIC_BASE_URL` is pinned in the conftest preamble beside the `BOT_TOKEN` that is already there for the same reason, and the button is asserted.

`tests/conftest.py::app_for` is what makes these possible, and it retires a deferred item: `test_landing.py` kept its own copy of the session override, and a second copy is a second opinion about what a request commits.

## Pure motion

The OpenAPI schema is byte-identical to `main`'s — generated on both and diffed. 229 tests green.

## Not done here

`public.py` still reaches into `app.state`, for the bot and for a per-process cache of its username. The cache is genuinely app-scoped and needs somewhere to live before it can become a dependency, so it is written down in `docs/architecture.md` rather than half-converted. The webhook route in `main.py` is named there too, as the second legitimate exception alongside `health.py`.

Docs updated first: docs/architecture.md