### PR TITLE
Give each priced service its own card

### DIFF
--- a/apps/web/scripts/check-scroll.mjs
+++ b/apps/web/scripts/check-scroll.mjs
@@ -67,8 +67,10 @@ const VIEWPORTS = [
  * screen. A gap left between two cards is above the segmented control at the
  * foot, and no version of this check has ever seen one.
  *
- * `expect` is what stops a rename of either service code from quietly
- * measuring the grid a second time under this screen's name.
+ * `expect` and `expectCount` are what stop a rename of a service code from
+ * quietly measuring something else under this screen's name. Counted, not
+ * merely present: one code renamed still draws the other's card, and a screen
+ * that has lost half of what it was chosen to show measures as fine.
  */
 const ROUTES = [
   { path: '/' },
@@ -88,6 +90,7 @@ const ROUTES = [
       // are on the screen being measured.
       state: { picked: ['tutoring', 'insurance'] },
       expect: '[class*="svcCard"]',
+      expectCount: 2,
     },
   },
   { path: '/my-helper' },
@@ -326,7 +329,14 @@ for (const viewport of VIEWPORTS) {
             },
             [route.into.state, route.into.path],
           );
-          await page.waitForSelector(route.into.expect, { timeout: 5000 });
+          // The exact count, not merely one: half a state that still names
+          // something renders half a screen, and a screen missing one of the
+          // two shapes it was chosen for would otherwise measure as fine.
+          await page.waitForFunction(
+            ([selector, wanted]) => document.querySelectorAll(selector).length === wanted,
+            [route.into.expect, route.into.expectCount],
+            { timeout: 5000 },
+          );
         } else {
           await page.locator(route.into.click).first().click({ timeout: 5000 });
           await page.waitForURL((url) => url.pathname !== route.path, { timeout: 5000 });
@@ -334,19 +344,22 @@ for (const viewport of VIEWPORTS) {
       } catch {
         opened = false;
       }
-      // A screen entered by state is not the empty-list case below: nothing
-      // about the database decides whether it comes up, so failing to reach it
-      // means this check has stopped checking. Recorded and carried on with —
-      // the remaining screens and sizes are still worth measuring, and one
-      // broken entry should not take the whole report down with it.
-      if (!opened && route.into.state) {
-        unreachable.push(
-          `${route.into.name} at ${label}: ${route.into.expect} never appeared` +
-            ` after pushing ${JSON.stringify(route.into.state)}`,
-        );
-      }
       if (opened) {
         await measure(page, route.into.name, label);
+      } else if (route.into.state) {
+        // Not the empty-list case below: nothing about the database decides
+        // whether a screen entered by state comes up, so failing to reach it
+        // means this check has stopped checking. Recorded and carried on with
+        // — the remaining screens and sizes are still worth measuring, and one
+        // broken entry should not take the whole report down with it.
+        console.log(
+          `  DEAD ${route.into.name.padEnd(20)} ${route.into.expect} ×` +
+            `${route.into.expectCount} never appeared`,
+        );
+        unreachable.push(
+          `${route.into.name} at ${label}: expected ${route.into.expectCount} of` +
+            ` ${route.into.expect} after pushing ${JSON.stringify(route.into.state)}`,
+        );
       } else {
         // An empty list is a seeding problem rather than a layout one, so it
         // does not fail the run — but it does mean a screen went unmeasured,
@@ -373,8 +386,8 @@ if (unreachable.length) {
   );
   console.error(
     'A screen entered by router state fails this way when what the state names' +
-      ' no longer exists — a renamed service code, or a rename of the class' +
-      ' `expect` looks for.',
+      ' no longer draws what it drew — a service code renamed or withdrawn, or' +
+      ' a rename of the class `expect` looks for.',
   );
 }
 if (failures.length) {

--- a/apps/web/scripts/check-scroll.mjs
+++ b/apps/web/scripts/check-scroll.mjs
@@ -61,11 +61,14 @@ const VIEWPORTS = [
  * One screen cannot be reached that way at all. `/offer/prices` opens on
  * Telegram's main button, which no browser has, and it redirects to `/offer`
  * without a choice in router state — so it is entered by pushing that state,
- * the same shape the app pushes. Measuring it matters more than the purity of
- * the route: it is the only screen whose spacing comes from a card rather than
- * from the screen, which is where a spacer hides best. `expect` is what stops
- * a rename of either code from quietly measuring the grid a second time under
- * this screen's name.
+ * the same shape the app pushes. Until it was, the screen was not measured at
+ * any size; being measured is the whole of what this buys. What it catches is
+ * what it catches everywhere else: emptiness under the last thing on the
+ * screen. A gap left between two cards is above the segmented control at the
+ * foot, and no version of this check has ever seen one.
+ *
+ * `expect` is what stops a rename of either service code from quietly
+ * measuring the grid a second time under this screen's name.
  */
 const ROUTES = [
   { path: '/' },
@@ -78,6 +81,9 @@ const ROUTES = [
     path: '/offer',
     into: {
       name: '/offer/prices',
+      // Where to push it. `name` is a label — the click routes call themselves
+      // "helper detail" — and a label is not a URL.
+      path: '/offer/prices',
       // One that takes subjects and one that does not, so both shapes of card
       // are on the screen being measured.
       state: { picked: ['tutoring', 'insurance'] },
@@ -99,6 +105,8 @@ const ROUNDING = 4;
 
 const browser = await chromium.launch();
 const failures = [];
+/** Screens that never came up — a broken check, not a thin database. */
+const unreachable = [];
 const skipped = new Set();
 
 /** Stop before measuring anything if the thing being measured is not there. */
@@ -316,7 +324,7 @@ for (const viewport of VIEWPORTS) {
               history.pushState({ usr, key: 'check-scroll', idx: 1 }, '', path);
               dispatchEvent(new PopStateEvent('popstate', { state: history.state }));
             },
-            [route.into.state, route.into.name],
+            [route.into.state, route.into.path],
           );
           await page.waitForSelector(route.into.expect, { timeout: 5000 });
         } else {
@@ -326,17 +334,16 @@ for (const viewport of VIEWPORTS) {
       } catch {
         opened = false;
       }
-      // A screen entered by state has nothing to be empty of: it did not open
-      // because the state no longer names anything, and that is a broken check
-      // rather than a thin database.
+      // A screen entered by state is not the empty-list case below: nothing
+      // about the database decides whether it comes up, so failing to reach it
+      // means this check has stopped checking. Recorded and carried on with —
+      // the remaining screens and sizes are still worth measuring, and one
+      // broken entry should not take the whole report down with it.
       if (!opened && route.into.state) {
-        console.error(
-          `\n${route.into.name} at ${label}: pushed ${JSON.stringify(route.into.state)}` +
-            ` and ${route.into.expect} never appeared.` +
-            '\nThose service codes are reference data — if one was renamed, rename it here too.',
+        unreachable.push(
+          `${route.into.name} at ${label}: ${route.into.expect} never appeared` +
+            ` after pushing ${JSON.stringify(route.into.state)}`,
         );
-        await browser.close();
-        process.exit(2);
       }
       if (opened) {
         await measure(page, route.into.name, label);
@@ -360,12 +367,22 @@ for (const viewport of VIEWPORTS) {
 
 await browser.close();
 
+if (unreachable.length) {
+  console.error(
+    `\n${unreachable.length} screen(s) never came up:\n  ${unreachable.join('\n  ')}`,
+  );
+  console.error(
+    'A screen entered by router state fails this way when what the state names' +
+      ' no longer exists — a renamed service code, or a rename of the class' +
+      ' `expect` looks for.',
+  );
+}
 if (failures.length) {
   console.error(
     `\n${failures.length} screen(s) scroll to nothing:\n  ${failures.join('\n  ')}`,
   );
-  process.exit(1);
 }
+if (failures.length || unreachable.length) process.exit(1);
 if (skipped.size) {
   console.log(`\nNot measured, nothing to open: ${[...skipped].join(', ')}.`);
 }

--- a/apps/web/scripts/check-scroll.mjs
+++ b/apps/web/scripts/check-scroll.mjs
@@ -57,6 +57,15 @@ const VIEWPORTS = [
  * The detail screens are behind an id this script cannot know, so they are
  * reached the way a person reaches them: by tapping the first row of the list
  * that leads there.
+ *
+ * One screen cannot be reached that way at all. `/offer/prices` opens on
+ * Telegram's main button, which no browser has, and it redirects to `/offer`
+ * without a choice in router state — so it is entered by pushing that state,
+ * the same shape the app pushes. Measuring it matters more than the purity of
+ * the route: it is the only screen whose spacing comes from a card rather than
+ * from the screen, which is where a spacer hides best. `expect` is what stops
+ * a rename of either code from quietly measuring the grid a second time under
+ * this screen's name.
  */
 const ROUTES = [
   { path: '/' },
@@ -65,11 +74,16 @@ const ROUTES = [
   { path: '/mine', into: { name: 'request detail', click: 'button[class*="card"]' } },
   { path: '/life' },
   { path: '/profile' },
-  { path: '/offer' },
-  // `/offer/prices` is not here. It is reachable only with a choice in router
-  // state and redirects to `/offer` without one, so measuring it would measure
-  // the grid a second time under a name that lies about which screen was seen.
-
+  {
+    path: '/offer',
+    into: {
+      name: '/offer/prices',
+      // One that takes subjects and one that does not, so both shapes of card
+      // are on the screen being measured.
+      state: { picked: ['tutoring', 'insurance'] },
+      expect: '[class*="svcCard"]',
+    },
+  },
   { path: '/my-helper' },
   { path: '/nope' },
 ];
@@ -296,10 +310,33 @@ for (const viewport of VIEWPORTS) {
     if (route.into) {
       let opened = true;
       try {
-        await page.locator(route.into.click).first().click({ timeout: 5000 });
-        await page.waitForURL((url) => url.pathname !== route.path, { timeout: 5000 });
+        if (route.into.state) {
+          await page.evaluate(
+            ([usr, path]) => {
+              history.pushState({ usr, key: 'check-scroll', idx: 1 }, '', path);
+              dispatchEvent(new PopStateEvent('popstate', { state: history.state }));
+            },
+            [route.into.state, route.into.name],
+          );
+          await page.waitForSelector(route.into.expect, { timeout: 5000 });
+        } else {
+          await page.locator(route.into.click).first().click({ timeout: 5000 });
+          await page.waitForURL((url) => url.pathname !== route.path, { timeout: 5000 });
+        }
       } catch {
         opened = false;
+      }
+      // A screen entered by state has nothing to be empty of: it did not open
+      // because the state no longer names anything, and that is a broken check
+      // rather than a thin database.
+      if (!opened && route.into.state) {
+        console.error(
+          `\n${route.into.name} at ${label}: pushed ${JSON.stringify(route.into.state)}` +
+            ` and ${route.into.expect} never appeared.` +
+            '\nThose service codes are reference data — if one was renamed, rename it here too.',
+        );
+        await browser.close();
+        process.exit(2);
       }
       if (opened) {
         await measure(page, route.into.name, label);

--- a/apps/web/src/components/ServiceGrid.tsx
+++ b/apps/web/src/components/ServiceGrid.tsx
@@ -59,8 +59,11 @@ export function ServiceGrid<T extends ServiceTile>({
 }) {
   return (
     <>
-      {groupRuns(items, (item) => item.group).map(({ key: group, items: tiles }) => (
-        <div key={group}>
+      {groupRuns(items, (item) => item.group).map(({ key: group, items: tiles }, run) => (
+        // Keyed by position: see the note in lib/groups.ts on why a split
+        // group has to survive as two headings.
+        // biome-ignore lint/suspicious/noArrayIndexKey: runs come from the server's order and never reorder in place
+        <div key={run}>
           <Label>
             <ServiceGroupLabel group={group} />
           </Label>

--- a/apps/web/src/components/ServiceGrid.tsx
+++ b/apps/web/src/components/ServiceGrid.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import { iconForService } from '@/components/icons';
 import { ServiceGroupLabel } from '@/components/Phrase';
 import { Cell, Grid, Label, Tile } from '@/components/Ui';
+import { groupRuns } from '@/lib/groups';
 import type { ServiceGroup } from '@/lib/types';
 
 /**
@@ -56,19 +57,9 @@ export function ServiceGrid<T extends ServiceTile>({
   /** Something to say under one group's heading, before its tiles. */
   renderNote?: (group: ServiceGroup) => ReactNode;
 }) {
-  const groups: { group: ServiceGroup; items: T[] }[] = [];
-  for (const item of items) {
-    const last = groups.at(-1);
-    // Contiguous runs, not a lookup: the order the server chose is the order
-    // the screen shows, and a group that came back split would show up as two
-    // headings rather than silently merging into one.
-    if (last && last.group === item.group) last.items.push(item);
-    else groups.push({ group: item.group, items: [item] });
-  }
-
   return (
     <>
-      {groups.map(({ group, items: tiles }) => (
+      {groupRuns(items, (item) => item.group).map(({ key: group, items: tiles }) => (
         <div key={group}>
           <Label>
             <ServiceGroupLabel group={group} />

--- a/apps/web/src/components/ServiceGrid.tsx
+++ b/apps/web/src/components/ServiceGrid.tsx
@@ -59,46 +59,45 @@ export function ServiceGrid<T extends ServiceTile>({
 }) {
   return (
     <>
-      {groupRuns(items, (item) => item.group).map(({ key: group, items: tiles }, run) => (
-        // Keyed by position: see the note in lib/groups.ts on why a split
-        // group has to survive as two headings.
-        // biome-ignore lint/suspicious/noArrayIndexKey: runs come from the server's order and never reorder in place
-        <div key={run}>
-          <Label>
-            <ServiceGroupLabel group={group} />
-          </Label>
-          {renderNote?.(group)}
-          <Grid>
-            {tiles.map((item, index) => {
-              const Icon = iconForService(item.code);
-              const isOn = selected?.has(item.code) ?? false;
-              // Two columns leave an odd group's last tile alone in its row,
-              // which reads as something having failed to load. Widening the
-              // first one makes the count even again — and the wide cell is
-              // the only one with room for faces.
-              const wide = tiles.length % 2 === 1 && index === 0;
-              return (
-                <Cell
-                  key={item.code}
-                  wide={wide}
-                  onClick={() =>
-                    onToggle ? onToggle(item.code) : onPick ? onPick(item) : undefined
-                  }
-                  selected={selected ? isOn : undefined}
-                  leading={
-                    <Tile tone={item.tone}>
-                      <Icon size={19} />
-                    </Tile>
-                  }
-                  title={item.name}
-                  hint={item.hint ?? undefined}
-                  trailing={renderTrailing?.(item, wide)}
-                />
-              );
-            })}
-          </Grid>
-        </div>
-      ))}
+      {groupRuns(items, (item) => item.group).map(
+        ({ id, value: group, items: tiles }) => (
+          <div key={id}>
+            <Label>
+              <ServiceGroupLabel group={group} />
+            </Label>
+            {renderNote?.(group)}
+            <Grid>
+              {tiles.map((item, index) => {
+                const Icon = iconForService(item.code);
+                const isOn = selected?.has(item.code) ?? false;
+                // Two columns leave an odd group's last tile alone in its row,
+                // which reads as something having failed to load. Widening the
+                // first one makes the count even again — and the wide cell is
+                // the only one with room for faces.
+                const wide = tiles.length % 2 === 1 && index === 0;
+                return (
+                  <Cell
+                    key={item.code}
+                    wide={wide}
+                    onClick={() =>
+                      onToggle ? onToggle(item.code) : onPick ? onPick(item) : undefined
+                    }
+                    selected={selected ? isOn : undefined}
+                    leading={
+                      <Tile tone={item.tone}>
+                        <Icon size={19} />
+                      </Tile>
+                    }
+                    title={item.name}
+                    hint={item.hint ?? undefined}
+                    trailing={renderTrailing?.(item, wide)}
+                  />
+                );
+              })}
+            </Grid>
+          </div>
+        ),
+      )}
     </>
   );
 }

--- a/apps/web/src/components/SubjectSearch.tsx
+++ b/apps/web/src/components/SubjectSearch.tsx
@@ -68,7 +68,9 @@ export function SubjectSearch({
         />
       </div>
       {results.length > 0 ? (
-        <div style={{ marginTop: 8 }}>
+        // No margin of its own: the only caller stacks this inside a service
+        // card, and the card spaces everything in it.
+        <div>
           <Rows>
             {results.map((subject) => (
               <Row

--- a/apps/web/src/components/SubjectSearch.tsx
+++ b/apps/web/src/components/SubjectSearch.tsx
@@ -19,6 +19,10 @@ import type { Subject } from '@/lib/types';
  * moving into that page because the next screen that lets someone name a
  * subject will want the same debounce, the same minimum length, and the same
  * idea of what counts as already taken.
+ *
+ * It brings no spacing of its own — no margin above the results, nothing after
+ * the box — because a caller that stacks it with a rule of its own would then
+ * have two answers for one gap. A second caller has to say what the gap is.
  */
 export function SubjectSearch({
   onPick,

--- a/apps/web/src/components/SubjectSearch.tsx
+++ b/apps/web/src/components/SubjectSearch.tsx
@@ -67,24 +67,22 @@ export function SubjectSearch({
           style={{ all: 'unset', flex: 1, minWidth: 0 }}
         />
       </div>
+      {/* No wrapper and no margin of its own: the only caller stacks this
+          inside a service card, and the card spaces everything in it. */}
       {results.length > 0 ? (
-        // No margin of its own: the only caller stacks this inside a service
-        // card, and the card spaces everything in it.
-        <div>
-          <Rows>
-            {results.map((subject) => (
-              <Row
-                key={subject.id}
-                title={subject.name}
-                onClick={() => {
-                  onPick(subject);
-                  setQuery('');
-                  setDebounced('');
-                }}
-              />
-            ))}
-          </Rows>
-        </div>
+        <Rows>
+          {results.map((subject) => (
+            <Row
+              key={subject.id}
+              title={subject.name}
+              onClick={() => {
+                onPick(subject);
+                setQuery('');
+                setDebounced('');
+              }}
+            />
+          ))}
+        </Rows>
       ) : null}
     </>
   );

--- a/apps/web/src/components/SubjectSearch.tsx
+++ b/apps/web/src/components/SubjectSearch.tsx
@@ -2,6 +2,7 @@ import { useLingui } from '@lingui/react/macro';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 
+import { SearchIcon } from '@/components/icons';
 import { Row, Rows, ui } from '@/components/Ui';
 import { api } from '@/lib/api';
 import type { Subject } from '@/lib/types';
@@ -54,13 +55,16 @@ export function SubjectSearch({
   return (
     <>
       <div className={ui.field}>
+        {/* Stacked with the price fields inside a service card, this one has to
+            say at a glance that it is not another price. */}
+        <SearchIcon size={18} className={ui.fieldIcon} />
         <input
           value={query}
           onChange={(event) => setQuery(event.target.value)}
           placeholder={placeholder ?? t`Добавить предмет — матан, čeština, физика`}
           disabled={disabled}
           maxLength={200}
-          style={{ all: 'unset', width: '100%' }}
+          style={{ all: 'unset', flex: 1, minWidth: 0 }}
         />
       </div>
       {results.length > 0 ? (

--- a/apps/web/src/components/ui.module.css
+++ b/apps/web/src/components/ui.module.css
@@ -464,7 +464,10 @@
 /* One offered service on the screen where prices are set.
    Four services in a row of grey labels read as one long list of fields, so
    each gets a box with its own icon — the same icon and the same tone the
-   category wears in the catalog. */
+   category wears in the catalog.
+
+   Not `.card`, which it resembles: that one is a person's listing and is
+   pressed, this one holds inputs and is not. */
 .svcCard {
   padding: 11px 12px 12px;
   border-radius: var(--r-card);
@@ -477,7 +480,12 @@
 
 /* The fields inside drop to the page colour. On --surface they would be the
    same grey as the card and the box would stop reading as a box — which is
-   the entire point of it. */
+   the entire point of it.
+
+   Two classes deep, so this beats any single-class state of .field or .row.
+   A future modifier that paints a background — an error field, a selected
+   row — has to be written to win here, or it will silently lose inside a
+   card. */
 .svcCard .field,
 .svcCard .row {
   background: var(--bg);

--- a/apps/web/src/components/ui.module.css
+++ b/apps/web/src/components/ui.module.css
@@ -459,6 +459,76 @@
   white-space: nowrap;
 }
 
+/* ── service card ───────────────────────────────────────────────────── */
+
+/* One offered service on the screen where prices are set.
+   Four services in a row of grey labels read as one long list of fields, so
+   each gets a box with its own icon — the same icon and the same tone the
+   category wears in the catalog. */
+.svcCard {
+  padding: 11px 12px 12px;
+  border-radius: var(--r-card);
+  background: var(--surface);
+}
+
+.svcCard + .svcCard {
+  margin-top: 9px;
+}
+
+/* The fields inside drop to the page colour. On --surface they would be the
+   same grey as the card and the box would stop reading as a box — which is
+   the entire point of it. */
+.svcCard .field,
+.svcCard .row {
+  background: var(--bg);
+}
+
+.svcCard .row:active {
+  background: var(--surface);
+}
+
+.svcHead {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* min-width:0 so the hint can truncate rather than push the tile off. */
+.svcTitle {
+  flex: 1;
+  min-width: 0;
+}
+
+.svcName {
+  display: block;
+  font-size: 14.5px;
+  font-weight: 660;
+  letter-spacing: -0.015em;
+  line-height: 1.25;
+}
+
+.svcHint {
+  display: block;
+  margin-top: 1px;
+  font-size: 11.5px;
+  line-height: 1.3;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* One rule for everything stacked inside a card — subjects, the search box,
+   the prices — instead of a margin on each, which is how the gaps drifted
+   apart on the screens that came before. */
+.svcBody {
+  margin-top: 10px;
+}
+
+.svcBody > * + * {
+  margin-top: 8px;
+}
+
 /* ── sheet ──────────────────────────────────────────────────────────── */
 
 .scrim {

--- a/apps/web/src/components/ui.module.css
+++ b/apps/web/src/components/ui.module.css
@@ -466,8 +466,10 @@
    each gets a box with its own icon — the same icon and the same tone the
    category wears in the catalog.
 
-   Not `.card`, which it resembles: that one is a person's listing and is
-   pressed, this one holds inputs and is not. */
+   It is a paler twin of `.card` — a hair less padding at the top — and stays
+   a class of its own for the sake of the two rules below, which re-skin what
+   is inside. Written as `.card .field` they would reach the fields in every
+   card on every other screen. */
 .svcCard {
   padding: 11px 12px 12px;
   border-radius: var(--r-card);

--- a/apps/web/src/components/ui.module.css
+++ b/apps/web/src/components/ui.module.css
@@ -466,10 +466,10 @@
    each gets a box with its own icon — the same icon and the same tone the
    category wears in the catalog.
 
-   It is a paler twin of `.card` — a hair less padding at the top — and stays
-   a class of its own for the sake of the two rules below, which re-skin what
-   is inside. Written as `.card .field` they would reach the fields in every
-   card on every other screen. */
+   It is `.card` with a hair less padding at the top, and stays a class of its
+   own for the sake of the two rules below, which re-skin what is inside.
+   Written as `.card .field` they would reach the fields in every card on
+   every other screen. */
 .svcCard {
   padding: 11px 12px 12px;
   border-radius: var(--r-card);
@@ -494,8 +494,10 @@
   background: var(--bg);
 }
 
+/* --surface-pressed, not --surface: that is the card's own colour, and a row
+   that becomes the card under the finger reads as having vanished. */
 .svcCard .row:active {
-  background: var(--surface);
+  background: var(--surface-pressed);
 }
 
 /* The head is a row without the row: a tile, a name, a hint. It borrows

--- a/apps/web/src/components/ui.module.css
+++ b/apps/web/src/components/ui.module.css
@@ -482,10 +482,11 @@
    same grey as the card and the box would stop reading as a box — which is
    the entire point of it.
 
-   Two classes deep, so this beats any single-class state of .field or .row.
-   A future modifier that paints a background — an error field, a selected
-   row — has to be written to win here, or it will silently lose inside a
-   card. */
+   These are two classes deep, which ties with a single-class state like
+   `.row:active` rather than beating it — the tie goes to whichever comes
+   last in this file. That is why the pressed colour is restated here, and
+   why a `:hover` or `:focus` on .field or .row written *below* this block
+   would quietly win inside a card. */
 .svcCard .field,
 .svcCard .row {
   background: var(--bg);
@@ -495,35 +496,14 @@
   background: var(--surface);
 }
 
+/* The head is a row without the row: a tile, a name, a hint. It borrows
+   .rowBody, .rowName and .rowHint rather than restating them at slightly
+   different weights, which is how three near-identical title styles would
+   have ended up in one file. */
 .svcHead {
   display: flex;
   align-items: center;
   gap: 10px;
-}
-
-/* min-width:0 so the hint can truncate rather than push the tile off. */
-.svcTitle {
-  flex: 1;
-  min-width: 0;
-}
-
-.svcName {
-  display: block;
-  font-size: 14.5px;
-  font-weight: 660;
-  letter-spacing: -0.015em;
-  line-height: 1.25;
-}
-
-.svcHint {
-  display: block;
-  margin-top: 1px;
-  font-size: 11.5px;
-  line-height: 1.3;
-  color: var(--muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 /* One rule for everything stacked inside a card — subjects, the search box,

--- a/apps/web/src/lib/groups.ts
+++ b/apps/web/src/lib/groups.ts
@@ -1,0 +1,22 @@
+/**
+ * Contiguous runs of items that share a key.
+ *
+ * Two screens show kinds of help under their group heading — the grid of
+ * tiles and the screen where prices are set — and both take the order the
+ * server chose rather than sorting again here. Runs, not a lookup: a group
+ * that came back split shows up as two headings instead of silently merging
+ * into one, which is the honest rendering of a server that has gone wrong.
+ */
+export function groupRuns<T, K>(
+  items: T[],
+  keyOf: (item: T) => K,
+): { key: K; items: T[] }[] {
+  const runs: { key: K; items: T[] }[] = [];
+  for (const item of items) {
+    const key = keyOf(item);
+    const last = runs.at(-1);
+    if (last && last.key === key) last.items.push(item);
+    else runs.push({ key, items: [item] });
+  }
+  return runs;
+}

--- a/apps/web/src/lib/groups.ts
+++ b/apps/web/src/lib/groups.ts
@@ -1,9 +1,12 @@
 /**
  * Contiguous runs of items that share a key.
  *
- * Two screens show kinds of help under their group heading — the grid of
- * tiles and the screen where prices are set — and both take the order the
- * server chose rather than sorting again here. Runs, not a lookup: a group
+ * Kinds of help appear under their group heading in two components — the
+ * grid of tiles, which draws the home screen and the screen where a service
+ * is offered, and the screen where prices are set. All of them take the
+ * order the server chose rather than sorting again here.
+ *
+ * Runs, not a lookup: a group
  * that came back split shows up as two headings instead of silently merging
  * into one, which is the honest rendering of a server that has gone wrong.
  *
@@ -11,7 +14,9 @@
  * a split group would otherwise hand React the same key twice, and the two
  * honest headings would collapse back into a warning.
  */
-export function groupRuns<T, K>(
+// The key is compared with ===, so it has to be something that compares by
+// value. An object would give one run per item and no complaint.
+export function groupRuns<T, K extends PropertyKey>(
   items: T[],
   keyOf: (item: T) => K,
 ): { key: K; items: T[] }[] {

--- a/apps/web/src/lib/groups.ts
+++ b/apps/web/src/lib/groups.ts
@@ -1,31 +1,40 @@
 /**
  * Contiguous runs of items that share a key.
  *
- * Kinds of help appear under their group heading in two components — the
- * grid of tiles, which draws the home screen and the screen where a service
- * is offered, and the screen where prices are set. All of them take the
- * order the server chose rather than sorting again here.
+ * Kinds of help appear under their group heading in two components — the grid
+ * of tiles, which draws the home screen and the screen where a service is
+ * offered, and the screen where prices are set. All of them take the order the
+ * server chose rather than sorting again here.
  *
- * Runs, not a lookup: a group
- * that came back split shows up as two headings instead of silently merging
- * into one, which is the honest rendering of a server that has gone wrong.
- *
- * That is also why callers key the list by position and not by the group:
- * a split group would otherwise hand React the same key twice, and the two
- * honest headings would collapse back into a warning.
+ * Runs, not a lookup: a group that came back split shows up as two headings
+ * instead of silently merging into one, which is the honest rendering of a
+ * server that has gone wrong.
  */
-// The key is compared with ===, so it has to be something that compares by
-// value. An object would give one run per item and no complaint.
+export interface Run<T, K> {
+  /** What every item in the run has in common. */
+  value: K;
+  /**
+   * What to give React. One per run rather than one per value, because the
+   * split group above has to survive as two headings — keyed by the value
+   * alone it would hand React the same key twice and collapse into a warning.
+   */
+  id: string;
+  items: T[];
+}
+
+// Runs are merged with ===, so the key is constrained to something that
+// compares by value. Without that bound an object key would type-check and
+// then give one run per item.
 export function groupRuns<T, K extends PropertyKey>(
   items: T[],
   keyOf: (item: T) => K,
-): { key: K; items: T[] }[] {
-  const runs: { key: K; items: T[] }[] = [];
+): Run<T, K>[] {
+  const runs: Run<T, K>[] = [];
   for (const item of items) {
-    const key = keyOf(item);
+    const value = keyOf(item);
     const last = runs.at(-1);
-    if (last && last.key === key) last.items.push(item);
-    else runs.push({ key, items: [item] });
+    if (last && last.value === value) last.items.push(item);
+    else runs.push({ value, id: `${String(value)}#${runs.length}`, items: [item] });
   }
   return runs;
 }

--- a/apps/web/src/lib/groups.ts
+++ b/apps/web/src/lib/groups.ts
@@ -6,6 +6,10 @@
  * server chose rather than sorting again here. Runs, not a lookup: a group
  * that came back split shows up as two headings instead of silently merging
  * into one, which is the honest rendering of a server that has gone wrong.
+ *
+ * That is also why callers key the list by position and not by the group:
+ * a split group would otherwise hand React the same key twice, and the two
+ * honest headings would collapse back into a warning.
  */
 export function groupRuns<T, K>(
   items: T[],

--- a/apps/web/src/pages/OfferPrices.tsx
+++ b/apps/web/src/pages/OfferPrices.tsx
@@ -211,11 +211,8 @@ export default function OfferPricesPage() {
         </div>
       ) : (
         <>
-          {groupRuns(chosen, (type) => type.group).map(({ key: group, items }, run) => (
-            // Keyed by position: see the note in lib/groups.ts on why a split
-            // group has to survive as two headings.
-            // biome-ignore lint/suspicious/noArrayIndexKey: runs come from the server's order and never reorder in place
-            <div key={run}>
+          {groupRuns(chosen, (type) => type.group).map(({ id, value: group, items }) => (
+            <div key={id}>
               <Label>
                 <ServiceGroupLabel group={group} />
               </Label>

--- a/apps/web/src/pages/OfferPrices.tsx
+++ b/apps/web/src/pages/OfferPrices.tsx
@@ -216,7 +216,7 @@ export default function OfferPricesPage() {
             // group has to survive as two headings.
             // biome-ignore lint/suspicious/noArrayIndexKey: runs come from the server's order and never reorder in place
             <div key={run}>
-              <Label aside={items.length}>
+              <Label>
                 <ServiceGroupLabel group={group} />
               </Label>
               {items.map((type) => {
@@ -231,10 +231,10 @@ export default function OfferPricesPage() {
                       <Tile tone={type.tone}>
                         <Icon size={19} />
                       </Tile>
-                      <span className={ui.svcTitle}>
-                        <span className={ui.svcName}>{type.name}</span>
+                      <span className={ui.rowBody}>
+                        <span className={ui.rowName}>{type.name}</span>
                         {type.hint ? (
-                          <span className={ui.svcHint}>{type.hint}</span>
+                          <span className={ui.rowHint}>{type.hint}</span>
                         ) : null}
                       </span>
                     </div>

--- a/apps/web/src/pages/OfferPrices.tsx
+++ b/apps/web/src/pages/OfferPrices.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router';
 
 import { AppHeader } from '@/components/AppHeader';
+import { iconForService } from '@/components/icons';
+import { ServiceGroupLabel } from '@/components/Phrase';
 import { SubjectSearch } from '@/components/SubjectSearch';
 import {
   Chips,
@@ -15,11 +17,13 @@ import {
   Segmented,
   SkeletonRows,
   Sub,
+  Tile,
   Title,
   ui,
 } from '@/components/Ui';
 import { hapticSelection, hapticSuccess, useMainButton } from '@/hooks/useTelegram';
 import { api } from '@/lib/api';
+import { groupRuns } from '@/lib/groups';
 import type {
   MyOffer,
   OfferInput,
@@ -69,15 +73,15 @@ export default function OfferPricesPage() {
   const [workFormat, setWorkFormat] = useState<WorkFormat>('both');
   const [loaded, setLoaded] = useState(false);
 
-  const chosen = useMemo(
-    () =>
-      picked && serviceTypes
-        ? picked
-            .map((code) => serviceTypes.find((type) => type.code === code))
-            .filter((type): type is ServiceType => type !== undefined)
-        : [],
-    [picked, serviceTypes],
-  );
+  // In the catalog's order, not the order the tiles happened to be tapped.
+  // The headings below are contiguous runs of the group field, so a person who
+  // ticked insurance first and tutoring second would otherwise get «Документы и
+  // жизнь» above «Учёба» — and two headings if they went back for a third.
+  const chosen = useMemo(() => {
+    if (!picked || !serviceTypes) return [];
+    const wanted = new Set(picked);
+    return serviceTypes.filter((type) => wanted.has(type.code));
+  }, [picked, serviceTypes]);
 
   // Filled once. Whatever the person already offers is carried in, so a save
   // that replaces the whole list does not throw away the prices they set last
@@ -207,85 +211,106 @@ export default function OfferPricesPage() {
         </div>
       ) : (
         <>
-          {chosen.map((type) => {
-            const mineHere = rows.filter((row) => row.service_type_id === type.id);
-            return (
-              <div key={type.id}>
-                <Label>{type.name}</Label>
+          {groupRuns(chosen, (type) => type.group).map(({ key: group, items }) => (
+            <div key={group}>
+              <Label aside={items.length}>
+                <ServiceGroupLabel group={group} />
+              </Label>
+              {items.map((type) => {
+                const mineHere = rows.filter((row) => row.service_type_id === type.id);
+                const Icon = iconForService(type.code);
+                return (
+                  // A box each, with the icon and the colour the category wears
+                  // everywhere else. Four services under four grey labels read
+                  // as one long list of fields belonging to nothing.
+                  <div key={type.id} className={ui.svcCard}>
+                    <div className={ui.svcHead}>
+                      <Tile tone={type.tone}>
+                        <Icon size={19} />
+                      </Tile>
+                      <span className={ui.svcTitle}>
+                        <span className={ui.svcName}>{type.name}</span>
+                        {type.hint ? (
+                          <span className={ui.svcHint}>{type.hint}</span>
+                        ) : null}
+                      </span>
+                    </div>
 
-                {type.requires_subject ? (
-                  <>
-                    {mineHere.some((row) => row.subject_id !== null) ? (
-                      <div style={{ marginBottom: 8 }}>
-                        <Chips>
-                          {mineHere
-                            .filter((row) => row.subject_id !== null)
-                            .map((row) => (
-                              <ChipView
-                                key={row.key}
-                                active
-                                removeLabel={t`Убрать`}
-                                onRemove={() =>
-                                  setRows((current) => {
-                                    const left = current.filter(
-                                      (other) => other.key !== row.key,
-                                    );
-                                    // Removing the last subject must not remove
-                                    // the service: the person ticked it, and a
-                                    // service with no subject is one search
-                                    // cannot reach yet, not one they withdrew.
-                                    return left.some(
-                                      (other) => other.service_type_id === type.id,
-                                    )
-                                      ? left
-                                      : [...left, blank(type)];
-                                  })
-                                }
-                              >
-                                {row.subject_name}
-                              </ChipView>
-                            ))}
-                        </Chips>
-                      </div>
-                    ) : null}
-                    <SubjectSearch
-                      onPick={(subject) => addSubject(type, subject)}
-                      taken={new Set(mineHere.map((row) => row.subject_id))}
-                    />
-                    <div style={{ height: 8 }} />
-                  </>
-                ) : null}
+                    <div className={ui.svcBody}>
+                      {type.requires_subject ? (
+                        <>
+                          {mineHere.some((row) => row.subject_id !== null) ? (
+                            <Chips>
+                              {mineHere
+                                .filter((row) => row.subject_id !== null)
+                                .map((row) => (
+                                  <ChipView
+                                    key={row.key}
+                                    active
+                                    removeLabel={t`Убрать`}
+                                    onRemove={() =>
+                                      setRows((current) => {
+                                        const left = current.filter(
+                                          (other) => other.key !== row.key,
+                                        );
+                                        // Removing the last subject must not
+                                        // remove the service: the person ticked
+                                        // it, and a service with no subject is
+                                        // one search cannot reach yet, not one
+                                        // they withdrew.
+                                        return left.some(
+                                          (other) => other.service_type_id === type.id,
+                                        )
+                                          ? left
+                                          : [...left, blank(type)];
+                                      })
+                                    }
+                                  >
+                                    {row.subject_name}
+                                  </ChipView>
+                                ))}
+                            </Chips>
+                          ) : null}
+                          <SubjectSearch
+                            onPick={(subject) => addSubject(type, subject)}
+                            taken={new Set(mineHere.map((row) => row.subject_id))}
+                          />
+                        </>
+                      ) : null}
 
-                {/* One price per row, not per service. A tutor really does
-                    charge 500 for calculus and 700 for physics, and a single
-                    field for the pair rewrites both the first time either is
-                    touched. The subject names the line when there is more than
-                    one. */}
-                {mineHere.map((row) => (
-                  <PriceRow
-                    key={row.key}
-                    name={mineHere.length > 1 ? row.subject_name : null}
-                    value={row.price}
-                    unit={row.unit}
-                    onPrice={(price) =>
-                      setRows((current) =>
-                        current.map((other) =>
-                          other.key === row.key ? { ...other, price } : other,
-                        ),
-                      )
-                    }
-                    onUnit={(unit) =>
-                      setRows((current) =>
-                        current.map((other) =>
-                          other.key === row.key ? { ...other, unit } : other,
-                        ),
-                      )
-                    }
-                  />
-                ))}
-              </div>
-            );
-          })}
+                      {/* One price per row, not per service. A tutor really
+                          does charge 500 for calculus and 700 for physics, and
+                          a single field for the pair rewrites both the first
+                          time either is touched. The subject names the line
+                          when there is more than one. */}
+                      {mineHere.map((row) => (
+                        <PriceRow
+                          key={row.key}
+                          name={mineHere.length > 1 ? row.subject_name : null}
+                          value={row.price}
+                          unit={row.unit}
+                          onPrice={(price) =>
+                            setRows((current) =>
+                              current.map((other) =>
+                                other.key === row.key ? { ...other, price } : other,
+                              ),
+                            )
+                          }
+                          onUnit={(unit) =>
+                            setRows((current) =>
+                              current.map((other) =>
+                                other.key === row.key ? { ...other, unit } : other,
+                              ),
+                            )
+                          }
+                        />
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ))}
 
           <Label>
             <Trans>Как занимаешься</Trans>
@@ -359,7 +384,8 @@ function PriceRow({
   ];
 
   return (
-    <div className={ui.field} style={{ marginTop: 8 }}>
+    // No margin of its own: everything inside a card is spaced by the card.
+    <div className={ui.field}>
       {name ? (
         <span
           style={{

--- a/apps/web/src/pages/OfferPrices.tsx
+++ b/apps/web/src/pages/OfferPrices.tsx
@@ -211,8 +211,11 @@ export default function OfferPricesPage() {
         </div>
       ) : (
         <>
-          {groupRuns(chosen, (type) => type.group).map(({ key: group, items }) => (
-            <div key={group}>
+          {groupRuns(chosen, (type) => type.group).map(({ key: group, items }, run) => (
+            // Keyed by position: see the note in lib/groups.ts on why a split
+            // group has to survive as two headings.
+            // biome-ignore lint/suspicious/noArrayIndexKey: runs come from the server's order and never reorder in place
+            <div key={run}>
               <Label aside={items.length}>
                 <ServiceGroupLabel group={group} />
               </Label>


### PR DESCRIPTION
Each chosen service on the prices screen is a card now, carrying the icon and the tone the category already wears in the catalog and on the grid where it was ticked. Cards sit under their group heading — «Учёба», «Экзамены и поступление», «Документы и жизнь». Before this, four services were four grey labels and read as one column of fields belonging to nothing.

The variant was chosen from three mockups; this is the one the user picked.

Two things had to move for the grouping to hold. The screen takes the catalog's order rather than the order the tiles happened to be tapped, because the headings are contiguous runs of the group field — somebody who ticked insurance before tutoring would otherwise have seen «Документы и жизнь» first, and two «Учёба» headings if they went back for a third. And the run-splitting moved to `apps/web/src/lib/groups.ts`, because the tile grid does the same thing for the same reason and two copies drift the first time a group is renamed.

`/offer/prices` was never measured by the layout check: it opens on Telegram's main button, which no browser has, and redirects to `/offer` without a choice in router state. It is now entered by pushing that state, which is the only screen this change touches and the only one that was going out on screenshots alone.

Docs not applicable: visual composition of an existing screen — `docs/` describes the architecture, the data model and deployment, names no screen, and no rule changed here.

Verified: `pnpm lint`, `pnpm typecheck`, `pnpm build`, and `pnpm check:scroll` at 390x664, 360x640 and 390x568, all green. The new scroll entry was proven to bite twice — a 40px trailing spacer put back on the screen fails at all three sizes, and pointing the pushed state at a service code that does not exist reports DEAD and exits 1. Screenshots taken at 390px in both themes.

Six independent review rounds; the last returned no findings. Between them they caught: the scroll entry's justification claiming it could see a gap between two cards when it can only see the foot of the screen; `expect` satisfied by one card when two were named, so renaming one code would have measured a half-empty screen as fine; a broken state route printing "nothing to open", which is the empty-database message; the pressed colour inside a card being the card's own colour; the group runs keyed by the group, which hands React the same key twice exactly when the helper promises two honest headings; and three comments claiming more than the code does.

Out of scope, carried forward:

- CI does not check that `src/lib/generated` matches the OpenAPI document.
- `requires_institution` is read by nothing — there is no institution picker anywhere, so `entrance_prep` can only be offered without a school.
- Avatar stacks appear only in the wide cell, so the four-tile «Учёба» shelf never shows faces.
- `test_health.py` does not pin the `elsewhere: <url>` webhook state.
- The function-level `services.lookup` import in `api/v1/taxonomy.py` is still not hoisted.
- The subject chips inside a card stayed green (`chipOn`); the mockup showed them neutral. Changing what a chip's colour means is a decision of its own.
- The per-group count beside each heading, which was in the approved mockup, is not here: a bare digit next to a word reads as "Учёба 3" to a screen reader with nothing saying what is counted, and the same headings on the tile grid carry none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL
