### PR TITLE
Stop promising what the bot does not do

### DIFF
--- a/apps/api/src/konnekt/bot/__init__.py
+++ b/apps/api/src/konnekt/bot/__init__.py
@@ -35,9 +35,14 @@ GREETING = (
     "нострификация и работы."
 )
 
+# "Больше писать не буду" was the first half of this sentence and it was not
+# true either. `notify.Recipient.of` does not consult `unsubscribed_at` on
+# purpose — an answer to your own request is not us writing to you unprompted —
+# so those messages keep arriving, and somebody told otherwise finds out when
+# one does.
 UNSUBSCRIBED = (
-    "Больше писать не буду. Каталогом можно пользоваться как обычно — "
-    "кнопка «Каталог» внизу."
+    "Рассылок не будет. Ответы на твои заявки продолжат приходить — "
+    "их ты просил сам. Каталог работает как обычно."
 )
 
 

--- a/apps/api/src/konnekt/bot/__init__.py
+++ b/apps/api/src/konnekt/bot/__init__.py
@@ -6,8 +6,6 @@ later. Adding conversational flows here would recreate the command-driven
 interface this rewrite exists to remove.
 """
 
-from datetime import UTC, datetime
-
 from aiogram import Bot, Dispatcher, Router
 from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
@@ -19,14 +17,28 @@ from aiogram.types import (
     Message,
     WebAppInfo,
 )
-from sqlalchemy import select
 
 from konnekt.bot.middleware import RememberUserMiddleware
 from konnekt.core.config import Settings
-from konnekt.db.models import User
 from konnekt.db.session import get_sessionmaker
+from konnekt.services.people import unsubscribe
 
 router = Router(name="konnekt")
+
+# Named rather than written inline, because these are claims about the code and
+# a claim wants somewhere a test can read it. See tests/test_bot.py: one says
+# what the catalog has, the other is careful not to offer a way back that does
+# not exist.
+GREETING = (
+    "<b>Students CZ</b> — кто поможет с учёбой в Чехии.\n\n"
+    "Репетиторы, подготовка к přijímačky, помощь на экзамене, "
+    "нострификация и работы."
+)
+
+UNSUBSCRIBED = (
+    "Больше писать не буду. Каталогом можно пользоваться как обычно — "
+    "кнопка «Каталог» внизу."
+)
 
 
 def build_bot(settings: Settings) -> Bot:
@@ -59,9 +71,7 @@ async def on_start(message: Message, settings: Settings) -> None:
     # a new person reads, and every sentence in it that is not about what the
     # catalog does is a sentence spent talking about ourselves.
     await message.answer(
-        "<b>Students CZ</b> — кто поможет с учёбой в Чехии.\n\n"
-        "Репетиторы, подготовка к přijímačky, помощь на экзамене, "
-        "нострификация, работы и материалы.",
+        GREETING,
         reply_markup=InlineKeyboardMarkup(
             inline_keyboard=[
                 [
@@ -103,14 +113,7 @@ async def on_stop(message: Message) -> None:
         return
 
     async with get_sessionmaker()() as session:
-        user = await session.scalar(
-            select(User).where(User.tg_id == message.from_user.id)
-        )
-        if user is not None and user.unsubscribed_at is None:
-            user.unsubscribed_at = datetime.now(UTC)
+        if await unsubscribe(session, message.from_user.id):
             await session.commit()
 
-    await message.answer(
-        "Больше писать не буду. Каталогом можно пользоваться как обычно — "
-        "кнопка «Каталог» внизу. Передумаешь — /start."
-    )
+    await message.answer(UNSUBSCRIBED)

--- a/apps/api/src/konnekt/services/people.py
+++ b/apps/api/src/konnekt/services/people.py
@@ -120,6 +120,25 @@ async def log_event(
     )
 
 
+async def unsubscribe(session: AsyncSession, tg_id: int) -> bool:
+    """Stop writing to this person unprompted. Returns whether anything changed.
+
+    A timestamp and nothing else. Not the person, not their profile, not their
+    requests or the answers to them: opting out of being written to is not
+    leaving, and the row is what makes somebody the same person if they come
+    back. An opt-out that destroyed it would be a worse answer than the
+    blocking it exists to prevent.
+
+    Answers `False` for somebody who already had, and for somebody with no row
+    at all — a /stop from an update we never saw the start of is not a failure.
+    """
+    user = await session.scalar(select(User).where(User.tg_id == tg_id))
+    if user is None or user.unsubscribed_at is not None:
+        return False
+    user.unsubscribed_at = datetime.now(UTC)
+    return True
+
+
 async def mark_unreachable(session: AsyncSession, tg_id: int, reason: str) -> None:
     """Telegram said we may not write to this person any more.
 

--- a/apps/api/tests/test_bot.py
+++ b/apps/api/tests/test_bot.py
@@ -6,14 +6,17 @@ finds out that it is empty is the one who tried it.
 """
 
 import re
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
+from types import SimpleNamespace
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from konnekt import bot as konnekt_bot
 from konnekt.bot import GREETING, UNSUBSCRIBED
-from konnekt.db.models import User
+from konnekt.db.models import HelperProfile, HelpRequest, RequestResponse, User
 from konnekt.db.models.enums import UiLang
 from konnekt.services.people import unsubscribe
 
@@ -83,19 +86,21 @@ async def test_unsubscribing_somebody_unknown_is_not_an_error(
     assert await unsubscribe(session, 91999) is False
 
 
-async def test_unsubscribing_keeps_everything_else(session: AsyncSession) -> None:
+async def test_unsubscribing_keeps_every_column(session: AsyncSession) -> None:
     """The whole point. Opting out of being written to is not leaving, and the
-    row is what makes somebody the same person if they come back."""
+    row is what makes somebody the same person if they come back.
+
+    Every column the mapper knows about, asked for by name rather than listed
+    here: a column added next year is one nobody would think to add to a list,
+    and the first thing anybody would do with a new column is forget it.
+    """
     user = await _person(session)
-    before = {
-        "first_name": user.first_name,
-        "last_name": user.last_name,
-        "tg_username": user.tg_username,
-        "ui_lang": user.ui_lang,
-        "source": user.source,
-        "bot_started_at": user.bot_started_at,
-        "is_blocked": user.is_blocked,
-    }
+    columns = [
+        column.key
+        for column in User.__mapper__.columns
+        if column.key != "unsubscribed_at"
+    ]
+    before = {name: getattr(user, name) for name in columns}
 
     await unsubscribe(session, user.tg_id)
     await session.flush()
@@ -108,5 +113,102 @@ async def test_unsubscribing_keeps_everything_else(session: AsyncSession) -> Non
 
     kept = await session.scalar(select(User).where(User.tg_id == user.tg_id))
     assert kept is not None
-    assert {key: getattr(kept, key) for key in before} == before
+    assert {name: getattr(kept, name) for name in columns} == before
     assert kept.unsubscribed_at is not None
+
+
+async def test_unsubscribing_keeps_what_belongs_to_them(
+    session: AsyncSession,
+) -> None:
+    """Their profile, their requests, and the answers to them.
+
+    `User.helper` cascades `delete-orphan`, so a `session.delete` here would
+    take the profile with it and this is the assertion that would say so.
+    """
+    user = await _person(session, tg_id=91002)
+    session.add(HelperProfile(user_id=user.id, headline="Матан и линал"))
+    request = HelpRequest(author_id=user.id, raw_text="нужен матан")
+    session.add(request)
+    await session.flush()
+    session.add(RequestResponse(request_id=request.id, helper_id=user.id, message="могу"))
+    await session.flush()
+
+    await unsubscribe(session, user.tg_id)
+    await session.flush()
+
+    assert await session.get(HelperProfile, user.id) is not None
+    assert (
+        await session.scalar(
+            select(func.count())
+            .select_from(HelpRequest)
+            .where(HelpRequest.author_id == user.id)
+        )
+        == 1
+    )
+    assert (
+        await session.scalar(
+            select(func.count())
+            .select_from(RequestResponse)
+            .where(RequestResponse.helper_id == user.id)
+        )
+        == 1
+    )
+
+
+class _Message:
+    """Just enough of an aiogram `Message` for the handler.
+
+    A recorder rather than a mock: what is asserted is the text that would have
+    reached Telegram, which is the only thing the handler produces.
+    """
+
+    def __init__(self, tg_id: int | None) -> None:
+        self.from_user = SimpleNamespace(id=tg_id) if tg_id is not None else None
+        self.answers: list[str] = []
+
+    async def answer(self, text: str, **_: object) -> None:
+        self.answers.append(text)
+
+
+def _lend(session: AsyncSession):
+    """Hand the handler this test's session instead of a new one.
+
+    The handler opens its own — it has no request to hang a transaction on, and
+    docs/architecture.md says so — which is exactly what makes it invisible to
+    the rest of the suite. Lending the session is what lets the assertion below
+    read what the handler wrote.
+    """
+
+    @asynccontextmanager
+    async def scope():
+        yield session
+
+    return lambda: scope()
+
+
+async def test_the_stop_handler_unsubscribes_and_says_so(
+    session: AsyncSession, monkeypatch
+) -> None:
+    """The wiring. Every other test here would still pass if `on_stop` stopped
+    calling the rule, stopped committing, or answered something else."""
+    monkeypatch.setattr(konnekt_bot, "get_sessionmaker", lambda: _lend(session))
+    user = await _person(session, tg_id=91003)
+    message = _Message(user.tg_id)
+
+    await konnekt_bot.on_stop(message)
+
+    assert user.unsubscribed_at is not None
+    assert message.answers == [UNSUBSCRIBED]
+
+
+async def test_an_update_without_a_sender_is_ignored(
+    session: AsyncSession, monkeypatch
+) -> None:
+    """Channel posts have no `from_user`. Nothing to unsubscribe and nobody to
+    answer, which is a return rather than an exception."""
+    monkeypatch.setattr(konnekt_bot, "get_sessionmaker", lambda: _lend(session))
+    message = _Message(None)
+
+    await konnekt_bot.on_stop(message)
+
+    assert message.answers == []

--- a/apps/api/tests/test_bot.py
+++ b/apps/api/tests/test_bot.py
@@ -1,0 +1,112 @@
+"""What the bot says, and what saying it costs somebody.
+
+The copy is tested here because it is a claim about the code. A sentence
+telling somebody how to undo something is a promise, and the only person who
+finds out that it is empty is the one who tried it.
+"""
+
+import re
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from konnekt.bot import GREETING, UNSUBSCRIBED
+from konnekt.db.models import User
+from konnekt.db.models.enums import UiLang
+from konnekt.services.people import unsubscribe
+
+pytestmark = pytest.mark.asyncio
+
+# `/start`, `/stop` — anything that reads as "type this and something happens".
+COMMAND = re.compile(r"(?:^|\s)/[a-z][a-z_]*")
+
+
+async def test_the_opt_out_reply_offers_no_way_back() -> None:
+    """Because there is none.
+
+    Nothing clears `unsubscribed_at` — not `remember`, which leaves everything
+    the person chose alone, and not any other line in the tree. A reply that
+    named a command would be describing a feature that does not exist, and the
+    only way to discover that is to unsubscribe and try it.
+    """
+    assert COMMAND.search(UNSUBSCRIBED) is None
+
+
+async def test_the_greeting_names_only_what_the_catalog_has() -> None:
+    """`home_sections` returns no things at all — the second element is `[]`
+    and the comment above it says why. Listing materials in the first sentence
+    a new person reads is an invitation to look for a section that is not
+    there."""
+    assert "материал" not in GREETING.lower()
+
+
+async def _person(session: AsyncSession, tg_id: int = 91001) -> User:
+    user = User(
+        tg_id=tg_id,
+        first_name="Азамат",
+        last_name="Алмазбек уулу",
+        tg_username="azamat",
+        ui_lang=UiLang.RU,
+        source="instagram",
+        bot_started_at=datetime.now(UTC),
+    )
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def test_unsubscribing_records_when(session: AsyncSession) -> None:
+    user = await _person(session)
+
+    assert await unsubscribe(session, user.tg_id) is True
+    assert user.unsubscribed_at is not None
+
+
+async def test_unsubscribing_twice_changes_nothing(session: AsyncSession) -> None:
+    """Answers whether it did anything, so a caller can tell "you are now
+    unsubscribed" apart from "you already were" without asking twice."""
+    user = await _person(session)
+    await unsubscribe(session, user.tg_id)
+    first = user.unsubscribed_at
+
+    assert await unsubscribe(session, user.tg_id) is False
+    assert user.unsubscribed_at == first
+
+
+async def test_unsubscribing_somebody_unknown_is_not_an_error(
+    session: AsyncSession,
+) -> None:
+    """A /stop from someone with no row is a person the middleware has not
+    written yet, or an update we never saw the start of. Not a failure."""
+    assert await unsubscribe(session, 91999) is False
+
+
+async def test_unsubscribing_keeps_everything_else(session: AsyncSession) -> None:
+    """The whole point. Opting out of being written to is not leaving, and the
+    row is what makes somebody the same person if they come back."""
+    user = await _person(session)
+    before = {
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "tg_username": user.tg_username,
+        "ui_lang": user.ui_lang,
+        "source": user.source,
+        "bot_started_at": user.bot_started_at,
+        "is_blocked": user.is_blocked,
+    }
+
+    await unsubscribe(session, user.tg_id)
+    await session.flush()
+    # Read back rather than trusted: the assertion is about what landed in the
+    # row, and every attribute here is still in memory until something asks
+    # the database. `refresh` and not `expire`, because an expired attribute
+    # loads on the next read — which, outside an await, is a MissingGreenlet
+    # rather than an answer.
+    await session.refresh(user)
+
+    kept = await session.scalar(select(User).where(User.tg_id == user.tg_id))
+    assert kept is not None
+    assert {key: getattr(kept, key) for key in before} == before
+    assert kept.unsubscribed_at is not None

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,12 +15,16 @@ bot handler and an endpoint both have to get right belongs in `services/`, and
 `services/people.remember` is the pattern: both doors call it, so a person who
 writes to the bot and a person who opens the app are recorded the same way.
 
-**What the bot says is part of what it does.** A sentence telling somebody how
-to undo something is a claim about the code, and it is the kind that rots
-quietly: nobody tests prose, and the person who finds out is the one who tried
-it. So the copy names only what exists — no command that nothing implements, no
-section the catalog cannot show. When a promise and the code disagree, cutting
-the promise is a fix, not a retreat.
+**What we say is part of what we do.** A sentence telling somebody how to undo
+something, or who can see their request, or how fast an answer comes, is a
+claim about the code — and it is the kind that rots quietly, because nobody
+tests prose and the person who finds out is the one who tried it. The rule is
+that copy names only what exists: no command nothing implements, no section the
+catalog cannot show, no filter that does not filter. When a promise and the
+code disagree, cutting the promise is a fix, not a retreat.
+
+The rule is younger than the copy, and the copy has not all been brought to it
+yet — what is still owed is listed at the bottom of this document.
 
 **Opting out keeps everything.** `/stop` writes one timestamp and deletes
 nothing: not the person, not their profile, not their requests or the answers
@@ -244,6 +248,18 @@ finds, and a rule with silent exceptions is worse than no rule.
   `browse.helper_detail` and `search.parse`. Named rather than counted — a
   number here is one nobody remembers to correct, and the last three attempts
   at one were all wrong.
+- **Five sentences in the mini app still claim things the code does not do.**
+  `Request.tsx` says a request is seen by helpers who teach that subject —
+  `requests.feed_for` filters on status, authorship and expiry only, and uses
+  the subject for *ranking*, so every helper sees every open request. The same
+  file promises an answer "usually within a day": nothing tells a helper a
+  request exists, and `response_minutes_avg` is written only by `db/demo.py`.
+  `Profile.tsx` says the spoken languages are used to filter the catalog —
+  `Results.tsx` never sends `langs`, so nothing does. `Ask.tsx` offers
+  filtering in the results list, which has a three-way sort and no filters.
+  `Landing.tsx` still lists materials, which is the section `home_sections`
+  cannot return. Each is a copy change, and each needs somebody to decide
+  whether to cut the sentence or build the thing.
 - **`public.py` still reaches into `app.state`** — for the bot, and for the
   per-process cache of its username. The cache is genuinely app-scoped, so
   this one needs somewhere for that state to live before it can become a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,19 @@ bot handler and an endpoint both have to get right belongs in `services/`, and
 `services/people.remember` is the pattern: both doors call it, so a person who
 writes to the bot and a person who opens the app are recorded the same way.
 
+**What the bot says is part of what it does.** A sentence telling somebody how
+to undo something is a claim about the code, and it is the kind that rots
+quietly: nobody tests prose, and the person who finds out is the one who tried
+it. So the copy names only what exists — no command that nothing implements, no
+section the catalog cannot show. When a promise and the code disagree, cutting
+the promise is a fix, not a retreat.
+
+**Opting out keeps everything.** `/stop` writes one timestamp and deletes
+nothing: not the person, not their profile, not their requests or the answers
+to them. The row is what makes them the same person if they come back, and an
+opt-out that destroyed it would be a worse answer than the blocking it exists
+to prevent.
+
 Nothing here is DDD. There are no aggregates, no repository per model, no
 command bus. This is a catalog with two dozen endpoints, one bot and one
 database; layering it further would cost more than it returns.


### PR DESCRIPTION
Two sentences the bot says were not true of the code.

**`/stop` answered "Передумаешь — /start".** Nothing anywhere clears `unsubscribed_at`: `remember` deliberately leaves alone everything the person chose, and no other line in the tree touches it. So the only way back was to block the bot and unblock it — which is the outcome `/stop` exists to prevent.

The promise is **cut rather than implemented**. A way back is a product decision nobody has made, and a sentence describing a feature that does not exist is worse than no sentence.

**The greeting listed "работы и материалы".** `home_sections` returns no things at all — the second element is `[]`, and the comment above it says why. So the first sentence a new person reads sent them looking for a section that is not there. Materials go back in when there are materials.

## Opting out keeps everything

One timestamp, and nothing else. Not the person, not their profile, not their requests or the answers to them. `people.unsubscribe` is that rule, moved out of the handler, and it answers whether anything changed so a caller can tell "you are now unsubscribed" from "you already were".

The test that matters reads the row back afterwards and compares every other column. Opting out of being written to is not leaving, and the row is what makes somebody the same person if they come back.

## Copy is testable now

Both strings are named constants, because a claim about the code wants somewhere a test can read it.

| test | says |
| --- | --- |
| `test_the_opt_out_reply_offers_no_way_back` | the reply mentions no command — a rule that survives rewording, where `assert "/start" not in ...` would not |
| `test_the_greeting_names_only_what_the_catalog_has` | it does not name a section `home_sections` cannot return |

Each of the three claims fails its own test when reverted, checked one at a time:

| reverted | test that fails |
| --- | --- |
| the `/start` promise comes back | `test_the_opt_out_reply_offers_no_way_back` |
| materials come back | `test_the_greeting_names_only_what_the_catalog_has` |
| unsubscribing twice moves the timestamp | `test_unsubscribing_twice_changes_nothing` |

235 tests green.

Docs updated first: docs/architecture.md