### PR TITLE
Say what the search will return, before it returns it

### DIFF
--- a/apps/api/src/students_cz/api/v1/search.py
+++ b/apps/api/src/students_cz/api/v1/search.py
@@ -99,10 +99,12 @@ async def parse_query(
             )
         )
 
-    # Every filter the parse produced, the budget included. The screen shows a
-    # chip for it and then this number; leaving it out counts people the next
-    # screen will not list, and writes that same number into `search_queries`,
-    # where a result for a query nobody ran is worse than no row at all.
+    # Every parsed filter the search can apply, the budget included. Leaving one
+    # out counts people this query does not reach, and writes that number into
+    # `search_queries`, where a result for a query nobody ran is worse than no
+    # row at all. The deadline is the exception that cannot be honoured: there is
+    # no date filter to pass it to, so a query saying nothing but a date counts
+    # the whole catalog — see docs/data-model.md.
     total, _ = await catalog.search(
         session,
         lang,

--- a/apps/api/src/students_cz/api/v1/search.py
+++ b/apps/api/src/students_cz/api/v1/search.py
@@ -99,6 +99,10 @@ async def parse_query(
             )
         )
 
+    # Every filter the parse produced, the budget included. The screen shows a
+    # chip for it and then this number; leaving it out counts people the next
+    # screen will not list, and writes that same number into `search_queries`,
+    # where a result for a query nobody ran is worse than no row at all.
     total, _ = await catalog.search(
         session,
         lang,
@@ -106,6 +110,7 @@ async def parse_query(
         subject_id=parsed.subject.id if parsed.subject else None,
         institution_id=parsed.institution.id if parsed.institution else None,
         service_type_id=service_type_id,
+        max_price=parsed.budget_max,
         limit=1,
     )
 

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -202,6 +202,59 @@ async def test_clarify_is_asked_only_when_it_narrows(client):
     assert unnamed["clarify"]["code"] == "clarify.when"
 
 
+async def test_parse_counts_only_what_the_search_will_show(
+    client, helper_factory, session
+):
+    """The number promised is the number delivered.
+
+    The screen shows a budget chip and then a count. Computing that count
+    without the budget promises people who will not be in the list, and writes
+    the same wrong number into `search_queries.results_count`, which is read as
+    the ranked list of what the catalog is missing.
+    """
+    from sqlalchemy import select
+
+    from students_cz.db.models import Subject
+
+    await helper_factory(tg_id=91021, first_name="Cheap", price=400)
+    await helper_factory(tg_id=91022, first_name="Dear", price=900)
+    await session.flush()
+
+    body = (
+        await client.post(
+            "/api/v1/search/parse",
+            json={"text": "матан до 500 крон"},
+            headers=auth_header(90121),
+        )
+    ).json()
+
+    budget = [c for c in body["chips"] if c["kind"] == "budget"]
+    assert budget and budget[0]["value"] == 500, body["chips"]
+
+    # Against the search itself rather than a literal, because the seed brings
+    # its own helpers on this subject and any fixed number would be a statement
+    # about the seed. What is being pinned is that the two agree.
+    subject = await session.scalar(
+        select(Subject).where(Subject.slug == "matematicka-analyza")
+    )
+    params = {"subject_id": subject.id}
+    listed = (
+        await client.get(
+            "/api/v1/search",
+            params={**params, "max_price": 500},
+            headers=auth_header(90121),
+        )
+    ).json()
+    assert body["matches"] == listed["total"]
+
+    # And the filter has to be doing something, or the assertion above would
+    # hold just as well with the bug in place. `Dear` costs 900.
+    everyone = (
+        await client.get("/api/v1/search", params=params, headers=auth_header(90121))
+    ).json()
+    assert listed["total"] < everyone["total"]
+
+
 async def test_search_finds_a_published_helper(client, helper_factory, session):
     await helper_factory(tg_id=91001, first_name="Marek", deals=8)
     await session.flush()

--- a/apps/web/src/components/HelperCard.tsx
+++ b/apps/web/src/components/HelperCard.tsx
@@ -1,0 +1,61 @@
+import { PhraseView, PriceUnitLabel } from '@/components/Phrase';
+import { AvatarView, Card, Free, PriceView, Reason } from '@/components/Ui';
+import type { HelperCard } from '@/lib/types';
+
+/**
+ * One person, as a card.
+ *
+ * Drawn by the results list and by the preview on the search screen, which is
+ * the reason it left `Results.tsx`: the preview exists to show what the list
+ * will contain, and two copies of this markup would eventually show something
+ * else.
+ */
+export function HelperCardView({
+  card,
+  locale,
+  onClick,
+}: {
+  card: HelperCard;
+  locale: string;
+  onClick: () => void;
+}) {
+  // "Cheaper but unproven" is the one reason that should not wear the same
+  // confident green dot as the others.
+  const weak = card.reason?.code === 'reason.cheapest_but_unproven';
+
+  return (
+    <Card onClick={onClick}>
+      <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+        <AvatarView avatar={card.avatar} size={40} square />
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontSize: 14.5, fontWeight: 680, letterSpacing: '-0.015em' }}>
+            {card.name}
+          </div>
+          {card.affiliation ? (
+            <div style={{ marginTop: 2, fontSize: 12, color: 'var(--muted)' }}>
+              {card.affiliation}
+            </div>
+          ) : null}
+        </div>
+        {card.price ? (
+          <PriceView
+            price={card.price}
+            unitLabel={<PriceUnitLabel unit={card.price.unit} />}
+          />
+        ) : null}
+      </div>
+
+      {card.reason ? (
+        <Reason weak={weak}>
+          <PhraseView phrase={card.reason} locale={locale} />
+        </Reason>
+      ) : null}
+
+      {card.availability ? (
+        <Free>
+          <PhraseView phrase={card.availability} locale={locale} />
+        </Free>
+      ) : null}
+    </Card>
+  );
+}

--- a/apps/web/src/hooks/useSearchFilters.ts
+++ b/apps/web/src/hooks/useSearchFilters.ts
@@ -23,10 +23,12 @@ export function useSearchFilters(query: string | URLSearchParams): {
   filters: SearchParams | null;
   isError: boolean;
 } {
-  const params = useMemo(
-    () => (typeof query === 'string' ? new URLSearchParams(query) : query),
-    [query],
-  );
+  // The string is the input, whichever shape it arrived in: one caller builds a
+  // fresh URLSearchParams on every render, and that object is a new identity
+  // each time even when nothing about the query changed.
+  const key = typeof query === 'string' ? query : query.toString();
+  const params = useMemo(() => new URLSearchParams(key), [key]);
+
   const code = params.get('service');
   // An explicit id in the query string is already the answer, so a code beside
   // it is nothing to wait for. Without this a link carrying both would block on
@@ -40,22 +42,17 @@ export function useSearchFilters(query: string | URLSearchParams): {
     enabled: lookup !== null,
   });
 
-  // Depends on the string rather than on the URLSearchParams object, which is a
-  // new identity on every render of a screen that builds one.
-  const key = params.toString();
-
   const filters = useMemo(() => {
-    const read = new URLSearchParams(key);
     const byCode = lookup ? data?.find((type) => type.code === lookup)?.id : undefined;
     if (lookup && byCode === undefined) return null;
 
     return {
-      subject_id: numeric(read.get('subject_id')),
-      institution_id: numeric(read.get('institution_id')),
-      service_type_id: numeric(read.get('service_type_id')) ?? byCode,
-      max_price: numeric(read.get('max_price')),
+      subject_id: numeric(params.get('subject_id')),
+      institution_id: numeric(params.get('institution_id')),
+      service_type_id: numeric(params.get('service_type_id')) ?? byCode,
+      max_price: numeric(params.get('max_price')),
     };
-  }, [key, lookup, data]);
+  }, [params, lookup, data]);
 
   // Only when this hook is the one that asked. `['service-types']` is a key
   // several screens share, so an unguarded flag would hand a failure caused by

--- a/apps/web/src/hooks/useSearchFilters.ts
+++ b/apps/web/src/hooks/useSearchFilters.ts
@@ -28,12 +28,16 @@ export function useSearchFilters(query: string | URLSearchParams): {
     [query],
   );
   const code = params.get('service');
+  // An explicit id in the query string is already the answer, so a code beside
+  // it is nothing to wait for. Without this a link carrying both would block on
+  // a lookup it does not need, and fail with it.
+  const lookup = code && !params.get('service_type_id') ? code : null;
 
   const { data, isError } = useQuery({
     queryKey: ['service-types'],
     queryFn: ({ signal }) => api.getServiceTypes(signal),
     staleTime: 60 * 60 * 1000,
-    enabled: Boolean(code),
+    enabled: lookup !== null,
   });
 
   // Depends on the string rather than on the URLSearchParams object, which is a
@@ -42,8 +46,8 @@ export function useSearchFilters(query: string | URLSearchParams): {
 
   const filters = useMemo(() => {
     const read = new URLSearchParams(key);
-    const byCode = code ? data?.find((type) => type.code === code)?.id : undefined;
-    if (code && byCode === undefined) return null;
+    const byCode = lookup ? data?.find((type) => type.code === lookup)?.id : undefined;
+    if (lookup && byCode === undefined) return null;
 
     return {
       subject_id: numeric(read.get('subject_id')),
@@ -51,9 +55,13 @@ export function useSearchFilters(query: string | URLSearchParams): {
       service_type_id: numeric(read.get('service_type_id')) ?? byCode,
       max_price: numeric(read.get('max_price')),
     };
-  }, [key, code, data]);
+  }, [key, lookup, data]);
 
-  return { filters, isError };
+  // Only when this hook is the one that asked. `['service-types']` is a key
+  // several screens share, so an unguarded flag would hand a failure caused by
+  // the offer screen to a search that needs no reference data at all — and both
+  // screens would report a failure while their own request had succeeded.
+  return { filters, isError: isError && lookup !== null };
 }
 
 function numeric(value: string | null): number | undefined {

--- a/apps/web/src/hooks/useSearchFilters.ts
+++ b/apps/web/src/hooks/useSearchFilters.ts
@@ -1,0 +1,63 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { api } from '@/lib/api';
+import type { SearchParams } from '@/lib/types';
+
+/**
+ * The filters a query string describes, as the search endpoint takes them.
+ *
+ * Shared by the two screens that read the same query string: the search screen,
+ * which shows how many people it finds and the first two of them, and the
+ * results screen, which lists them. Those two numbers have to be the same
+ * number — that is the whole point of showing one at all — and a second copy of
+ * this mapping is the way they would stop being.
+ *
+ * The clarifying answer travels as a service *code* rather than an id, because
+ * the screen that asks the question has no reason to hold the reference list.
+ * Resolving it needs that list, so `filters` is null until it is here: filtering
+ * by nothing instead would count everyone who teaches the subject and then hand
+ * over to a screen that does apply the filter.
+ */
+export function useSearchFilters(query: string | URLSearchParams): {
+  filters: SearchParams | null;
+  isError: boolean;
+} {
+  const params = useMemo(
+    () => (typeof query === 'string' ? new URLSearchParams(query) : query),
+    [query],
+  );
+  const code = params.get('service');
+
+  const { data, isError } = useQuery({
+    queryKey: ['service-types'],
+    queryFn: ({ signal }) => api.getServiceTypes(signal),
+    staleTime: 60 * 60 * 1000,
+    enabled: Boolean(code),
+  });
+
+  // Depends on the string rather than on the URLSearchParams object, which is a
+  // new identity on every render of a screen that builds one.
+  const key = params.toString();
+
+  const filters = useMemo(() => {
+    const read = new URLSearchParams(key);
+    const byCode = code ? data?.find((type) => type.code === code)?.id : undefined;
+    if (code && byCode === undefined) return null;
+
+    return {
+      subject_id: numeric(read.get('subject_id')),
+      institution_id: numeric(read.get('institution_id')),
+      service_type_id: numeric(read.get('service_type_id')) ?? byCode,
+      max_price: numeric(read.get('max_price')),
+    };
+  }, [key, code, data]);
+
+  return { filters, isError };
+}
+
+function numeric(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}

--- a/apps/web/src/locales/cs/messages.po
+++ b/apps/web/src/locales/cs/messages.po
@@ -52,9 +52,17 @@ msgstr "Zkontroluj připojení a zkus to znovu."
 msgid "Онлайн"
 msgstr "Online"
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Напиши хотя бы пару предложений — предметы, цену и как удобно заниматься."
+#~ msgstr "Napiš aspoň pár vět — jaké předměty, za kolik a jak ti vyhovuje mít hodiny."
+
 #: src/pages/Request.tsx
 msgid "Такой заявки нет"
 msgstr "Taková poptávka neexistuje"
+
+#: src/pages/Ask.tsx
+msgid "Добавь предмет — по одному сроку искать нечего."
+msgstr "Přidej předmět — podle samotného termínu není co hledat."
 
 #: src/pages/Landing.tsx
 msgid "Přijímačky"
@@ -67,6 +75,10 @@ msgstr "Viditelnost"
 #: src/components/TabBar.tsx
 msgid "Поиск"
 msgstr "Hledat"
+
+#: src/pages/MyHelper.tsx
+#~ msgid "Предметы и цены"
+#~ msgstr "Předměty a ceny"
 
 #: src/components/Incoming.tsx
 msgid "Не сейчас"
@@ -106,6 +118,10 @@ msgstr "za týden"
 msgid "Откликнуться"
 msgstr "Odpovědět"
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Когда ты свободен"
+#~ msgstr "Kdy máš čas"
+
 #: src/pages/MyHelper.tsx
 msgid "Где"
 msgstr "Kde"
@@ -118,6 +134,10 @@ msgstr "Přidat službu"
 msgid "Это не наши услуги. Мы получаем комиссию с партнёра, со студента — ничего."
 msgstr "Tohle nejsou naše služby. Provizi bereme od partnera, od studenta nic."
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Какие предметы"
+#~ msgstr "Jaké předměty"
+
 #: src/pages/Home.tsx
 msgid "Вещи"
 msgstr "Věci"
@@ -125,6 +145,10 @@ msgstr "Věci"
 #: src/pages/MyHelper.tsx
 msgid "Всё можно менять когда угодно. Пустые поля просто не показываем."
 msgstr "Vše můžeš kdykoli změnit. Prázdná pole prostě neukazujeme."
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Одним куском, как другу. Анкету соберём сами."
+#~ msgstr "Napiš to naráz, jako kamarádovi. Anketu sestavíme sami."
 
 #: src/pages/Profile.tsx
 msgid "На каких языках тебе удобно"
@@ -142,6 +166,10 @@ msgstr "Na tenhle dotaz zatím nikdo není. Založ poptávku — pak si tě najd
 msgid "Оформление: как в системе. Нажми, чтобы сменить"
 msgstr "Vzhled: podle systému. Klepnutím změníš"
 
+#: src/pages/Profile.tsx
+#~ msgid "Хочу помогать"
+#~ msgstr "Chci pomáhat"
+
 #: src/components/AppHeader.tsx
 msgid "Язык"
 msgstr "Jazyk"
@@ -150,6 +178,10 @@ msgstr "Jazyk"
 #: src/components/Phrase.tsx
 msgid "Твой предмет — {0}"
 msgstr "Tvůj předmět — {0}"
+
+#: src/pages/Profile.tsx
+#~ msgid "Тёмное"
+#~ msgstr "Tmavé"
 
 #. placeholder {0}: picked.size
 #: src/pages/Offer.tsx
@@ -243,6 +275,27 @@ msgstr "Cena"
 msgid "И так, и так"
 msgstr "Obojí"
 
+#: src/components/TabBar.tsx
+#: src/pages/Chats.tsx
+#~ msgid "Чаты"
+#~ msgstr "Chaty"
+
+#: src/pages/MyHelper.tsx
+#~ msgid "Без предмета"
+#~ msgstr "Bez předmětu"
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Сколько берёшь"
+#~ msgstr "Kolik si bereš"
+
+#: src/pages/Landing.tsx
+#~ msgid "Работы и материалы"
+#~ msgstr "Práce a materiály"
+
+#: src/pages/Profile.tsx
+#~ msgid "опубликована"
+#~ msgstr "zveřejněna"
+
 #: src/pages/Ask.tsx
 msgid "Убери что-нибудь из уточнений выше или напиши иначе."
 msgstr "Odeber něco z upřesnění výše, nebo to napiš jinak."
@@ -259,6 +312,10 @@ msgstr "Odmítnout"
 msgid "Пока без откликов"
 msgstr "Zatím bez odpovědí"
 
+#: src/pages/Chats.tsx
+#~ msgid "Разговоры мы не храним"
+#~ msgstr "Rozhovory neukládáme"
+
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
 msgid "За что цена"
@@ -269,6 +326,10 @@ msgstr "Za co je cena"
 #: src/pages/OfferPrices.tsx
 msgid "за работу"
 msgstr "za práci"
+
+#: src/pages/MyHelper.tsx
+#~ msgid "Пока ни одного. Найди предмет ниже — без них тебя не найдут по поиску."
+#~ msgstr "Zatím žádný. Najdi předmět níž — bez nich tě vyhledávání nenajde."
 
 #: src/pages/MyHelper.tsx
 msgid "Тебя видят в поиске и могут написать."
@@ -285,6 +346,10 @@ msgstr "v katalogu"
 #: src/components/Phrase.tsx
 msgid "И то, и другое"
 msgstr "Obojí"
+
+#: src/pages/Ask.tsx
+#~ msgid "нужен матан на ČVUT, экзамен 14 февраля"
+#~ msgstr "potřebuju matanu na ČVUT, zkouška 14. února"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -345,6 +410,10 @@ msgstr "doučování, práce, pomoc"
 msgid "Дальше вопросов не будет."
 msgstr "Víc otázek nebude."
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Получилось так"
+#~ msgstr "Vyšlo to takhle"
+
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
@@ -374,6 +443,10 @@ msgstr "Jak učíš"
 #: src/pages/Profile.tsx
 msgid "Мои услуги"
 msgstr "Moje služby"
+
+#: src/pages/Ask.tsx
+#~ msgid "Искать всё равно"
+#~ msgstr "Hledat i tak"
 
 #: src/components/TabBar.tsx
 msgid "опиши задачу — придут отклики"
@@ -411,6 +484,10 @@ msgstr "Profil"
 #: src/pages/Helper.tsx
 msgid "Возможно, человек скрыл его."
 msgstr "Možná ho ten člověk skryl."
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Без расписания анкету покажем, но реже — люди чаще пишут тем, у кого видно свободные дни."
+#~ msgstr "Bez rozvrhu anketu ukážeme, ale míň často — lidi častěji píšou těm, u koho vidí volné dny."
 
 #: src/pages/MyHelper.tsx
 msgid "Строчка под именем"
@@ -453,9 +530,17 @@ msgstr "Kdo může pomoct"
 msgid "Это первое, что читают. Пара живых предложений работает лучше списка."
 msgstr "Tohle si přečtou první. Pár živých vět funguje líp než seznam."
 
+#: src/pages/Profile.tsx
+#~ msgid "По этому мы отсеиваем тех, с кем вы друг друга не поймёте."
+#~ msgstr "Podle toho vyřazujeme ty, se kterými byste si nerozuměli."
+
 #: src/pages/Results.tsx
 msgid "изменить"
 msgstr "změnit"
+
+#: src/pages/Profile.tsx
+#~ msgid "Светлое"
+#~ msgstr "Světlé"
 
 #: src/components/TabBar.tsx
 msgid "Мне нужна помощь"
@@ -474,6 +559,18 @@ msgstr "Co potřebuješ?"
 msgid "Не удалось загрузить каталог"
 msgstr "Nepodařilo se načíst katalog"
 
+#: src/pages/Chats.tsx
+#~ msgid "Мы сводим людей и запоминаем, что контакт состоялся — по этому считается время ответа. Сама переписка остаётся в Telegram."
+#~ msgstr "Spojujeme lidi a zaznamenáváme, že ke kontaktu došlo — podle toho počítáme dobu odezvy. Samotná konverzace zůstává v Telegramu."
+
+#: src/pages/Home.tsx
+#~ msgid "Люди"
+#~ msgstr "Lidé"
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Онлайн или очно"
+#~ msgstr "Online nebo osobně"
+
 #: src/pages/Landing.tsx
 msgid "Кто поможет с учёбой в Чехии"
 msgstr "Kdo pomůže se studiem v Česku"
@@ -481,6 +578,10 @@ msgstr "Kdo pomůže se studiem v Česku"
 #: src/pages/Helper.tsx
 msgid "Свободные окна"
 msgstr "Volné termíny"
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Не хватает"
+#~ msgstr "Chybí"
 
 #: src/pages/Profile.tsx
 msgid "черновик — не видна в каталоге"
@@ -528,6 +629,10 @@ msgstr "Vyber, s čím můžeš pomoct"
 msgid "Чем ты можешь помочь?"
 msgstr "S čím můžeš pomoct?"
 
+#: src/pages/Chats.tsx
+#~ msgid "Открыть переписку в Telegram"
+#~ msgstr "Otevřít konverzaci v Telegramu"
+
 #: src/pages/MyHelper.tsx
 msgid "Город"
 msgstr "Město"
@@ -547,6 +652,10 @@ msgstr "S čím pomáhá"
 #: src/components/TabBar.tsx
 msgid "Закрыть"
 msgstr "Zavřít"
+
+#: src/pages/Profile.tsx
+#~ msgid "Оформление"
+#~ msgstr "Vzhled"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -620,6 +729,10 @@ msgstr "pojištění, vízum, banka, převody"
 #: src/components/Phrase.tsx
 msgid "{0, plural, one {Готовил к этому же экзамену # человека} few {Готовил к этому же экзамену # человек} many {Готовил к этому же экзамену # человек} other {Готовил к этому же экзамену # человека}}"
 msgstr "{0, plural, one {Připravil na tuhle zkoušku # člověka} few {Připravil na tuhle zkoušku # lidi} many {Připravil na tuhle zkoušku # člověka} other {Připravil na tuhle zkoušku # lidí}}"
+
+#: src/pages/Chats.tsx
+#~ msgid "там же, где и все остальные разговоры"
+#~ msgstr "tam, kde máš i ostatní konverzace"
 
 #: src/pages/MyHelper.tsx
 msgid "ČVUT FEL, 3 курс"
@@ -710,6 +823,10 @@ msgstr "Zatím žádné poptávky"
 msgid "Убрать"
 msgstr "Odebrat"
 
+#: src/pages/Ask.tsx
+msgid "По этому пока не найти"
+msgstr "Podle tohohle to zatím nenajdeme"
+
 #: src/pages/Results.tsx
 msgid "Пока никого"
 msgstr "Zatím nikdo"
@@ -747,6 +864,10 @@ msgstr "čeština B2"
 msgid "Не получилось посчитать"
 msgstr "Nepodařilo se to spočítat"
 
+#: src/pages/Profile.tsx
+#~ msgid "Как в системе"
+#~ msgstr "Podle systému"
+
 #: src/components/Phrase.tsx
 msgid "Документы и жизнь"
 msgstr "Dokumenty a život"
@@ -764,6 +885,15 @@ msgstr "Nepovinné. Prázdné pole znamená „domluvíme se“."
 msgid "Написать"
 msgstr "Napsat"
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Расскажи своими словами"
+#~ msgstr "Napiš vlastními slovy"
+
+#. placeholder {0}: parsed.matches
+#: src/pages/Ask.tsx
+#~ msgid "Показать {0}"
+#~ msgstr "Zobrazit {0}"
+
 #: src/pages/MyHelper.tsx
 msgid "Моя анкета"
 msgstr "Moje anketa"
@@ -779,6 +909,11 @@ msgstr "Zatím žádné odpovědi"
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"
 msgstr "Potřebuješ pomoc před zkouškou, nebo přímo na ní?"
+
+#: src/components/TabBar.tsx
+#: src/pages/Mine.tsx
+#~ msgid "Мои"
+#~ msgstr "Moje"
 
 #: src/pages/MyHelper.tsx
 msgid "Что преподаёшь, где учишься, как проходят занятия. Своими словами."
@@ -814,6 +949,10 @@ msgstr "Doučování"
 #: src/components/Phrase.tsx
 msgid "лет на площадке"
 msgstr "let na platformě"
+
+#: src/pages/Ask.tsx
+#~ msgid "Дальше вопросов не будет — остальное отфильтруешь прямо в списке."
+#~ msgstr "Dál se už ptát nebudeme — zbytek si odfiltruješ přímo v seznamu."
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx

--- a/apps/web/src/locales/cs/messages.po
+++ b/apps/web/src/locales/cs/messages.po
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n>=2 && n<=4) ? 1 : n%1!=0 ? 2 : 3);\n"
 
+#: src/pages/Ask.tsx
+msgid "курсовая по экономике"
+msgstr "seminárka z ekonomie"
+
 #: src/components/Incoming.tsx
 msgid "Заведи в Telegram публичный @username — иначе тебе не ответят"
 msgstr "Nastav si v Telegramu veřejný @username — jinak ti nikdo neodpoví"
@@ -81,8 +85,8 @@ msgid "Kč"
 msgstr "Kč"
 
 #: src/pages/Ask.tsx
-msgid "страховка на год"
-msgstr "pojištění na rok"
+#~ msgid "страховка на год"
+#~ msgstr "pojištění na rok"
 
 #: src/pages/MyHelper.tsx
 msgid "Скрыть"
@@ -791,6 +795,7 @@ msgstr "Pracuje přímo s touhle školou"
 msgid "Открыть в Telegram"
 msgstr "Otevřít v Telegramu"
 
+#: src/pages/Ask.tsx
 #: src/pages/Results.tsx
 msgid "Проверь соединение и попробуй ещё раз."
 msgstr "Zkontroluj připojení a zkus to znovu."
@@ -853,6 +858,10 @@ msgstr "Odmítl jsi"
 #: src/pages/Ask.tsx
 msgid "čeština B2"
 msgstr "čeština B2"
+
+#: src/pages/Ask.tsx
+msgid "Не получилось посчитать"
+msgstr "Nepodařilo se to spočítat"
 
 #: src/pages/Profile.tsx
 #~ msgid "Как в системе"

--- a/apps/web/src/locales/cs/messages.po
+++ b/apps/web/src/locales/cs/messages.po
@@ -14,8 +14,8 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n>=2 && n<=4) ? 1 : n%1!=0 ? 2 : 3);\n"
 
 #: src/pages/Ask.tsx
-msgid "курсовая по экономике"
-msgstr "seminárka z ekonomie"
+#~ msgid "курсовая по экономике"
+#~ msgstr "seminárka z ekonomie"
 
 #: src/components/Incoming.tsx
 msgid "Заведи в Telegram публичный @username — иначе тебе не ответят"
@@ -389,8 +389,8 @@ msgid "за штуку"
 msgstr "za kus"
 
 #: src/pages/Ask.tsx
-msgid "přijímačky на медицину"
-msgstr "přijímačky na medicínu"
+#~ msgid "přijímačky на медицину"
+#~ msgstr "přijímačky na medicínu"
 
 #: src/pages/MyHelper.tsx
 msgid "В каталоге"
@@ -621,6 +621,10 @@ msgstr "nostrifikace vysvědčení"
 msgid "Вуз, с которым ты работаешь"
 msgstr "Škola, se kterou pracuješ"
 
+#: src/pages/Ask.tsx
+msgid "помощь на экзамене по матану"
+msgstr "pomoc u zkoušky z matiky"
+
 #: src/pages/Offer.tsx
 msgid "Выбери, чем можешь помочь"
 msgstr "Vyber, s čím můžeš pomoct"
@@ -838,6 +842,10 @@ msgstr "Zatím zdarma. Až bude lidí víc, bude zveřejnění takových služeb
 #: src/pages/Life.tsx
 msgid "Не про учёбу"
 msgstr "Není o škole"
+
+#: src/pages/Ask.tsx
+msgid "курсовая работа"
+msgstr "seminární práce"
 
 #: src/components/Phrase.tsx
 msgid "Дешевле остальных, но этот экзамен не вёл"

--- a/apps/web/src/locales/cs/messages.po
+++ b/apps/web/src/locales/cs/messages.po
@@ -80,6 +80,10 @@ msgstr "Teď ne"
 msgid "Kč"
 msgstr "Kč"
 
+#: src/pages/Ask.tsx
+msgid "страховка на год"
+msgstr "pojištění na rok"
+
 #: src/pages/MyHelper.tsx
 msgid "Скрыть"
 msgstr "Skrýt"
@@ -192,6 +196,10 @@ msgstr "napiš to vlastními slovy, anketu sestavíme sami"
 msgid "Заявку уже закрыли"
 msgstr "Poptávka už je uzavřená"
 
+#: src/pages/Ask.tsx
+msgid "всего {total}"
+msgstr "celkem {total}"
+
 #: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
 #: src/pages/Request.tsx
@@ -207,6 +215,10 @@ msgstr "Profil se uloží, ale v katalogu nebude."
 msgid "Сколько"
 msgstr "Kolik"
 
+#: src/pages/Ask.tsx
+msgid "Показать {total}"
+msgstr "Zobrazit {total}"
+
 #: src/pages/Mine.tsx
 msgid "Мои заявки"
 msgstr "Moje poptávky"
@@ -218,6 +230,10 @@ msgstr "Jsou vidět na tvé stránce."
 #: src/components/Phrase.tsx
 msgid "Не понял запрос. Попробуй назвать предмет — «матан», «čeština B2», «сопромат»."
 msgstr "Nerozuměl jsem dotazu. Zkus napsat předmět — „matana“, „čeština B2“, „sopromat“."
+
+#: src/pages/Ask.tsx
+msgid "Напиши как думаешь. Поймём предмет, вуз, срок и бюджет."
+msgstr "Napiš to tak, jak to máš v hlavě. Poznáme předmět, školu, termín i rozpočet."
 
 #: src/components/Phrase.tsx
 msgid "сдали"
@@ -280,6 +296,10 @@ msgstr "Obojí"
 #~ msgid "опубликована"
 #~ msgstr "zveřejněna"
 
+#: src/pages/Ask.tsx
+msgid "Убери что-нибудь из уточнений выше или напиши иначе."
+msgstr "Odeber něco z upřesnění výše, nebo to napiš jinak."
+
 #: src/pages/OfferPrices.tsx
 msgid "Анкета скрыта — услуги сохранятся, но в каталоге их не будет. Включить видимость можно в анкете."
 msgstr "Profil je skrytý — služby se uloží, ale v katalogu nebudou. Viditelnost zapneš v profilu."
@@ -328,14 +348,18 @@ msgid "И то, и другое"
 msgstr "Obojí"
 
 #: src/pages/Ask.tsx
-msgid "нужен матан на ČVUT, экзамен 14 февраля"
-msgstr "potřebuju matanu na ČVUT, zkouška 14. února"
+#~ msgid "нужен матан на ČVUT, экзамен 14 февраля"
+#~ msgstr "potřebuju matanu na ČVUT, zkouška 14. února"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
 msgid "за час"
 msgstr "za hodinu"
+
+#: src/pages/Ask.tsx
+msgid "матан на ČVUT к 14 февраля, до 600 Kč"
+msgstr "matika na ČVUT do 14. února, do 600 Kč"
 
 #: src/pages/Profile.tsx
 msgid "Предлагать услуги"
@@ -363,6 +387,10 @@ msgstr "Nejdřív zveřejni profil"
 #: src/pages/OfferPrices.tsx
 msgid "за штуку"
 msgstr "za kus"
+
+#: src/pages/Ask.tsx
+msgid "přijímačky на медицину"
+msgstr "přijímačky na medicínu"
 
 #: src/pages/MyHelper.tsx
 msgid "В каталоге"
@@ -417,8 +445,8 @@ msgid "Мои услуги"
 msgstr "Moje služby"
 
 #: src/pages/Ask.tsx
-msgid "Искать всё равно"
-msgstr "Hledat i tak"
+#~ msgid "Искать всё равно"
+#~ msgstr "Hledat i tak"
 
 #: src/components/TabBar.tsx
 msgid "опиши задачу — придут отклики"
@@ -427,6 +455,14 @@ msgstr "popiš zadání — přijdou nabídky"
 #: src/pages/Request.tsx
 msgid "Заявку видят те, кто ведёт этот предмет. Обычно отвечают в течение дня."
 msgstr "Poptávku vidí ti, kdo tenhle předmět učí. Obvykle odpovídají do dne."
+
+#: src/pages/Ask.tsx
+msgid "Кого тут можно найти"
+msgstr "Koho tu najdeš"
+
+#: src/pages/Ask.tsx
+msgid "Кто найдётся"
+msgstr "Koho to najde"
 
 #: src/components/Phrase.tsx
 msgid "Ведёт предмет, но не привязан к этому вузу"
@@ -514,6 +550,7 @@ msgstr "Potřebuju pomoc"
 msgid "Оформление. Нажми, чтобы сменить; удерживай, чтобы вернуть системное"
 msgstr "Vzhled. Klepnutím změníš, podržením vrátíš systémový"
 
+#: src/pages/Ask.tsx
 #: src/pages/Home.tsx
 msgid "Что нужно?"
 msgstr "Co potřebuješ?"
@@ -566,10 +603,18 @@ msgstr "Levnější"
 msgid "Загружаем"
 msgstr "Načítáme"
 
+#: src/pages/Ask.tsx
+msgid "матан ČVUT"
+msgstr "matika ČVUT"
+
 #. placeholder {0}: data.total
 #: src/pages/Results.tsx
 msgid "всего {0}"
 msgstr "celkem {0}"
+
+#: src/pages/Ask.tsx
+msgid "нострификация аттестата"
+msgstr "nostrifikace vysvědčení"
 
 #: src/components/Phrase.tsx
 msgid "Вуз, с которым ты работаешь"
@@ -665,6 +710,10 @@ msgstr "Odeslat"
 msgid "У этого человека нет @username — написать не получится"
 msgstr "Tenhle člověk nemá @username — nedá se mu napsat"
 
+#: src/pages/Ask.tsx
+msgid "Например"
+msgstr "Například"
+
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
@@ -716,6 +765,10 @@ msgstr "Na tuhle poptávku jsi už odpovídal"
 #: src/pages/Helper.tsx
 msgid "У этого человека нет открытого username в Telegram, написать не получится."
 msgstr "Tenhle člověk nemá veřejný username v Telegramu, napsat mu nepůjde."
+
+#: src/pages/Ask.tsx
+msgid "По этому запросу пока никого"
+msgstr "Na tenhle dotaz tu zatím nikdo není"
 
 #. placeholder {0}: formatMoney(price.amount)
 #: src/pages/Helper.tsx
@@ -797,6 +850,10 @@ msgstr "{0, plural, one {Odpovídá zhruba za # minutu} few {Odpovídá zhruba z
 msgid "Ты отказался"
 msgstr "Odmítl jsi"
 
+#: src/pages/Ask.tsx
+msgid "čeština B2"
+msgstr "čeština B2"
+
 #: src/pages/Profile.tsx
 #~ msgid "Как в системе"
 #~ msgstr "Podle systému"
@@ -824,8 +881,8 @@ msgstr "Napsat"
 
 #. placeholder {0}: parsed.matches
 #: src/pages/Ask.tsx
-msgid "Показать {0}"
-msgstr "Zobrazit {0}"
+#~ msgid "Показать {0}"
+#~ msgstr "Zobrazit {0}"
 
 #: src/pages/MyHelper.tsx
 msgid "Моя анкета"
@@ -856,6 +913,7 @@ msgstr "Co učíš, kde studuješ, jak hodiny probíhají. Vlastními slovy."
 msgid "Отклики"
 msgstr "Odpovědi"
 
+#: src/pages/Ask.tsx
 #: src/pages/Results.tsx
 msgid "Ищем…"
 msgstr "Hledáme…"

--- a/apps/web/src/locales/cs/messages.po
+++ b/apps/web/src/locales/cs/messages.po
@@ -52,10 +52,6 @@ msgstr "Zkontroluj připojení a zkus to znovu."
 msgid "Онлайн"
 msgstr "Online"
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Напиши хотя бы пару предложений — предметы, цену и как удобно заниматься."
-#~ msgstr "Napiš aspoň pár vět — jaké předměty, za kolik a jak ti vyhovuje mít hodiny."
-
 #: src/pages/Request.tsx
 msgid "Такой заявки нет"
 msgstr "Taková poptávka neexistuje"
@@ -72,10 +68,6 @@ msgstr "Viditelnost"
 msgid "Поиск"
 msgstr "Hledat"
 
-#: src/pages/MyHelper.tsx
-#~ msgid "Предметы и цены"
-#~ msgstr "Předměty a ceny"
-
 #: src/components/Incoming.tsx
 msgid "Не сейчас"
 msgstr "Teď ne"
@@ -83,10 +75,6 @@ msgstr "Teď ne"
 #: src/pages/MyHelper.tsx
 msgid "Kč"
 msgstr "Kč"
-
-#: src/pages/Ask.tsx
-#~ msgid "страховка на год"
-#~ msgstr "pojištění na rok"
 
 #: src/pages/MyHelper.tsx
 msgid "Скрыть"
@@ -118,10 +106,6 @@ msgstr "za týden"
 msgid "Откликнуться"
 msgstr "Odpovědět"
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Когда ты свободен"
-#~ msgstr "Kdy máš čas"
-
 #: src/pages/MyHelper.tsx
 msgid "Где"
 msgstr "Kde"
@@ -134,10 +118,6 @@ msgstr "Přidat službu"
 msgid "Это не наши услуги. Мы получаем комиссию с партнёра, со студента — ничего."
 msgstr "Tohle nejsou naše služby. Provizi bereme od partnera, od studenta nic."
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Какие предметы"
-#~ msgstr "Jaké předměty"
-
 #: src/pages/Home.tsx
 msgid "Вещи"
 msgstr "Věci"
@@ -145,10 +125,6 @@ msgstr "Věci"
 #: src/pages/MyHelper.tsx
 msgid "Всё можно менять когда угодно. Пустые поля просто не показываем."
 msgstr "Vše můžeš kdykoli změnit. Prázdná pole prostě neukazujeme."
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Одним куском, как другу. Анкету соберём сами."
-#~ msgstr "Napiš to naráz, jako kamarádovi. Anketu sestavíme sami."
 
 #: src/pages/Profile.tsx
 msgid "На каких языках тебе удобно"
@@ -166,10 +142,6 @@ msgstr "Na tenhle dotaz zatím nikdo není. Založ poptávku — pak si tě najd
 msgid "Оформление: как в системе. Нажми, чтобы сменить"
 msgstr "Vzhled: podle systému. Klepnutím změníš"
 
-#: src/pages/Profile.tsx
-#~ msgid "Хочу помогать"
-#~ msgstr "Chci pomáhat"
-
 #: src/components/AppHeader.tsx
 msgid "Язык"
 msgstr "Jazyk"
@@ -178,10 +150,6 @@ msgstr "Jazyk"
 #: src/components/Phrase.tsx
 msgid "Твой предмет — {0}"
 msgstr "Tvůj předmět — {0}"
-
-#: src/pages/Profile.tsx
-#~ msgid "Тёмное"
-#~ msgstr "Tmavé"
 
 #. placeholder {0}: picked.size
 #: src/pages/Offer.tsx
@@ -199,10 +167,6 @@ msgstr "napiš to vlastními slovy, anketu sestavíme sami"
 #: src/components/Incoming.tsx
 msgid "Заявку уже закрыли"
 msgstr "Poptávka už je uzavřená"
-
-#: src/pages/Ask.tsx
-msgid "всего {total}"
-msgstr "celkem {total}"
 
 #: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
@@ -279,27 +243,6 @@ msgstr "Cena"
 msgid "И так, и так"
 msgstr "Obojí"
 
-#: src/components/TabBar.tsx
-#: src/pages/Chats.tsx
-#~ msgid "Чаты"
-#~ msgstr "Chaty"
-
-#: src/pages/MyHelper.tsx
-#~ msgid "Без предмета"
-#~ msgstr "Bez předmětu"
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Сколько берёшь"
-#~ msgstr "Kolik si bereš"
-
-#: src/pages/Landing.tsx
-#~ msgid "Работы и материалы"
-#~ msgstr "Práce a materiály"
-
-#: src/pages/Profile.tsx
-#~ msgid "опубликована"
-#~ msgstr "zveřejněna"
-
 #: src/pages/Ask.tsx
 msgid "Убери что-нибудь из уточнений выше или напиши иначе."
 msgstr "Odeber něco z upřesnění výše, nebo to napiš jinak."
@@ -316,10 +259,6 @@ msgstr "Odmítnout"
 msgid "Пока без откликов"
 msgstr "Zatím bez odpovědí"
 
-#: src/pages/Chats.tsx
-#~ msgid "Разговоры мы не храним"
-#~ msgstr "Rozhovory neukládáme"
-
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
 msgid "За что цена"
@@ -330,10 +269,6 @@ msgstr "Za co je cena"
 #: src/pages/OfferPrices.tsx
 msgid "за работу"
 msgstr "za práci"
-
-#: src/pages/MyHelper.tsx
-#~ msgid "Пока ни одного. Найди предмет ниже — без них тебя не найдут по поиску."
-#~ msgstr "Zatím žádný. Najdi předmět níž — bez nich tě vyhledávání nenajde."
 
 #: src/pages/MyHelper.tsx
 msgid "Тебя видят в поиске и могут написать."
@@ -350,10 +285,6 @@ msgstr "v katalogu"
 #: src/components/Phrase.tsx
 msgid "И то, и другое"
 msgstr "Obojí"
-
-#: src/pages/Ask.tsx
-#~ msgid "нужен матан на ČVUT, экзамен 14 февраля"
-#~ msgstr "potřebuju matanu na ČVUT, zkouška 14. února"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -414,10 +345,6 @@ msgstr "doučování, práce, pomoc"
 msgid "Дальше вопросов не будет."
 msgstr "Víc otázek nebude."
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Получилось так"
-#~ msgstr "Vyšlo to takhle"
-
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
@@ -447,10 +374,6 @@ msgstr "Jak učíš"
 #: src/pages/Profile.tsx
 msgid "Мои услуги"
 msgstr "Moje služby"
-
-#: src/pages/Ask.tsx
-#~ msgid "Искать всё равно"
-#~ msgstr "Hledat i tak"
 
 #: src/components/TabBar.tsx
 msgid "опиши задачу — придут отклики"
@@ -488,10 +411,6 @@ msgstr "Profil"
 #: src/pages/Helper.tsx
 msgid "Возможно, человек скрыл его."
 msgstr "Možná ho ten člověk skryl."
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Без расписания анкету покажем, но реже — люди чаще пишут тем, у кого видно свободные дни."
-#~ msgstr "Bez rozvrhu anketu ukážeme, ale míň často — lidi častěji píšou těm, u koho vidí volné dny."
 
 #: src/pages/MyHelper.tsx
 msgid "Строчка под именем"
@@ -534,17 +453,9 @@ msgstr "Kdo může pomoct"
 msgid "Это первое, что читают. Пара живых предложений работает лучше списка."
 msgstr "Tohle si přečtou první. Pár živých vět funguje líp než seznam."
 
-#: src/pages/Profile.tsx
-#~ msgid "По этому мы отсеиваем тех, с кем вы друг друга не поймёте."
-#~ msgstr "Podle toho vyřazujeme ty, se kterými byste si nerozuměli."
-
 #: src/pages/Results.tsx
 msgid "изменить"
 msgstr "změnit"
-
-#: src/pages/Profile.tsx
-#~ msgid "Светлое"
-#~ msgstr "Světlé"
 
 #: src/components/TabBar.tsx
 msgid "Мне нужна помощь"
@@ -563,18 +474,6 @@ msgstr "Co potřebuješ?"
 msgid "Не удалось загрузить каталог"
 msgstr "Nepodařilo se načíst katalog"
 
-#: src/pages/Chats.tsx
-#~ msgid "Мы сводим людей и запоминаем, что контакт состоялся — по этому считается время ответа. Сама переписка остаётся в Telegram."
-#~ msgstr "Spojujeme lidi a zaznamenáváme, že ke kontaktu došlo — podle toho počítáme dobu odezvy. Samotná konverzace zůstává v Telegramu."
-
-#: src/pages/Home.tsx
-#~ msgid "Люди"
-#~ msgstr "Lidé"
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Онлайн или очно"
-#~ msgstr "Online nebo osobně"
-
 #: src/pages/Landing.tsx
 msgid "Кто поможет с учёбой в Чехии"
 msgstr "Kdo pomůže se studiem v Česku"
@@ -582,10 +481,6 @@ msgstr "Kdo pomůže se studiem v Česku"
 #: src/pages/Helper.tsx
 msgid "Свободные окна"
 msgstr "Volné termíny"
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Не хватает"
-#~ msgstr "Chybí"
 
 #: src/pages/Profile.tsx
 msgid "черновик — не видна в каталоге"
@@ -612,6 +507,7 @@ msgid "матан ČVUT"
 msgstr "matika ČVUT"
 
 #. placeholder {0}: data.total
+#: src/pages/Ask.tsx
 #: src/pages/Results.tsx
 msgid "всего {0}"
 msgstr "celkem {0}"
@@ -632,10 +528,6 @@ msgstr "Vyber, s čím můžeš pomoct"
 msgid "Чем ты можешь помочь?"
 msgstr "S čím můžeš pomoct?"
 
-#: src/pages/Chats.tsx
-#~ msgid "Открыть переписку в Telegram"
-#~ msgstr "Otevřít konverzaci v Telegramu"
-
 #: src/pages/MyHelper.tsx
 msgid "Город"
 msgstr "Město"
@@ -655,10 +547,6 @@ msgstr "S čím pomáhá"
 #: src/components/TabBar.tsx
 msgid "Закрыть"
 msgstr "Zavřít"
-
-#: src/pages/Profile.tsx
-#~ msgid "Оформление"
-#~ msgstr "Vzhled"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -732,10 +620,6 @@ msgstr "pojištění, vízum, banka, převody"
 #: src/components/Phrase.tsx
 msgid "{0, plural, one {Готовил к этому же экзамену # человека} few {Готовил к этому же экзамену # человек} many {Готовил к этому же экзамену # человек} other {Готовил к этому же экзамену # человека}}"
 msgstr "{0, plural, one {Připravil na tuhle zkoušku # člověka} few {Připravil na tuhle zkoušku # lidi} many {Připravil na tuhle zkoušku # člověka} other {Připravil na tuhle zkoušku # lidí}}"
-
-#: src/pages/Chats.tsx
-#~ msgid "там же, где и все остальные разговоры"
-#~ msgstr "tam, kde máš i ostatní konverzace"
 
 #: src/pages/MyHelper.tsx
 msgid "ČVUT FEL, 3 курс"
@@ -863,10 +747,6 @@ msgstr "čeština B2"
 msgid "Не получилось посчитать"
 msgstr "Nepodařilo se to spočítat"
 
-#: src/pages/Profile.tsx
-#~ msgid "Как в системе"
-#~ msgstr "Podle systému"
-
 #: src/components/Phrase.tsx
 msgid "Документы и жизнь"
 msgstr "Dokumenty a život"
@@ -884,15 +764,6 @@ msgstr "Nepovinné. Prázdné pole znamená „domluvíme se“."
 msgid "Написать"
 msgstr "Napsat"
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Расскажи своими словами"
-#~ msgstr "Napiš vlastními slovy"
-
-#. placeholder {0}: parsed.matches
-#: src/pages/Ask.tsx
-#~ msgid "Показать {0}"
-#~ msgstr "Zobrazit {0}"
-
 #: src/pages/MyHelper.tsx
 msgid "Моя анкета"
 msgstr "Moje anketa"
@@ -908,11 +779,6 @@ msgstr "Zatím žádné odpovědi"
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"
 msgstr "Potřebuješ pomoc před zkouškou, nebo přímo na ní?"
-
-#: src/components/TabBar.tsx
-#: src/pages/Mine.tsx
-#~ msgid "Мои"
-#~ msgstr "Moje"
 
 #: src/pages/MyHelper.tsx
 msgid "Что преподаёшь, где учишься, как проходят занятия. Своими словами."
@@ -948,10 +814,6 @@ msgstr "Doučování"
 #: src/components/Phrase.tsx
 msgid "лет на площадке"
 msgstr "let na platformě"
-
-#: src/pages/Ask.tsx
-#~ msgid "Дальше вопросов не будет — остальное отфильтруешь прямо в списке."
-#~ msgstr "Dál se už ptát nebudeme — zbytek si odfiltruješ přímo v seznamu."
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx

--- a/apps/web/src/locales/cs/messages.po
+++ b/apps/web/src/locales/cs/messages.po
@@ -359,7 +359,7 @@ msgstr "za hodinu"
 
 #: src/pages/Ask.tsx
 msgid "матан на ČVUT к 14 февраля, до 600 Kč"
-msgstr "matika na ČVUT do 14. února, do 600 Kč"
+msgstr "matan na ČVUT do 14. února, do 600 Kč"
 
 #: src/pages/Profile.tsx
 msgid "Предлагать услуги"
@@ -605,7 +605,7 @@ msgstr "Načítáme"
 
 #: src/pages/Ask.tsx
 msgid "матан ČVUT"
-msgstr "matika ČVUT"
+msgstr "matan ČVUT"
 
 #. placeholder {0}: data.total
 #: src/pages/Ask.tsx
@@ -623,7 +623,7 @@ msgstr "Škola, se kterou pracuješ"
 
 #: src/pages/Ask.tsx
 msgid "помощь на экзамене по матану"
-msgstr "pomoc u zkoušky z matiky"
+msgstr "pomoc u zkoušky z matanu"
 
 #: src/pages/Offer.tsx
 msgid "Выбери, чем можешь помочь"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -80,6 +80,10 @@ msgstr "Not now"
 msgid "Kč"
 msgstr "Kč"
 
+#: src/pages/Ask.tsx
+msgid "страховка на год"
+msgstr "insurance for a year"
+
 #: src/pages/MyHelper.tsx
 msgid "Скрыть"
 msgstr "Hide"
@@ -192,6 +196,10 @@ msgstr "tell it in your own words, we'll build the profile"
 msgid "Заявку уже закрыли"
 msgstr "This request is already closed"
 
+#: src/pages/Ask.tsx
+msgid "всего {total}"
+msgstr "{total} in all"
+
 #: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
 #: src/pages/Request.tsx
@@ -207,6 +215,10 @@ msgstr "Your profile is saved, but it will not be in the catalog."
 msgid "Сколько"
 msgstr "How much"
 
+#: src/pages/Ask.tsx
+msgid "Показать {total}"
+msgstr "Show {total}"
+
 #: src/pages/Mine.tsx
 msgid "Мои заявки"
 msgstr "My requests"
@@ -218,6 +230,10 @@ msgstr "They show on your page."
 #: src/components/Phrase.tsx
 msgid "Не понял запрос. Попробуй назвать предмет — «матан», «čeština B2», «сопромат»."
 msgstr "Didn't get that. Try naming a subject — \"calculus\", \"čeština B2\", \"structural mechanics\"."
+
+#: src/pages/Ask.tsx
+msgid "Напиши как думаешь. Поймём предмет, вуз, срок и бюджет."
+msgstr "Write it the way you think it. We read the subject, the school, the deadline and the budget."
 
 #: src/components/Phrase.tsx
 msgid "сдали"
@@ -280,6 +296,10 @@ msgstr "Either way"
 #~ msgid "опубликована"
 #~ msgstr "published"
 
+#: src/pages/Ask.tsx
+msgid "Убери что-нибудь из уточнений выше или напиши иначе."
+msgstr "Drop one of the details above, or put it differently."
+
 #: src/pages/OfferPrices.tsx
 msgid "Анкета скрыта — услуги сохранятся, но в каталоге их не будет. Включить видимость можно в анкете."
 msgstr "Your profile is hidden — the services are saved but will not be in the catalog. You can turn visibility on there."
@@ -328,14 +348,18 @@ msgid "И то, и другое"
 msgstr "Both"
 
 #: src/pages/Ask.tsx
-msgid "нужен матан на ČVUT, экзамен 14 февраля"
-msgstr "need calculus at ČVUT, exam on Feb 14"
+#~ msgid "нужен матан на ČVUT, экзамен 14 февраля"
+#~ msgstr "need calculus at ČVUT, exam on Feb 14"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
 msgid "за час"
 msgstr "per hour"
+
+#: src/pages/Ask.tsx
+msgid "матан на ČVUT к 14 февраля, до 600 Kč"
+msgstr "calculus at ČVUT by 14 February, up to 600 Kč"
 
 #: src/pages/Profile.tsx
 msgid "Предлагать услуги"
@@ -363,6 +387,10 @@ msgstr "Publish your profile first"
 #: src/pages/OfferPrices.tsx
 msgid "за штуку"
 msgstr "per item"
+
+#: src/pages/Ask.tsx
+msgid "přijímačky на медицину"
+msgstr "přijímačky for medicine"
 
 #: src/pages/MyHelper.tsx
 msgid "В каталоге"
@@ -417,8 +445,8 @@ msgid "Мои услуги"
 msgstr "My services"
 
 #: src/pages/Ask.tsx
-msgid "Искать всё равно"
-msgstr "Search anyway"
+#~ msgid "Искать всё равно"
+#~ msgstr "Search anyway"
 
 #: src/components/TabBar.tsx
 msgid "опиши задачу — придут отклики"
@@ -427,6 +455,14 @@ msgstr "describe the task and replies will come"
 #: src/pages/Request.tsx
 msgid "Заявку видят те, кто ведёт этот предмет. Обычно отвечают в течение дня."
 msgstr "People who teach this subject can see your request. They usually answer within a day."
+
+#: src/pages/Ask.tsx
+msgid "Кого тут можно найти"
+msgstr "Who you can find here"
+
+#: src/pages/Ask.tsx
+msgid "Кто найдётся"
+msgstr "Who this finds"
 
 #: src/components/Phrase.tsx
 msgid "Ведёт предмет, но не привязан к этому вузу"
@@ -514,6 +550,7 @@ msgstr "I need help"
 msgid "Оформление. Нажми, чтобы сменить; удерживай, чтобы вернуть системное"
 msgstr "Appearance. Tap to change, hold to follow the system"
 
+#: src/pages/Ask.tsx
 #: src/pages/Home.tsx
 msgid "Что нужно?"
 msgstr "What do you need?"
@@ -566,10 +603,18 @@ msgstr "Cheaper"
 msgid "Загружаем"
 msgstr "Loading"
 
+#: src/pages/Ask.tsx
+msgid "матан ČVUT"
+msgstr "calculus ČVUT"
+
 #. placeholder {0}: data.total
 #: src/pages/Results.tsx
 msgid "всего {0}"
 msgstr "{0} total"
+
+#: src/pages/Ask.tsx
+msgid "нострификация аттестата"
+msgstr "nostrification of a school certificate"
 
 #: src/components/Phrase.tsx
 msgid "Вуз, с которым ты работаешь"
@@ -665,6 +710,10 @@ msgstr "Send"
 msgid "У этого человека нет @username — написать не получится"
 msgstr "This person has no @username — there is no way to write to them"
 
+#: src/pages/Ask.tsx
+msgid "Например"
+msgstr "For example"
+
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
@@ -716,6 +765,10 @@ msgstr "You have already answered this request"
 #: src/pages/Helper.tsx
 msgid "У этого человека нет открытого username в Telegram, написать не получится."
 msgstr "This person doesn't have a public Telegram username, so you can't message them."
+
+#: src/pages/Ask.tsx
+msgid "По этому запросу пока никого"
+msgstr "Nobody for this one yet"
 
 #. placeholder {0}: formatMoney(price.amount)
 #: src/pages/Helper.tsx
@@ -797,6 +850,10 @@ msgstr "{0, plural, one {Replies in about # minute} other {Replies in about # mi
 msgid "Ты отказался"
 msgstr "You declined"
 
+#: src/pages/Ask.tsx
+msgid "čeština B2"
+msgstr "čeština B2"
+
 #: src/pages/Profile.tsx
 #~ msgid "Как в системе"
 #~ msgstr "Match the system"
@@ -824,8 +881,8 @@ msgstr "Message"
 
 #. placeholder {0}: parsed.matches
 #: src/pages/Ask.tsx
-msgid "Показать {0}"
-msgstr "Show {0}"
+#~ msgid "Показать {0}"
+#~ msgstr "Show {0}"
 
 #: src/pages/MyHelper.tsx
 msgid "Моя анкета"
@@ -856,6 +913,7 @@ msgstr "What you teach, where you study, how lessons go. In your own words."
 msgid "Отклики"
 msgstr "Responses"
 
+#: src/pages/Ask.tsx
 #: src/pages/Results.tsx
 msgid "Ищем…"
 msgstr "Searching…"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -52,10 +52,6 @@ msgstr "Check your connection and try again."
 msgid "Онлайн"
 msgstr "Online"
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Напиши хотя бы пару предложений — предметы, цену и как удобно заниматься."
-#~ msgstr "Write at least a couple sentences — subjects, price, and how you like to meet."
-
 #: src/pages/Request.tsx
 msgid "Такой заявки нет"
 msgstr "No such request"
@@ -72,10 +68,6 @@ msgstr "Visibility"
 msgid "Поиск"
 msgstr "Search"
 
-#: src/pages/MyHelper.tsx
-#~ msgid "Предметы и цены"
-#~ msgstr "Subjects and prices"
-
 #: src/components/Incoming.tsx
 msgid "Не сейчас"
 msgstr "Not now"
@@ -83,10 +75,6 @@ msgstr "Not now"
 #: src/pages/MyHelper.tsx
 msgid "Kč"
 msgstr "Kč"
-
-#: src/pages/Ask.tsx
-#~ msgid "страховка на год"
-#~ msgstr "insurance for a year"
 
 #: src/pages/MyHelper.tsx
 msgid "Скрыть"
@@ -118,10 +106,6 @@ msgstr "per week"
 msgid "Откликнуться"
 msgstr "Respond"
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Когда ты свободен"
-#~ msgstr "When you're free"
-
 #: src/pages/MyHelper.tsx
 msgid "Где"
 msgstr "Where"
@@ -134,10 +118,6 @@ msgstr "Add a service"
 msgid "Это не наши услуги. Мы получаем комиссию с партнёра, со студента — ничего."
 msgstr "These aren't our services. We take a commission from the partner, nothing from the student."
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Какие предметы"
-#~ msgstr "Which subjects"
-
 #: src/pages/Home.tsx
 msgid "Вещи"
 msgstr "Things"
@@ -145,10 +125,6 @@ msgstr "Things"
 #: src/pages/MyHelper.tsx
 msgid "Всё можно менять когда угодно. Пустые поля просто не показываем."
 msgstr "Change anything whenever you like. Empty fields simply are not shown."
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Одним куском, как другу. Анкету соберём сами."
-#~ msgstr "All in one go, like to a friend. We'll put the profile together."
 
 #: src/pages/Profile.tsx
 msgid "На каких языках тебе удобно"
@@ -166,10 +142,6 @@ msgstr "No one matches this search yet. Post a request — then people will find
 msgid "Оформление: как в системе. Нажми, чтобы сменить"
 msgstr "Appearance: follows the system. Tap to change"
 
-#: src/pages/Profile.tsx
-#~ msgid "Хочу помогать"
-#~ msgstr "I want to help"
-
 #: src/components/AppHeader.tsx
 msgid "Язык"
 msgstr "Language"
@@ -178,10 +150,6 @@ msgstr "Language"
 #: src/components/Phrase.tsx
 msgid "Твой предмет — {0}"
 msgstr "Your subject — {0}"
-
-#: src/pages/Profile.tsx
-#~ msgid "Тёмное"
-#~ msgstr "Dark"
 
 #. placeholder {0}: picked.size
 #: src/pages/Offer.tsx
@@ -199,10 +167,6 @@ msgstr "tell it in your own words, we'll build the profile"
 #: src/components/Incoming.tsx
 msgid "Заявку уже закрыли"
 msgstr "This request is already closed"
-
-#: src/pages/Ask.tsx
-msgid "всего {total}"
-msgstr "{total} in all"
 
 #: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
@@ -279,27 +243,6 @@ msgstr "Price"
 msgid "И так, и так"
 msgstr "Either way"
 
-#: src/components/TabBar.tsx
-#: src/pages/Chats.tsx
-#~ msgid "Чаты"
-#~ msgstr "Chats"
-
-#: src/pages/MyHelper.tsx
-#~ msgid "Без предмета"
-#~ msgstr "No subject"
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Сколько берёшь"
-#~ msgstr "What you charge"
-
-#: src/pages/Landing.tsx
-#~ msgid "Работы и материалы"
-#~ msgstr "Papers and materials"
-
-#: src/pages/Profile.tsx
-#~ msgid "опубликована"
-#~ msgstr "published"
-
 #: src/pages/Ask.tsx
 msgid "Убери что-нибудь из уточнений выше или напиши иначе."
 msgstr "Drop one of the details above, or put it differently."
@@ -316,10 +259,6 @@ msgstr "Decline"
 msgid "Пока без откликов"
 msgstr "No responses yet"
 
-#: src/pages/Chats.tsx
-#~ msgid "Разговоры мы не храним"
-#~ msgstr "We don't store conversations"
-
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
 msgid "За что цена"
@@ -330,10 +269,6 @@ msgstr "What the price is for"
 #: src/pages/OfferPrices.tsx
 msgid "за работу"
 msgstr "per assignment"
-
-#: src/pages/MyHelper.tsx
-#~ msgid "Пока ни одного. Найди предмет ниже — без них тебя не найдут по поиску."
-#~ msgstr "None yet. Find a subject below — without them search cannot reach you."
 
 #: src/pages/MyHelper.tsx
 msgid "Тебя видят в поиске и могут написать."
@@ -350,10 +285,6 @@ msgstr "in the catalog"
 #: src/components/Phrase.tsx
 msgid "И то, и другое"
 msgstr "Both"
-
-#: src/pages/Ask.tsx
-#~ msgid "нужен матан на ČVUT, экзамен 14 февраля"
-#~ msgstr "need calculus at ČVUT, exam on Feb 14"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -414,10 +345,6 @@ msgstr "tutoring, written work, exam help"
 msgid "Дальше вопросов не будет."
 msgstr "No more questions after this."
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Получилось так"
-#~ msgstr "Here's how it turned out"
-
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
@@ -447,10 +374,6 @@ msgstr "How you work"
 #: src/pages/Profile.tsx
 msgid "Мои услуги"
 msgstr "My services"
-
-#: src/pages/Ask.tsx
-#~ msgid "Искать всё равно"
-#~ msgstr "Search anyway"
 
 #: src/components/TabBar.tsx
 msgid "опиши задачу — придут отклики"
@@ -488,10 +411,6 @@ msgstr "Profile"
 #: src/pages/Helper.tsx
 msgid "Возможно, человек скрыл его."
 msgstr "Maybe they hid it."
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Без расписания анкету покажем, но реже — люди чаще пишут тем, у кого видно свободные дни."
-#~ msgstr "Without a schedule we'll still show your profile, just less often — people tend to message those whose free days are visible."
 
 #: src/pages/MyHelper.tsx
 msgid "Строчка под именем"
@@ -534,17 +453,9 @@ msgstr "Who can help"
 msgid "Это первое, что читают. Пара живых предложений работает лучше списка."
 msgstr "This is the first thing people read. A couple of real sentences beat a list."
 
-#: src/pages/Profile.tsx
-#~ msgid "По этому мы отсеиваем тех, с кем вы друг друга не поймёте."
-#~ msgstr "That's how we filter out people you wouldn't understand each other with."
-
 #: src/pages/Results.tsx
 msgid "изменить"
 msgstr "change"
-
-#: src/pages/Profile.tsx
-#~ msgid "Светлое"
-#~ msgstr "Light"
 
 #: src/components/TabBar.tsx
 msgid "Мне нужна помощь"
@@ -563,18 +474,6 @@ msgstr "What do you need?"
 msgid "Не удалось загрузить каталог"
 msgstr "Couldn't load the catalog"
 
-#: src/pages/Chats.tsx
-#~ msgid "Мы сводим людей и запоминаем, что контакт состоялся — по этому считается время ответа. Сама переписка остаётся в Telegram."
-#~ msgstr "We connect people and note that contact happened — that's how response time is measured. The conversation itself stays in Telegram."
-
-#: src/pages/Home.tsx
-#~ msgid "Люди"
-#~ msgstr "People"
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Онлайн или очно"
-#~ msgstr "Online or in person"
-
 #: src/pages/Landing.tsx
 msgid "Кто поможет с учёбой в Чехии"
 msgstr "Who can help you study in Czechia"
@@ -582,10 +481,6 @@ msgstr "Who can help you study in Czechia"
 #: src/pages/Helper.tsx
 msgid "Свободные окна"
 msgstr "Open time slots"
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Не хватает"
-#~ msgstr "Missing"
 
 #: src/pages/Profile.tsx
 msgid "черновик — не видна в каталоге"
@@ -612,6 +507,7 @@ msgid "матан ČVUT"
 msgstr "calculus ČVUT"
 
 #. placeholder {0}: data.total
+#: src/pages/Ask.tsx
 #: src/pages/Results.tsx
 msgid "всего {0}"
 msgstr "{0} total"
@@ -632,10 +528,6 @@ msgstr "Pick what you can help with"
 msgid "Чем ты можешь помочь?"
 msgstr "What can you help with?"
 
-#: src/pages/Chats.tsx
-#~ msgid "Открыть переписку в Telegram"
-#~ msgstr "Open the chat in Telegram"
-
 #: src/pages/MyHelper.tsx
 msgid "Город"
 msgstr "City"
@@ -655,10 +547,6 @@ msgstr "What they help with"
 #: src/components/TabBar.tsx
 msgid "Закрыть"
 msgstr "Close"
-
-#: src/pages/Profile.tsx
-#~ msgid "Оформление"
-#~ msgstr "Appearance"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -732,10 +620,6 @@ msgstr "insurance, visa, bank, transfers"
 #: src/components/Phrase.tsx
 msgid "{0, plural, one {Готовил к этому же экзамену # человека} few {Готовил к этому же экзамену # человек} many {Готовил к этому же экзамену # человек} other {Готовил к этому же экзамену # человека}}"
 msgstr "{0, plural, one {Prepared # person for this exam} other {Prepared # people for this exam}}"
-
-#: src/pages/Chats.tsx
-#~ msgid "там же, где и все остальные разговоры"
-#~ msgstr "same place as your other chats"
 
 #: src/pages/MyHelper.tsx
 msgid "ČVUT FEL, 3 курс"
@@ -863,10 +747,6 @@ msgstr "čeština B2"
 msgid "Не получилось посчитать"
 msgstr "Could not count that"
 
-#: src/pages/Profile.tsx
-#~ msgid "Как в системе"
-#~ msgstr "Match the system"
-
 #: src/components/Phrase.tsx
 msgid "Документы и жизнь"
 msgstr "Documents and life"
@@ -884,15 +764,6 @@ msgstr "Optional. An empty field means you will agree on it."
 msgid "Написать"
 msgstr "Message"
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Расскажи своими словами"
-#~ msgstr "Tell it in your own words"
-
-#. placeholder {0}: parsed.matches
-#: src/pages/Ask.tsx
-#~ msgid "Показать {0}"
-#~ msgstr "Show {0}"
-
 #: src/pages/MyHelper.tsx
 msgid "Моя анкета"
 msgstr "My profile"
@@ -908,11 +779,6 @@ msgstr "No responses yet"
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"
 msgstr "Do you need help before the exam or during it?"
-
-#: src/components/TabBar.tsx
-#: src/pages/Mine.tsx
-#~ msgid "Мои"
-#~ msgstr "Mine"
 
 #: src/pages/MyHelper.tsx
 msgid "Что преподаёшь, где учишься, как проходят занятия. Своими словами."
@@ -948,10 +814,6 @@ msgstr "Tutors"
 #: src/components/Phrase.tsx
 msgid "лет на площадке"
 msgstr "years on the platform"
-
-#: src/pages/Ask.tsx
-#~ msgid "Дальше вопросов не будет — остальное отфильтруешь прямо в списке."
-#~ msgstr "No more questions after this — filter the rest right in the list."
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -14,8 +14,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: src/pages/Ask.tsx
-msgid "курсовая по экономике"
-msgstr "term paper in economics"
+#~ msgid "курсовая по экономике"
+#~ msgstr "term paper in economics"
 
 #: src/components/Incoming.tsx
 msgid "Заведи в Telegram публичный @username — иначе тебе не ответят"
@@ -389,8 +389,8 @@ msgid "за штуку"
 msgstr "per item"
 
 #: src/pages/Ask.tsx
-msgid "přijímačky на медицину"
-msgstr "přijímačky for medicine"
+#~ msgid "přijímačky на медицину"
+#~ msgstr "přijímačky for medicine"
 
 #: src/pages/MyHelper.tsx
 msgid "В каталоге"
@@ -621,6 +621,10 @@ msgstr "nostrification of a school certificate"
 msgid "Вуз, с которым ты работаешь"
 msgstr "A school you work with"
 
+#: src/pages/Ask.tsx
+msgid "помощь на экзамене по матану"
+msgstr "help at the calculus exam"
+
 #: src/pages/Offer.tsx
 msgid "Выбери, чем можешь помочь"
 msgstr "Pick what you can help with"
@@ -838,6 +842,10 @@ msgstr "Free for now. Once there are more people, listing these services will co
 #: src/pages/Life.tsx
 msgid "Не про учёбу"
 msgstr "Not about school"
+
+#: src/pages/Ask.tsx
+msgid "курсовая работа"
+msgstr "a term paper"
 
 #: src/components/Phrase.tsx
 msgid "Дешевле остальных, но этот экзамен не вёл"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -52,9 +52,17 @@ msgstr "Check your connection and try again."
 msgid "Онлайн"
 msgstr "Online"
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Напиши хотя бы пару предложений — предметы, цену и как удобно заниматься."
+#~ msgstr "Write at least a couple sentences — subjects, price, and how you like to meet."
+
 #: src/pages/Request.tsx
 msgid "Такой заявки нет"
 msgstr "No such request"
+
+#: src/pages/Ask.tsx
+msgid "Добавь предмет — по одному сроку искать нечего."
+msgstr "Name a subject — a date on its own is nothing to search for."
 
 #: src/pages/Landing.tsx
 msgid "Přijímačky"
@@ -67,6 +75,10 @@ msgstr "Visibility"
 #: src/components/TabBar.tsx
 msgid "Поиск"
 msgstr "Search"
+
+#: src/pages/MyHelper.tsx
+#~ msgid "Предметы и цены"
+#~ msgstr "Subjects and prices"
 
 #: src/components/Incoming.tsx
 msgid "Не сейчас"
@@ -106,6 +118,10 @@ msgstr "per week"
 msgid "Откликнуться"
 msgstr "Respond"
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Когда ты свободен"
+#~ msgstr "When you're free"
+
 #: src/pages/MyHelper.tsx
 msgid "Где"
 msgstr "Where"
@@ -118,6 +134,10 @@ msgstr "Add a service"
 msgid "Это не наши услуги. Мы получаем комиссию с партнёра, со студента — ничего."
 msgstr "These aren't our services. We take a commission from the partner, nothing from the student."
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Какие предметы"
+#~ msgstr "Which subjects"
+
 #: src/pages/Home.tsx
 msgid "Вещи"
 msgstr "Things"
@@ -125,6 +145,10 @@ msgstr "Things"
 #: src/pages/MyHelper.tsx
 msgid "Всё можно менять когда угодно. Пустые поля просто не показываем."
 msgstr "Change anything whenever you like. Empty fields simply are not shown."
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Одним куском, как другу. Анкету соберём сами."
+#~ msgstr "All in one go, like to a friend. We'll put the profile together."
 
 #: src/pages/Profile.tsx
 msgid "На каких языках тебе удобно"
@@ -142,6 +166,10 @@ msgstr "No one matches this search yet. Post a request — then people will find
 msgid "Оформление: как в системе. Нажми, чтобы сменить"
 msgstr "Appearance: follows the system. Tap to change"
 
+#: src/pages/Profile.tsx
+#~ msgid "Хочу помогать"
+#~ msgstr "I want to help"
+
 #: src/components/AppHeader.tsx
 msgid "Язык"
 msgstr "Language"
@@ -150,6 +178,10 @@ msgstr "Language"
 #: src/components/Phrase.tsx
 msgid "Твой предмет — {0}"
 msgstr "Your subject — {0}"
+
+#: src/pages/Profile.tsx
+#~ msgid "Тёмное"
+#~ msgstr "Dark"
 
 #. placeholder {0}: picked.size
 #: src/pages/Offer.tsx
@@ -243,6 +275,27 @@ msgstr "Price"
 msgid "И так, и так"
 msgstr "Either way"
 
+#: src/components/TabBar.tsx
+#: src/pages/Chats.tsx
+#~ msgid "Чаты"
+#~ msgstr "Chats"
+
+#: src/pages/MyHelper.tsx
+#~ msgid "Без предмета"
+#~ msgstr "No subject"
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Сколько берёшь"
+#~ msgstr "What you charge"
+
+#: src/pages/Landing.tsx
+#~ msgid "Работы и материалы"
+#~ msgstr "Papers and materials"
+
+#: src/pages/Profile.tsx
+#~ msgid "опубликована"
+#~ msgstr "published"
+
 #: src/pages/Ask.tsx
 msgid "Убери что-нибудь из уточнений выше или напиши иначе."
 msgstr "Drop one of the details above, or put it differently."
@@ -259,6 +312,10 @@ msgstr "Decline"
 msgid "Пока без откликов"
 msgstr "No responses yet"
 
+#: src/pages/Chats.tsx
+#~ msgid "Разговоры мы не храним"
+#~ msgstr "We don't store conversations"
+
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
 msgid "За что цена"
@@ -269,6 +326,10 @@ msgstr "What the price is for"
 #: src/pages/OfferPrices.tsx
 msgid "за работу"
 msgstr "per assignment"
+
+#: src/pages/MyHelper.tsx
+#~ msgid "Пока ни одного. Найди предмет ниже — без них тебя не найдут по поиску."
+#~ msgstr "None yet. Find a subject below — without them search cannot reach you."
 
 #: src/pages/MyHelper.tsx
 msgid "Тебя видят в поиске и могут написать."
@@ -285,6 +346,10 @@ msgstr "in the catalog"
 #: src/components/Phrase.tsx
 msgid "И то, и другое"
 msgstr "Both"
+
+#: src/pages/Ask.tsx
+#~ msgid "нужен матан на ČVUT, экзамен 14 февраля"
+#~ msgstr "need calculus at ČVUT, exam on Feb 14"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -345,6 +410,10 @@ msgstr "tutoring, written work, exam help"
 msgid "Дальше вопросов не будет."
 msgstr "No more questions after this."
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Получилось так"
+#~ msgstr "Here's how it turned out"
+
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
@@ -374,6 +443,10 @@ msgstr "How you work"
 #: src/pages/Profile.tsx
 msgid "Мои услуги"
 msgstr "My services"
+
+#: src/pages/Ask.tsx
+#~ msgid "Искать всё равно"
+#~ msgstr "Search anyway"
 
 #: src/components/TabBar.tsx
 msgid "опиши задачу — придут отклики"
@@ -411,6 +484,10 @@ msgstr "Profile"
 #: src/pages/Helper.tsx
 msgid "Возможно, человек скрыл его."
 msgstr "Maybe they hid it."
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Без расписания анкету покажем, но реже — люди чаще пишут тем, у кого видно свободные дни."
+#~ msgstr "Without a schedule we'll still show your profile, just less often — people tend to message those whose free days are visible."
 
 #: src/pages/MyHelper.tsx
 msgid "Строчка под именем"
@@ -453,9 +530,17 @@ msgstr "Who can help"
 msgid "Это первое, что читают. Пара живых предложений работает лучше списка."
 msgstr "This is the first thing people read. A couple of real sentences beat a list."
 
+#: src/pages/Profile.tsx
+#~ msgid "По этому мы отсеиваем тех, с кем вы друг друга не поймёте."
+#~ msgstr "That's how we filter out people you wouldn't understand each other with."
+
 #: src/pages/Results.tsx
 msgid "изменить"
 msgstr "change"
+
+#: src/pages/Profile.tsx
+#~ msgid "Светлое"
+#~ msgstr "Light"
 
 #: src/components/TabBar.tsx
 msgid "Мне нужна помощь"
@@ -474,6 +559,18 @@ msgstr "What do you need?"
 msgid "Не удалось загрузить каталог"
 msgstr "Couldn't load the catalog"
 
+#: src/pages/Chats.tsx
+#~ msgid "Мы сводим людей и запоминаем, что контакт состоялся — по этому считается время ответа. Сама переписка остаётся в Telegram."
+#~ msgstr "We connect people and note that contact happened — that's how response time is measured. The conversation itself stays in Telegram."
+
+#: src/pages/Home.tsx
+#~ msgid "Люди"
+#~ msgstr "People"
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Онлайн или очно"
+#~ msgstr "Online or in person"
+
 #: src/pages/Landing.tsx
 msgid "Кто поможет с учёбой в Чехии"
 msgstr "Who can help you study in Czechia"
@@ -481,6 +578,10 @@ msgstr "Who can help you study in Czechia"
 #: src/pages/Helper.tsx
 msgid "Свободные окна"
 msgstr "Open time slots"
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Не хватает"
+#~ msgstr "Missing"
 
 #: src/pages/Profile.tsx
 msgid "черновик — не видна в каталоге"
@@ -528,6 +629,10 @@ msgstr "Pick what you can help with"
 msgid "Чем ты можешь помочь?"
 msgstr "What can you help with?"
 
+#: src/pages/Chats.tsx
+#~ msgid "Открыть переписку в Telegram"
+#~ msgstr "Open the chat in Telegram"
+
 #: src/pages/MyHelper.tsx
 msgid "Город"
 msgstr "City"
@@ -547,6 +652,10 @@ msgstr "What they help with"
 #: src/components/TabBar.tsx
 msgid "Закрыть"
 msgstr "Close"
+
+#: src/pages/Profile.tsx
+#~ msgid "Оформление"
+#~ msgstr "Appearance"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -620,6 +729,10 @@ msgstr "insurance, visa, bank, transfers"
 #: src/components/Phrase.tsx
 msgid "{0, plural, one {Готовил к этому же экзамену # человека} few {Готовил к этому же экзамену # человек} many {Готовил к этому же экзамену # человек} other {Готовил к этому же экзамену # человека}}"
 msgstr "{0, plural, one {Prepared # person for this exam} other {Prepared # people for this exam}}"
+
+#: src/pages/Chats.tsx
+#~ msgid "там же, где и все остальные разговоры"
+#~ msgstr "same place as your other chats"
 
 #: src/pages/MyHelper.tsx
 msgid "ČVUT FEL, 3 курс"
@@ -710,6 +823,10 @@ msgstr "No requests yet"
 msgid "Убрать"
 msgstr "Remove"
 
+#: src/pages/Ask.tsx
+msgid "По этому пока не найти"
+msgstr "Not enough to search on"
+
 #: src/pages/Results.tsx
 msgid "Пока никого"
 msgstr "No one yet"
@@ -747,6 +864,10 @@ msgstr "čeština B2"
 msgid "Не получилось посчитать"
 msgstr "Could not count that"
 
+#: src/pages/Profile.tsx
+#~ msgid "Как в системе"
+#~ msgstr "Match the system"
+
 #: src/components/Phrase.tsx
 msgid "Документы и жизнь"
 msgstr "Documents and life"
@@ -764,6 +885,15 @@ msgstr "Optional. An empty field means you will agree on it."
 msgid "Написать"
 msgstr "Message"
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Расскажи своими словами"
+#~ msgstr "Tell it in your own words"
+
+#. placeholder {0}: parsed.matches
+#: src/pages/Ask.tsx
+#~ msgid "Показать {0}"
+#~ msgstr "Show {0}"
+
 #: src/pages/MyHelper.tsx
 msgid "Моя анкета"
 msgstr "My profile"
@@ -779,6 +909,11 @@ msgstr "No responses yet"
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"
 msgstr "Do you need help before the exam or during it?"
+
+#: src/components/TabBar.tsx
+#: src/pages/Mine.tsx
+#~ msgid "Мои"
+#~ msgstr "Mine"
 
 #: src/pages/MyHelper.tsx
 msgid "Что преподаёшь, где учишься, как проходят занятия. Своими словами."
@@ -814,6 +949,10 @@ msgstr "Tutors"
 #: src/components/Phrase.tsx
 msgid "лет на площадке"
 msgstr "years on the platform"
+
+#: src/pages/Ask.tsx
+#~ msgid "Дальше вопросов не будет — остальное отфильтруешь прямо в списке."
+#~ msgstr "No more questions after this — filter the rest right in the list."
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: src/pages/Ask.tsx
+msgid "курсовая по экономике"
+msgstr "term paper in economics"
+
 #: src/components/Incoming.tsx
 msgid "Заведи в Telegram публичный @username — иначе тебе не ответят"
 msgstr "Set a public @username in Telegram — otherwise nobody can write back"
@@ -81,8 +85,8 @@ msgid "Kč"
 msgstr "Kč"
 
 #: src/pages/Ask.tsx
-msgid "страховка на год"
-msgstr "insurance for a year"
+#~ msgid "страховка на год"
+#~ msgstr "insurance for a year"
 
 #: src/pages/MyHelper.tsx
 msgid "Скрыть"
@@ -791,6 +795,7 @@ msgstr "Works specifically with this university"
 msgid "Открыть в Telegram"
 msgstr "Open in Telegram"
 
+#: src/pages/Ask.tsx
 #: src/pages/Results.tsx
 msgid "Проверь соединение и попробуй ещё раз."
 msgstr "Check your connection and try again."
@@ -853,6 +858,10 @@ msgstr "You declined"
 #: src/pages/Ask.tsx
 msgid "čeština B2"
 msgstr "čeština B2"
+
+#: src/pages/Ask.tsx
+msgid "Не получилось посчитать"
+msgstr "Could not count that"
 
 #: src/pages/Profile.tsx
 #~ msgid "Как в системе"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -623,7 +623,7 @@ msgstr "A school you work with"
 
 #: src/pages/Ask.tsx
 msgid "помощь на экзамене по матану"
-msgstr "help at the calculus exam"
+msgstr "calculus tutor"
 
 #: src/pages/Offer.tsx
 msgid "Выбери, чем можешь помочь"
@@ -845,7 +845,7 @@ msgstr "Not about school"
 
 #: src/pages/Ask.tsx
 msgid "курсовая работа"
-msgstr "a term paper"
+msgstr "bachelor thesis"
 
 #: src/components/Phrase.tsx
 msgid "Дешевле остальных, но этот экзамен не вёл"

--- a/apps/web/src/locales/ru/messages.po
+++ b/apps/web/src/locales/ru/messages.po
@@ -52,9 +52,17 @@ msgstr "Проверь связь и попробуй ещё раз."
 msgid "Онлайн"
 msgstr "Онлайн"
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Напиши хотя бы пару предложений — предметы, цену и как удобно заниматься."
+#~ msgstr "Напиши хотя бы пару предложений — предметы, цену и как удобно заниматься."
+
 #: src/pages/Request.tsx
 msgid "Такой заявки нет"
 msgstr "Такой заявки нет"
+
+#: src/pages/Ask.tsx
+msgid "Добавь предмет — по одному сроку искать нечего."
+msgstr "Добавь предмет — по одному сроку искать нечего."
 
 #: src/pages/Landing.tsx
 msgid "Přijímačky"
@@ -67,6 +75,10 @@ msgstr "Видимость"
 #: src/components/TabBar.tsx
 msgid "Поиск"
 msgstr "Поиск"
+
+#: src/pages/MyHelper.tsx
+#~ msgid "Предметы и цены"
+#~ msgstr "Предметы и цены"
 
 #: src/components/Incoming.tsx
 msgid "Не сейчас"
@@ -106,6 +118,10 @@ msgstr "за неделю"
 msgid "Откликнуться"
 msgstr "Откликнуться"
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Когда ты свободен"
+#~ msgstr "Когда ты свободен"
+
 #: src/pages/MyHelper.tsx
 msgid "Где"
 msgstr "Где"
@@ -118,6 +134,10 @@ msgstr "Добавить услугу"
 msgid "Это не наши услуги. Мы получаем комиссию с партнёра, со студента — ничего."
 msgstr "Это не наши услуги. Мы получаем комиссию с партнёра, со студента — ничего."
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Какие предметы"
+#~ msgstr "Какие предметы"
+
 #: src/pages/Home.tsx
 msgid "Вещи"
 msgstr "Вещи"
@@ -125,6 +145,10 @@ msgstr "Вещи"
 #: src/pages/MyHelper.tsx
 msgid "Всё можно менять когда угодно. Пустые поля просто не показываем."
 msgstr "Всё можно менять когда угодно. Пустые поля просто не показываем."
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Одним куском, как другу. Анкету соберём сами."
+#~ msgstr "Одним куском, как другу. Анкету соберём сами."
 
 #: src/pages/Profile.tsx
 msgid "На каких языках тебе удобно"
@@ -142,6 +166,10 @@ msgstr "По этому запросу ещё нет никого. Создай 
 msgid "Оформление: как в системе. Нажми, чтобы сменить"
 msgstr "Оформление: как в системе. Нажми, чтобы сменить"
 
+#: src/pages/Profile.tsx
+#~ msgid "Хочу помогать"
+#~ msgstr "Хочу помогать"
+
 #: src/components/AppHeader.tsx
 msgid "Язык"
 msgstr "Язык"
@@ -150,6 +178,10 @@ msgstr "Язык"
 #: src/components/Phrase.tsx
 msgid "Твой предмет — {0}"
 msgstr "Твой предмет — {0}"
+
+#: src/pages/Profile.tsx
+#~ msgid "Тёмное"
+#~ msgstr "Тёмное"
 
 #. placeholder {0}: picked.size
 #: src/pages/Offer.tsx
@@ -243,6 +275,27 @@ msgstr "Цена"
 msgid "И так, и так"
 msgstr "И так, и так"
 
+#: src/components/TabBar.tsx
+#: src/pages/Chats.tsx
+#~ msgid "Чаты"
+#~ msgstr "Чаты"
+
+#: src/pages/MyHelper.tsx
+#~ msgid "Без предмета"
+#~ msgstr "Без предмета"
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Сколько берёшь"
+#~ msgstr "Сколько берёшь"
+
+#: src/pages/Landing.tsx
+#~ msgid "Работы и материалы"
+#~ msgstr "Работы и материалы"
+
+#: src/pages/Profile.tsx
+#~ msgid "опубликована"
+#~ msgstr "опубликована"
+
 #: src/pages/Ask.tsx
 msgid "Убери что-нибудь из уточнений выше или напиши иначе."
 msgstr "Убери что-нибудь из уточнений выше или напиши иначе."
@@ -259,6 +312,10 @@ msgstr "Отказать"
 msgid "Пока без откликов"
 msgstr "Пока без откликов"
 
+#: src/pages/Chats.tsx
+#~ msgid "Разговоры мы не храним"
+#~ msgstr "Разговоры мы не храним"
+
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
 msgid "За что цена"
@@ -269,6 +326,10 @@ msgstr "За что цена"
 #: src/pages/OfferPrices.tsx
 msgid "за работу"
 msgstr "за работу"
+
+#: src/pages/MyHelper.tsx
+#~ msgid "Пока ни одного. Найди предмет ниже — без них тебя не найдут по поиску."
+#~ msgstr "Пока ни одного. Найди предмет ниже — без них тебя не найдут по поиску."
 
 #: src/pages/MyHelper.tsx
 msgid "Тебя видят в поиске и могут написать."
@@ -285,6 +346,10 @@ msgstr "в каталоге"
 #: src/components/Phrase.tsx
 msgid "И то, и другое"
 msgstr "И то, и другое"
+
+#: src/pages/Ask.tsx
+#~ msgid "нужен матан на ČVUT, экзамен 14 февраля"
+#~ msgstr "нужен матан на ČVUT, экзамен 14 февраля"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -345,6 +410,10 @@ msgstr "репетиторство, работы, помощь"
 msgid "Дальше вопросов не будет."
 msgstr "Дальше вопросов не будет."
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Получилось так"
+#~ msgstr "Получилось так"
+
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
@@ -374,6 +443,10 @@ msgstr "Как занимаешься"
 #: src/pages/Profile.tsx
 msgid "Мои услуги"
 msgstr "Мои услуги"
+
+#: src/pages/Ask.tsx
+#~ msgid "Искать всё равно"
+#~ msgstr "Искать всё равно"
 
 #: src/components/TabBar.tsx
 msgid "опиши задачу — придут отклики"
@@ -411,6 +484,10 @@ msgstr "Профиль"
 #: src/pages/Helper.tsx
 msgid "Возможно, человек скрыл его."
 msgstr "Возможно, человек скрыл его."
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Без расписания анкету покажем, но реже — люди чаще пишут тем, у кого видно свободные дни."
+#~ msgstr "Без расписания анкету покажем, но реже — люди чаще пишут тем, у кого видно свободные дни."
 
 #: src/pages/MyHelper.tsx
 msgid "Строчка под именем"
@@ -453,9 +530,17 @@ msgstr "Кто может помочь"
 msgid "Это первое, что читают. Пара живых предложений работает лучше списка."
 msgstr "Это первое, что читают. Пара живых предложений работает лучше списка."
 
+#: src/pages/Profile.tsx
+#~ msgid "По этому мы отсеиваем тех, с кем вы друг друга не поймёте."
+#~ msgstr "По этому мы отсеиваем тех, с кем вы друг друга не поймёте."
+
 #: src/pages/Results.tsx
 msgid "изменить"
 msgstr "изменить"
+
+#: src/pages/Profile.tsx
+#~ msgid "Светлое"
+#~ msgstr "Светлое"
 
 #: src/components/TabBar.tsx
 msgid "Мне нужна помощь"
@@ -474,6 +559,18 @@ msgstr "Что нужно?"
 msgid "Не удалось загрузить каталог"
 msgstr "Не удалось загрузить каталог"
 
+#: src/pages/Chats.tsx
+#~ msgid "Мы сводим людей и запоминаем, что контакт состоялся — по этому считается время ответа. Сама переписка остаётся в Telegram."
+#~ msgstr "Мы сводим людей и запоминаем, что контакт состоялся — по этому считается время ответа. Сама переписка остаётся в Telegram."
+
+#: src/pages/Home.tsx
+#~ msgid "Люди"
+#~ msgstr "Люди"
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Онлайн или очно"
+#~ msgstr "Онлайн или очно"
+
 #: src/pages/Landing.tsx
 msgid "Кто поможет с учёбой в Чехии"
 msgstr "Кто поможет с учёбой в Чехии"
@@ -481,6 +578,10 @@ msgstr "Кто поможет с учёбой в Чехии"
 #: src/pages/Helper.tsx
 msgid "Свободные окна"
 msgstr "Свободные окна"
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Не хватает"
+#~ msgstr "Не хватает"
 
 #: src/pages/Profile.tsx
 msgid "черновик — не видна в каталоге"
@@ -528,6 +629,10 @@ msgstr "Выбери, чем можешь помочь"
 msgid "Чем ты можешь помочь?"
 msgstr "Чем ты можешь помочь?"
 
+#: src/pages/Chats.tsx
+#~ msgid "Открыть переписку в Telegram"
+#~ msgstr "Открыть переписку в Telegram"
+
 #: src/pages/MyHelper.tsx
 msgid "Город"
 msgstr "Город"
@@ -547,6 +652,10 @@ msgstr "Чем помогает"
 #: src/components/TabBar.tsx
 msgid "Закрыть"
 msgstr "Закрыть"
+
+#: src/pages/Profile.tsx
+#~ msgid "Оформление"
+#~ msgstr "Оформление"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -620,6 +729,10 @@ msgstr "страховка, виза, банк, переводы"
 #: src/components/Phrase.tsx
 msgid "{0, plural, one {Готовил к этому же экзамену # человека} few {Готовил к этому же экзамену # человек} many {Готовил к этому же экзамену # человек} other {Готовил к этому же экзамену # человека}}"
 msgstr "{0, plural, one {Готовил к этому же экзамену # человека} few {Готовил к этому же экзамену # человек} many {Готовил к этому же экзамену # человек} other {Готовил к этому же экзамену # человека}}"
+
+#: src/pages/Chats.tsx
+#~ msgid "там же, где и все остальные разговоры"
+#~ msgstr "там же, где и все остальные разговоры"
 
 #: src/pages/MyHelper.tsx
 msgid "ČVUT FEL, 3 курс"
@@ -710,6 +823,10 @@ msgstr "Заявок пока нет"
 msgid "Убрать"
 msgstr "Убрать"
 
+#: src/pages/Ask.tsx
+msgid "По этому пока не найти"
+msgstr "По этому пока не найти"
+
 #: src/pages/Results.tsx
 msgid "Пока никого"
 msgstr "Пока никого"
@@ -747,6 +864,10 @@ msgstr "čeština B2"
 msgid "Не получилось посчитать"
 msgstr "Не получилось посчитать"
 
+#: src/pages/Profile.tsx
+#~ msgid "Как в системе"
+#~ msgstr "Как в системе"
+
 #: src/components/Phrase.tsx
 msgid "Документы и жизнь"
 msgstr "Документы и жизнь"
@@ -764,6 +885,15 @@ msgstr "Необязательно. Пустое поле значит «дог�
 msgid "Написать"
 msgstr "Написать"
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Расскажи своими словами"
+#~ msgstr "Расскажи своими словами"
+
+#. placeholder {0}: parsed.matches
+#: src/pages/Ask.tsx
+#~ msgid "Показать {0}"
+#~ msgstr "Показать {0}"
+
 #: src/pages/MyHelper.tsx
 msgid "Моя анкета"
 msgstr "Моя анкета"
@@ -779,6 +909,11 @@ msgstr "Откликов пока нет"
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"
 msgstr "Помощь нужна до экзамена или на нём?"
+
+#: src/components/TabBar.tsx
+#: src/pages/Mine.tsx
+#~ msgid "Мои"
+#~ msgstr "Мои"
 
 #: src/pages/MyHelper.tsx
 msgid "Что преподаёшь, где учишься, как проходят занятия. Своими словами."
@@ -814,6 +949,10 @@ msgstr "Репетиторы"
 #: src/components/Phrase.tsx
 msgid "лет на площадке"
 msgstr "лет на площадке"
+
+#: src/pages/Ask.tsx
+#~ msgid "Дальше вопросов не будет — остальное отфильтруешь прямо в списке."
+#~ msgstr "Дальше вопросов не будет — остальное отфильтруешь прямо в списке."
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx

--- a/apps/web/src/locales/ru/messages.po
+++ b/apps/web/src/locales/ru/messages.po
@@ -52,10 +52,6 @@ msgstr "Проверь связь и попробуй ещё раз."
 msgid "Онлайн"
 msgstr "Онлайн"
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Напиши хотя бы пару предложений — предметы, цену и как удобно заниматься."
-#~ msgstr "Напиши хотя бы пару предложений — предметы, цену и как удобно заниматься."
-
 #: src/pages/Request.tsx
 msgid "Такой заявки нет"
 msgstr "Такой заявки нет"
@@ -72,10 +68,6 @@ msgstr "Видимость"
 msgid "Поиск"
 msgstr "Поиск"
 
-#: src/pages/MyHelper.tsx
-#~ msgid "Предметы и цены"
-#~ msgstr "Предметы и цены"
-
 #: src/components/Incoming.tsx
 msgid "Не сейчас"
 msgstr "Не сейчас"
@@ -83,10 +75,6 @@ msgstr "Не сейчас"
 #: src/pages/MyHelper.tsx
 msgid "Kč"
 msgstr "Kč"
-
-#: src/pages/Ask.tsx
-#~ msgid "страховка на год"
-#~ msgstr "страховка на год"
 
 #: src/pages/MyHelper.tsx
 msgid "Скрыть"
@@ -118,10 +106,6 @@ msgstr "за неделю"
 msgid "Откликнуться"
 msgstr "Откликнуться"
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Когда ты свободен"
-#~ msgstr "Когда ты свободен"
-
 #: src/pages/MyHelper.tsx
 msgid "Где"
 msgstr "Где"
@@ -134,10 +118,6 @@ msgstr "Добавить услугу"
 msgid "Это не наши услуги. Мы получаем комиссию с партнёра, со студента — ничего."
 msgstr "Это не наши услуги. Мы получаем комиссию с партнёра, со студента — ничего."
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Какие предметы"
-#~ msgstr "Какие предметы"
-
 #: src/pages/Home.tsx
 msgid "Вещи"
 msgstr "Вещи"
@@ -145,10 +125,6 @@ msgstr "Вещи"
 #: src/pages/MyHelper.tsx
 msgid "Всё можно менять когда угодно. Пустые поля просто не показываем."
 msgstr "Всё можно менять когда угодно. Пустые поля просто не показываем."
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Одним куском, как другу. Анкету соберём сами."
-#~ msgstr "Одним куском, как другу. Анкету соберём сами."
 
 #: src/pages/Profile.tsx
 msgid "На каких языках тебе удобно"
@@ -166,10 +142,6 @@ msgstr "По этому запросу ещё нет никого. Создай 
 msgid "Оформление: как в системе. Нажми, чтобы сменить"
 msgstr "Оформление: как в системе. Нажми, чтобы сменить"
 
-#: src/pages/Profile.tsx
-#~ msgid "Хочу помогать"
-#~ msgstr "Хочу помогать"
-
 #: src/components/AppHeader.tsx
 msgid "Язык"
 msgstr "Язык"
@@ -178,10 +150,6 @@ msgstr "Язык"
 #: src/components/Phrase.tsx
 msgid "Твой предмет — {0}"
 msgstr "Твой предмет — {0}"
-
-#: src/pages/Profile.tsx
-#~ msgid "Тёмное"
-#~ msgstr "Тёмное"
 
 #. placeholder {0}: picked.size
 #: src/pages/Offer.tsx
@@ -199,10 +167,6 @@ msgstr "расскажи своими словами, анкету соберё�
 #: src/components/Incoming.tsx
 msgid "Заявку уже закрыли"
 msgstr "Заявку уже закрыли"
-
-#: src/pages/Ask.tsx
-msgid "всего {total}"
-msgstr "всего {total}"
 
 #: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
@@ -279,27 +243,6 @@ msgstr "Цена"
 msgid "И так, и так"
 msgstr "И так, и так"
 
-#: src/components/TabBar.tsx
-#: src/pages/Chats.tsx
-#~ msgid "Чаты"
-#~ msgstr "Чаты"
-
-#: src/pages/MyHelper.tsx
-#~ msgid "Без предмета"
-#~ msgstr "Без предмета"
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Сколько берёшь"
-#~ msgstr "Сколько берёшь"
-
-#: src/pages/Landing.tsx
-#~ msgid "Работы и материалы"
-#~ msgstr "Работы и материалы"
-
-#: src/pages/Profile.tsx
-#~ msgid "опубликована"
-#~ msgstr "опубликована"
-
 #: src/pages/Ask.tsx
 msgid "Убери что-нибудь из уточнений выше или напиши иначе."
 msgstr "Убери что-нибудь из уточнений выше или напиши иначе."
@@ -316,10 +259,6 @@ msgstr "Отказать"
 msgid "Пока без откликов"
 msgstr "Пока без откликов"
 
-#: src/pages/Chats.tsx
-#~ msgid "Разговоры мы не храним"
-#~ msgstr "Разговоры мы не храним"
-
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
 msgid "За что цена"
@@ -330,10 +269,6 @@ msgstr "За что цена"
 #: src/pages/OfferPrices.tsx
 msgid "за работу"
 msgstr "за работу"
-
-#: src/pages/MyHelper.tsx
-#~ msgid "Пока ни одного. Найди предмет ниже — без них тебя не найдут по поиску."
-#~ msgstr "Пока ни одного. Найди предмет ниже — без них тебя не найдут по поиску."
 
 #: src/pages/MyHelper.tsx
 msgid "Тебя видят в поиске и могут написать."
@@ -350,10 +285,6 @@ msgstr "в каталоге"
 #: src/components/Phrase.tsx
 msgid "И то, и другое"
 msgstr "И то, и другое"
-
-#: src/pages/Ask.tsx
-#~ msgid "нужен матан на ČVUT, экзамен 14 февраля"
-#~ msgstr "нужен матан на ČVUT, экзамен 14 февраля"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -414,10 +345,6 @@ msgstr "репетиторство, работы, помощь"
 msgid "Дальше вопросов не будет."
 msgstr "Дальше вопросов не будет."
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Получилось так"
-#~ msgstr "Получилось так"
-
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
@@ -447,10 +374,6 @@ msgstr "Как занимаешься"
 #: src/pages/Profile.tsx
 msgid "Мои услуги"
 msgstr "Мои услуги"
-
-#: src/pages/Ask.tsx
-#~ msgid "Искать всё равно"
-#~ msgstr "Искать всё равно"
 
 #: src/components/TabBar.tsx
 msgid "опиши задачу — придут отклики"
@@ -488,10 +411,6 @@ msgstr "Профиль"
 #: src/pages/Helper.tsx
 msgid "Возможно, человек скрыл его."
 msgstr "Возможно, человек скрыл его."
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Без расписания анкету покажем, но реже — люди чаще пишут тем, у кого видно свободные дни."
-#~ msgstr "Без расписания анкету покажем, но реже — люди чаще пишут тем, у кого видно свободные дни."
 
 #: src/pages/MyHelper.tsx
 msgid "Строчка под именем"
@@ -534,17 +453,9 @@ msgstr "Кто может помочь"
 msgid "Это первое, что читают. Пара живых предложений работает лучше списка."
 msgstr "Это первое, что читают. Пара живых предложений работает лучше списка."
 
-#: src/pages/Profile.tsx
-#~ msgid "По этому мы отсеиваем тех, с кем вы друг друга не поймёте."
-#~ msgstr "По этому мы отсеиваем тех, с кем вы друг друга не поймёте."
-
 #: src/pages/Results.tsx
 msgid "изменить"
 msgstr "изменить"
-
-#: src/pages/Profile.tsx
-#~ msgid "Светлое"
-#~ msgstr "Светлое"
 
 #: src/components/TabBar.tsx
 msgid "Мне нужна помощь"
@@ -563,18 +474,6 @@ msgstr "Что нужно?"
 msgid "Не удалось загрузить каталог"
 msgstr "Не удалось загрузить каталог"
 
-#: src/pages/Chats.tsx
-#~ msgid "Мы сводим людей и запоминаем, что контакт состоялся — по этому считается время ответа. Сама переписка остаётся в Telegram."
-#~ msgstr "Мы сводим людей и запоминаем, что контакт состоялся — по этому считается время ответа. Сама переписка остаётся в Telegram."
-
-#: src/pages/Home.tsx
-#~ msgid "Люди"
-#~ msgstr "Люди"
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Онлайн или очно"
-#~ msgstr "Онлайн или очно"
-
 #: src/pages/Landing.tsx
 msgid "Кто поможет с учёбой в Чехии"
 msgstr "Кто поможет с учёбой в Чехии"
@@ -582,10 +481,6 @@ msgstr "Кто поможет с учёбой в Чехии"
 #: src/pages/Helper.tsx
 msgid "Свободные окна"
 msgstr "Свободные окна"
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Не хватает"
-#~ msgstr "Не хватает"
 
 #: src/pages/Profile.tsx
 msgid "черновик — не видна в каталоге"
@@ -612,6 +507,7 @@ msgid "матан ČVUT"
 msgstr "матан ČVUT"
 
 #. placeholder {0}: data.total
+#: src/pages/Ask.tsx
 #: src/pages/Results.tsx
 msgid "всего {0}"
 msgstr "всего {0}"
@@ -632,10 +528,6 @@ msgstr "Выбери, чем можешь помочь"
 msgid "Чем ты можешь помочь?"
 msgstr "Чем ты можешь помочь?"
 
-#: src/pages/Chats.tsx
-#~ msgid "Открыть переписку в Telegram"
-#~ msgstr "Открыть переписку в Telegram"
-
 #: src/pages/MyHelper.tsx
 msgid "Город"
 msgstr "Город"
@@ -655,10 +547,6 @@ msgstr "Чем помогает"
 #: src/components/TabBar.tsx
 msgid "Закрыть"
 msgstr "Закрыть"
-
-#: src/pages/Profile.tsx
-#~ msgid "Оформление"
-#~ msgstr "Оформление"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -732,10 +620,6 @@ msgstr "страховка, виза, банк, переводы"
 #: src/components/Phrase.tsx
 msgid "{0, plural, one {Готовил к этому же экзамену # человека} few {Готовил к этому же экзамену # человек} many {Готовил к этому же экзамену # человек} other {Готовил к этому же экзамену # человека}}"
 msgstr "{0, plural, one {Готовил к этому же экзамену # человека} few {Готовил к этому же экзамену # человек} many {Готовил к этому же экзамену # человек} other {Готовил к этому же экзамену # человека}}"
-
-#: src/pages/Chats.tsx
-#~ msgid "там же, где и все остальные разговоры"
-#~ msgstr "там же, где и все остальные разговоры"
 
 #: src/pages/MyHelper.tsx
 msgid "ČVUT FEL, 3 курс"
@@ -863,10 +747,6 @@ msgstr "čeština B2"
 msgid "Не получилось посчитать"
 msgstr "Не получилось посчитать"
 
-#: src/pages/Profile.tsx
-#~ msgid "Как в системе"
-#~ msgstr "Как в системе"
-
 #: src/components/Phrase.tsx
 msgid "Документы и жизнь"
 msgstr "Документы и жизнь"
@@ -884,15 +764,6 @@ msgstr "Необязательно. Пустое поле значит «дог�
 msgid "Написать"
 msgstr "Написать"
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Расскажи своими словами"
-#~ msgstr "Расскажи своими словами"
-
-#. placeholder {0}: parsed.matches
-#: src/pages/Ask.tsx
-#~ msgid "Показать {0}"
-#~ msgstr "Показать {0}"
-
 #: src/pages/MyHelper.tsx
 msgid "Моя анкета"
 msgstr "Моя анкета"
@@ -908,11 +779,6 @@ msgstr "Откликов пока нет"
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"
 msgstr "Помощь нужна до экзамена или на нём?"
-
-#: src/components/TabBar.tsx
-#: src/pages/Mine.tsx
-#~ msgid "Мои"
-#~ msgstr "Мои"
 
 #: src/pages/MyHelper.tsx
 msgid "Что преподаёшь, где учишься, как проходят занятия. Своими словами."
@@ -948,10 +814,6 @@ msgstr "Репетиторы"
 #: src/components/Phrase.tsx
 msgid "лет на площадке"
 msgstr "лет на площадке"
-
-#: src/pages/Ask.tsx
-#~ msgid "Дальше вопросов не будет — остальное отфильтруешь прямо в списке."
-#~ msgstr "Дальше вопросов не будет — остальное отфильтруешь прямо в списке."
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx

--- a/apps/web/src/locales/ru/messages.po
+++ b/apps/web/src/locales/ru/messages.po
@@ -14,8 +14,8 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
 #: src/pages/Ask.tsx
-msgid "курсовая по экономике"
-msgstr "курсовая по экономике"
+#~ msgid "курсовая по экономике"
+#~ msgstr "курсовая по экономике"
 
 #: src/components/Incoming.tsx
 msgid "Заведи в Telegram публичный @username — иначе тебе не ответят"
@@ -389,8 +389,8 @@ msgid "за штуку"
 msgstr "за штуку"
 
 #: src/pages/Ask.tsx
-msgid "přijímačky на медицину"
-msgstr "přijímačky на медицину"
+#~ msgid "přijímačky на медицину"
+#~ msgstr "přijímačky на медицину"
 
 #: src/pages/MyHelper.tsx
 msgid "В каталоге"
@@ -621,6 +621,10 @@ msgstr "нострификация аттестата"
 msgid "Вуз, с которым ты работаешь"
 msgstr "Вуз, с которым ты работаешь"
 
+#: src/pages/Ask.tsx
+msgid "помощь на экзамене по матану"
+msgstr "помощь на экзамене по матану"
+
 #: src/pages/Offer.tsx
 msgid "Выбери, чем можешь помочь"
 msgstr "Выбери, чем можешь помочь"
@@ -838,6 +842,10 @@ msgstr "Сейчас бесплатно. Когда людей станет бо
 #: src/pages/Life.tsx
 msgid "Не про учёбу"
 msgstr "Не про учёбу"
+
+#: src/pages/Ask.tsx
+msgid "курсовая работа"
+msgstr "курсовая работа"
 
 #: src/components/Phrase.tsx
 msgid "Дешевле остальных, но этот экзамен не вёл"

--- a/apps/web/src/locales/ru/messages.po
+++ b/apps/web/src/locales/ru/messages.po
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
+#: src/pages/Ask.tsx
+msgid "курсовая по экономике"
+msgstr "курсовая по экономике"
+
 #: src/components/Incoming.tsx
 msgid "Заведи в Telegram публичный @username — иначе тебе не ответят"
 msgstr "Заведи в Telegram публичный @username — иначе тебе не ответят"
@@ -81,8 +85,8 @@ msgid "Kč"
 msgstr "Kč"
 
 #: src/pages/Ask.tsx
-msgid "страховка на год"
-msgstr "страховка на год"
+#~ msgid "страховка на год"
+#~ msgstr "страховка на год"
 
 #: src/pages/MyHelper.tsx
 msgid "Скрыть"
@@ -791,6 +795,7 @@ msgstr "Работает именно с этим вузом"
 msgid "Открыть в Telegram"
 msgstr "Открыть в Telegram"
 
+#: src/pages/Ask.tsx
 #: src/pages/Results.tsx
 msgid "Проверь соединение и попробуй ещё раз."
 msgstr "Проверь соединение и попробуй ещё раз."
@@ -853,6 +858,10 @@ msgstr "Ты отказался"
 #: src/pages/Ask.tsx
 msgid "čeština B2"
 msgstr "čeština B2"
+
+#: src/pages/Ask.tsx
+msgid "Не получилось посчитать"
+msgstr "Не получилось посчитать"
 
 #: src/pages/Profile.tsx
 #~ msgid "Как в системе"

--- a/apps/web/src/locales/ru/messages.po
+++ b/apps/web/src/locales/ru/messages.po
@@ -80,6 +80,10 @@ msgstr "Не сейчас"
 msgid "Kč"
 msgstr "Kč"
 
+#: src/pages/Ask.tsx
+msgid "страховка на год"
+msgstr "страховка на год"
+
 #: src/pages/MyHelper.tsx
 msgid "Скрыть"
 msgstr "Скрыть"
@@ -192,6 +196,10 @@ msgstr "расскажи своими словами, анкету соберё�
 msgid "Заявку уже закрыли"
 msgstr "Заявку уже закрыли"
 
+#: src/pages/Ask.tsx
+msgid "всего {total}"
+msgstr "всего {total}"
+
 #: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
 #: src/pages/Request.tsx
@@ -207,6 +215,10 @@ msgstr "Анкета сохранится, но в каталоге её не б
 msgid "Сколько"
 msgstr "Сколько"
 
+#: src/pages/Ask.tsx
+msgid "Показать {total}"
+msgstr "Показать {total}"
+
 #: src/pages/Mine.tsx
 msgid "Мои заявки"
 msgstr "Мои заявки"
@@ -218,6 +230,10 @@ msgstr "Их видно на твоей странице."
 #: src/components/Phrase.tsx
 msgid "Не понял запрос. Попробуй назвать предмет — «матан», «čeština B2», «сопромат»."
 msgstr "Не понял запрос. Попробуй назвать предмет — «матан», «čeština B2», «сопромат»."
+
+#: src/pages/Ask.tsx
+msgid "Напиши как думаешь. Поймём предмет, вуз, срок и бюджет."
+msgstr "Напиши как думаешь. Поймём предмет, вуз, срок и бюджет."
 
 #: src/components/Phrase.tsx
 msgid "сдали"
@@ -280,6 +296,10 @@ msgstr "И так, и так"
 #~ msgid "опубликована"
 #~ msgstr "опубликована"
 
+#: src/pages/Ask.tsx
+msgid "Убери что-нибудь из уточнений выше или напиши иначе."
+msgstr "Убери что-нибудь из уточнений выше или напиши иначе."
+
 #: src/pages/OfferPrices.tsx
 msgid "Анкета скрыта — услуги сохранятся, но в каталоге их не будет. Включить видимость можно в анкете."
 msgstr "Анкета скрыта — услуги сохранятся, но в каталоге их не будет. Включить видимость можно в анкете."
@@ -328,14 +348,18 @@ msgid "И то, и другое"
 msgstr "И то, и другое"
 
 #: src/pages/Ask.tsx
-msgid "нужен матан на ČVUT, экзамен 14 февраля"
-msgstr "нужен матан на ČVUT, экзамен 14 февраля"
+#~ msgid "нужен матан на ČVUT, экзамен 14 февраля"
+#~ msgstr "нужен матан на ČVUT, экзамен 14 февраля"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
 msgid "за час"
 msgstr "за час"
+
+#: src/pages/Ask.tsx
+msgid "матан на ČVUT к 14 февраля, до 600 Kč"
+msgstr "матан на ČVUT к 14 февраля, до 600 Kč"
 
 #: src/pages/Profile.tsx
 msgid "Предлагать услуги"
@@ -363,6 +387,10 @@ msgstr "Сначала опубликуй профиль"
 #: src/pages/OfferPrices.tsx
 msgid "за штуку"
 msgstr "за штуку"
+
+#: src/pages/Ask.tsx
+msgid "přijímačky на медицину"
+msgstr "přijímačky на медицину"
 
 #: src/pages/MyHelper.tsx
 msgid "В каталоге"
@@ -417,8 +445,8 @@ msgid "Мои услуги"
 msgstr "Мои услуги"
 
 #: src/pages/Ask.tsx
-msgid "Искать всё равно"
-msgstr "Искать всё равно"
+#~ msgid "Искать всё равно"
+#~ msgstr "Искать всё равно"
 
 #: src/components/TabBar.tsx
 msgid "опиши задачу — придут отклики"
@@ -427,6 +455,14 @@ msgstr "опиши задачу — придут отклики"
 #: src/pages/Request.tsx
 msgid "Заявку видят те, кто ведёт этот предмет. Обычно отвечают в течение дня."
 msgstr "Заявку видят те, кто ведёт этот предмет. Обычно отвечают в течение дня."
+
+#: src/pages/Ask.tsx
+msgid "Кого тут можно найти"
+msgstr "Кого тут можно найти"
+
+#: src/pages/Ask.tsx
+msgid "Кто найдётся"
+msgstr "Кто найдётся"
 
 #: src/components/Phrase.tsx
 msgid "Ведёт предмет, но не привязан к этому вузу"
@@ -514,6 +550,7 @@ msgstr "Мне нужна помощь"
 msgid "Оформление. Нажми, чтобы сменить; удерживай, чтобы вернуть системное"
 msgstr "Оформление. Нажми, чтобы сменить; удерживай, чтобы вернуть системное"
 
+#: src/pages/Ask.tsx
 #: src/pages/Home.tsx
 msgid "Что нужно?"
 msgstr "Что нужно?"
@@ -566,10 +603,18 @@ msgstr "Дешевле"
 msgid "Загружаем"
 msgstr "Загружаем"
 
+#: src/pages/Ask.tsx
+msgid "матан ČVUT"
+msgstr "матан ČVUT"
+
 #. placeholder {0}: data.total
 #: src/pages/Results.tsx
 msgid "всего {0}"
 msgstr "всего {0}"
+
+#: src/pages/Ask.tsx
+msgid "нострификация аттестата"
+msgstr "нострификация аттестата"
 
 #: src/components/Phrase.tsx
 msgid "Вуз, с которым ты работаешь"
@@ -665,6 +710,10 @@ msgstr "Отправить"
 msgid "У этого человека нет @username — написать не получится"
 msgstr "У этого человека нет @username — написать не получится"
 
+#: src/pages/Ask.tsx
+msgid "Например"
+msgstr "Например"
+
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
@@ -716,6 +765,10 @@ msgstr "На эту заявку ты уже отвечал"
 #: src/pages/Helper.tsx
 msgid "У этого человека нет открытого username в Telegram, написать не получится."
 msgstr "У этого человека нет открытого username в Telegram, написать не получится."
+
+#: src/pages/Ask.tsx
+msgid "По этому запросу пока никого"
+msgstr "По этому запросу пока никого"
 
 #. placeholder {0}: formatMoney(price.amount)
 #: src/pages/Helper.tsx
@@ -797,6 +850,10 @@ msgstr "{0, plural, one {Отвечает примерно за # минуту} 
 msgid "Ты отказался"
 msgstr "Ты отказался"
 
+#: src/pages/Ask.tsx
+msgid "čeština B2"
+msgstr "čeština B2"
+
 #: src/pages/Profile.tsx
 #~ msgid "Как в системе"
 #~ msgstr "Как в системе"
@@ -824,8 +881,8 @@ msgstr "Написать"
 
 #. placeholder {0}: parsed.matches
 #: src/pages/Ask.tsx
-msgid "Показать {0}"
-msgstr "Показать {0}"
+#~ msgid "Показать {0}"
+#~ msgstr "Показать {0}"
 
 #: src/pages/MyHelper.tsx
 msgid "Моя анкета"
@@ -856,6 +913,7 @@ msgstr "Что преподаёшь, где учишься, как проход�
 msgid "Отклики"
 msgstr "Отклики"
 
+#: src/pages/Ask.tsx
 #: src/pages/Results.tsx
 msgid "Ищем…"
 msgstr "Ищем…"

--- a/apps/web/src/locales/uk/messages.po
+++ b/apps/web/src/locales/uk/messages.po
@@ -14,8 +14,8 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
 #: src/pages/Ask.tsx
-msgid "курсовая по экономике"
-msgstr "курсова з економіки"
+#~ msgid "курсовая по экономике"
+#~ msgstr "курсова з економіки"
 
 #: src/components/Incoming.tsx
 msgid "Заведи в Telegram публичный @username — иначе тебе не ответят"
@@ -389,8 +389,8 @@ msgid "за штуку"
 msgstr "за штуку"
 
 #: src/pages/Ask.tsx
-msgid "přijímačky на медицину"
-msgstr "přijímačky на медицину"
+#~ msgid "přijímačky на медицину"
+#~ msgstr "přijímačky на медицину"
 
 #: src/pages/MyHelper.tsx
 msgid "В каталоге"
@@ -621,6 +621,10 @@ msgstr "нострифікація атестата"
 msgid "Вуз, с которым ты работаешь"
 msgstr "Виш, з яким ти працюєш"
 
+#: src/pages/Ask.tsx
+msgid "помощь на экзамене по матану"
+msgstr "допомога на іспиті з матану"
+
 #: src/pages/Offer.tsx
 msgid "Выбери, чем можешь помочь"
 msgstr "Обери, чим можеш допомогти"
@@ -838,6 +842,10 @@ msgstr "Зараз безкоштовно. Коли людей стане біл
 #: src/pages/Life.tsx
 msgid "Не про учёбу"
 msgstr "Не про навчання"
+
+#: src/pages/Ask.tsx
+msgid "курсовая работа"
+msgstr "курсова робота"
 
 #: src/components/Phrase.tsx
 msgid "Дешевле остальных, но этот экзамен не вёл"

--- a/apps/web/src/locales/uk/messages.po
+++ b/apps/web/src/locales/uk/messages.po
@@ -52,9 +52,17 @@ msgstr "Перевір з'єднання і спробуй ще раз."
 msgid "Онлайн"
 msgstr "Онлайн"
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Напиши хотя бы пару предложений — предметы, цену и как удобно заниматься."
+#~ msgstr "Напиши хоча б кілька речень — предмети, ціну і як тобі зручно займатися."
+
 #: src/pages/Request.tsx
 msgid "Такой заявки нет"
 msgstr "Такої заявки немає"
+
+#: src/pages/Ask.tsx
+msgid "Добавь предмет — по одному сроку искать нечего."
+msgstr "Додай предмет — за одним строком шукати нічого."
 
 #: src/pages/Landing.tsx
 msgid "Přijímačky"
@@ -67,6 +75,10 @@ msgstr "Видимість"
 #: src/components/TabBar.tsx
 msgid "Поиск"
 msgstr "Пошук"
+
+#: src/pages/MyHelper.tsx
+#~ msgid "Предметы и цены"
+#~ msgstr "Предмети та ціни"
 
 #: src/components/Incoming.tsx
 msgid "Не сейчас"
@@ -106,6 +118,10 @@ msgstr "за тиждень"
 msgid "Откликнуться"
 msgstr "Відгукнутися"
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Когда ты свободен"
+#~ msgstr "Коли ти вільний"
+
 #: src/pages/MyHelper.tsx
 msgid "Где"
 msgstr "Де"
@@ -118,6 +134,10 @@ msgstr "Додати послугу"
 msgid "Это не наши услуги. Мы получаем комиссию с партнёра, со студента — ничего."
 msgstr "Це не наші послуги. Комісію ми отримуємо від партнера, зі студента — нічого."
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Какие предметы"
+#~ msgstr "Які предмети"
+
 #: src/pages/Home.tsx
 msgid "Вещи"
 msgstr "Речі"
@@ -125,6 +145,10 @@ msgstr "Речі"
 #: src/pages/MyHelper.tsx
 msgid "Всё можно менять когда угодно. Пустые поля просто не показываем."
 msgstr "Усе можна змінити будь-коли. Порожні поля просто не показуємо."
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Одним куском, как другу. Анкету соберём сами."
+#~ msgstr "Одним шматком, як другу. Анкету складемо самі."
 
 #: src/pages/Profile.tsx
 msgid "На каких языках тебе удобно"
@@ -142,6 +166,10 @@ msgstr "За цим запитом поки нікого немає. Створ�
 msgid "Оформление: как в системе. Нажми, чтобы сменить"
 msgstr "Оформлення: як у системі. Натисни, щоб змінити"
 
+#: src/pages/Profile.tsx
+#~ msgid "Хочу помогать"
+#~ msgstr "Хочу допомагати"
+
 #: src/components/AppHeader.tsx
 msgid "Язык"
 msgstr "Мова"
@@ -150,6 +178,10 @@ msgstr "Мова"
 #: src/components/Phrase.tsx
 msgid "Твой предмет — {0}"
 msgstr "Твій предмет — {0}"
+
+#: src/pages/Profile.tsx
+#~ msgid "Тёмное"
+#~ msgstr "Темне"
 
 #. placeholder {0}: picked.size
 #: src/pages/Offer.tsx
@@ -243,6 +275,27 @@ msgstr "Ціна"
 msgid "И так, и так"
 msgstr "І так, і так"
 
+#: src/components/TabBar.tsx
+#: src/pages/Chats.tsx
+#~ msgid "Чаты"
+#~ msgstr "Чати"
+
+#: src/pages/MyHelper.tsx
+#~ msgid "Без предмета"
+#~ msgstr "Без предмета"
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Сколько берёшь"
+#~ msgstr "Скільки береш"
+
+#: src/pages/Landing.tsx
+#~ msgid "Работы и материалы"
+#~ msgstr "Роботи та матеріали"
+
+#: src/pages/Profile.tsx
+#~ msgid "опубликована"
+#~ msgstr "опублікована"
+
 #: src/pages/Ask.tsx
 msgid "Убери что-нибудь из уточнений выше или напиши иначе."
 msgstr "Прибери щось з уточнень вище або напиши інакше."
@@ -259,6 +312,10 @@ msgstr "Відмовити"
 msgid "Пока без откликов"
 msgstr "Поки без відгуків"
 
+#: src/pages/Chats.tsx
+#~ msgid "Разговоры мы не храним"
+#~ msgstr "Розмови ми не зберігаємо"
+
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
 msgid "За что цена"
@@ -269,6 +326,10 @@ msgstr "За що ціна"
 #: src/pages/OfferPrices.tsx
 msgid "за работу"
 msgstr "за роботу"
+
+#: src/pages/MyHelper.tsx
+#~ msgid "Пока ни одного. Найди предмет ниже — без них тебя не найдут по поиску."
+#~ msgstr "Поки жодного. Знайди предмет нижче — без них тебе не знайдуть у пошуку."
 
 #: src/pages/MyHelper.tsx
 msgid "Тебя видят в поиске и могут написать."
@@ -285,6 +346,10 @@ msgstr "у каталозі"
 #: src/components/Phrase.tsx
 msgid "И то, и другое"
 msgstr "І те, і інше"
+
+#: src/pages/Ask.tsx
+#~ msgid "нужен матан на ČVUT, экзамен 14 февраля"
+#~ msgstr "потрібен матан на ČVUT, іспит 14 лютого"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -345,6 +410,10 @@ msgstr "репетиторство, роботи, допомога"
 msgid "Дальше вопросов не будет."
 msgstr "Далі питань не буде."
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Получилось так"
+#~ msgstr "Вийшло так"
+
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
@@ -374,6 +443,10 @@ msgstr "Як займаєшся"
 #: src/pages/Profile.tsx
 msgid "Мои услуги"
 msgstr "Мої послуги"
+
+#: src/pages/Ask.tsx
+#~ msgid "Искать всё равно"
+#~ msgstr "Шукати попри це"
 
 #: src/components/TabBar.tsx
 msgid "опиши задачу — придут отклики"
@@ -411,6 +484,10 @@ msgstr "Профіль"
 #: src/pages/Helper.tsx
 msgid "Возможно, человек скрыл его."
 msgstr "Можливо, людина його приховала."
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Без расписания анкету покажем, но реже — люди чаще пишут тем, у кого видно свободные дни."
+#~ msgstr "Без розкладу анкету покажемо, але рідше — люди частіше пишуть тим, у кого видно вільні дні."
 
 #: src/pages/MyHelper.tsx
 msgid "Строчка под именем"
@@ -453,9 +530,17 @@ msgstr "Хто може допомогти"
 msgid "Это первое, что читают. Пара живых предложений работает лучше списка."
 msgstr "Це перше, що читають. Пара живих речень працює краще за список."
 
+#: src/pages/Profile.tsx
+#~ msgid "По этому мы отсеиваем тех, с кем вы друг друга не поймёте."
+#~ msgstr "За цим ми відсіюємо тих, з ким ви не порозумієтесь."
+
 #: src/pages/Results.tsx
 msgid "изменить"
 msgstr "змінити"
+
+#: src/pages/Profile.tsx
+#~ msgid "Светлое"
+#~ msgstr "Світле"
 
 #: src/components/TabBar.tsx
 msgid "Мне нужна помощь"
@@ -474,6 +559,18 @@ msgstr "Що потрібно?"
 msgid "Не удалось загрузить каталог"
 msgstr "Не вдалося завантажити каталог"
 
+#: src/pages/Chats.tsx
+#~ msgid "Мы сводим людей и запоминаем, что контакт состоялся — по этому считается время ответа. Сама переписка остаётся в Telegram."
+#~ msgstr "Ми зводимо людей і фіксуємо, що контакт відбувся — за цим рахується час відповіді. Сама переписка залишається в Telegram."
+
+#: src/pages/Home.tsx
+#~ msgid "Люди"
+#~ msgstr "Люди"
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Онлайн или очно"
+#~ msgstr "Онлайн чи очно"
+
 #: src/pages/Landing.tsx
 msgid "Кто поможет с учёбой в Чехии"
 msgstr "Хто допоможе з навчанням у Чехії"
@@ -481,6 +578,10 @@ msgstr "Хто допоможе з навчанням у Чехії"
 #: src/pages/Helper.tsx
 msgid "Свободные окна"
 msgstr "Вільні вікна"
+
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Не хватает"
+#~ msgstr "Не вистачає"
 
 #: src/pages/Profile.tsx
 msgid "черновик — не видна в каталоге"
@@ -528,6 +629,10 @@ msgstr "Обери, чим можеш допомогти"
 msgid "Чем ты можешь помочь?"
 msgstr "Чим ти можеш допомогти?"
 
+#: src/pages/Chats.tsx
+#~ msgid "Открыть переписку в Telegram"
+#~ msgstr "Відкрити переписку в Telegram"
+
 #: src/pages/MyHelper.tsx
 msgid "Город"
 msgstr "Місто"
@@ -547,6 +652,10 @@ msgstr "Чим допомагає"
 #: src/components/TabBar.tsx
 msgid "Закрыть"
 msgstr "Закрити"
+
+#: src/pages/Profile.tsx
+#~ msgid "Оформление"
+#~ msgstr "Оформлення"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -620,6 +729,10 @@ msgstr "страхування, віза, банк, перекази"
 #: src/components/Phrase.tsx
 msgid "{0, plural, one {Готовил к этому же экзамену # человека} few {Готовил к этому же экзамену # человек} many {Готовил к этому же экзамену # человек} other {Готовил к этому же экзамену # человека}}"
 msgstr "{0, plural, one {Готував до цього ж іспиту # людину} few {Готував до цього ж іспиту # людини} many {Готував до цього ж іспиту # людей} other {Готував до цього ж іспиту # людини}}"
+
+#: src/pages/Chats.tsx
+#~ msgid "там же, где и все остальные разговоры"
+#~ msgstr "там само, де й усі інші розмови"
 
 #: src/pages/MyHelper.tsx
 msgid "ČVUT FEL, 3 курс"
@@ -710,6 +823,10 @@ msgstr "Заявок поки немає"
 msgid "Убрать"
 msgstr "Прибрати"
 
+#: src/pages/Ask.tsx
+msgid "По этому пока не найти"
+msgstr "За цим поки не знайти"
+
 #: src/pages/Results.tsx
 msgid "Пока никого"
 msgstr "Поки нікого"
@@ -747,6 +864,10 @@ msgstr "čeština B2"
 msgid "Не получилось посчитать"
 msgstr "Не вдалося порахувати"
 
+#: src/pages/Profile.tsx
+#~ msgid "Как в системе"
+#~ msgstr "Як у системі"
+
 #: src/components/Phrase.tsx
 msgid "Документы и жизнь"
 msgstr "Документи і життя"
@@ -764,6 +885,15 @@ msgstr "Необов'язково. Порожнє поле означає «до
 msgid "Написать"
 msgstr "Написати"
 
+#: src/pages/BecomeHelper.tsx
+#~ msgid "Расскажи своими словами"
+#~ msgstr "Розкажи своїми словами"
+
+#. placeholder {0}: parsed.matches
+#: src/pages/Ask.tsx
+#~ msgid "Показать {0}"
+#~ msgstr "Показати {0}"
+
 #: src/pages/MyHelper.tsx
 msgid "Моя анкета"
 msgstr "Моя анкета"
@@ -779,6 +909,11 @@ msgstr "Відгуків поки немає"
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"
 msgstr "Допомога потрібна до іспиту чи на ньому?"
+
+#: src/components/TabBar.tsx
+#: src/pages/Mine.tsx
+#~ msgid "Мои"
+#~ msgstr "Мої"
 
 #: src/pages/MyHelper.tsx
 msgid "Что преподаёшь, где учишься, как проходят занятия. Своими словами."
@@ -814,6 +949,10 @@ msgstr "Репетитори"
 #: src/components/Phrase.tsx
 msgid "лет на площадке"
 msgstr "років на майданчику"
+
+#: src/pages/Ask.tsx
+#~ msgid "Дальше вопросов не будет — остальное отфильтруешь прямо в списке."
+#~ msgstr "Далі питань не буде — решту відфільтруєш прямо у списку."
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx

--- a/apps/web/src/locales/uk/messages.po
+++ b/apps/web/src/locales/uk/messages.po
@@ -80,6 +80,10 @@ msgstr "Не зараз"
 msgid "Kč"
 msgstr "Kč"
 
+#: src/pages/Ask.tsx
+msgid "страховка на год"
+msgstr "страховка на рік"
+
 #: src/pages/MyHelper.tsx
 msgid "Скрыть"
 msgstr "Сховати"
@@ -192,6 +196,10 @@ msgstr "розкажи своїми словами, анкету складем�
 msgid "Заявку уже закрыли"
 msgstr "Заявку вже закрили"
 
+#: src/pages/Ask.tsx
+msgid "всего {total}"
+msgstr "усього {total}"
+
 #: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
 #: src/pages/Request.tsx
@@ -207,6 +215,10 @@ msgstr "Анкета збережеться, але в каталозі її н�
 msgid "Сколько"
 msgstr "Скільки"
 
+#: src/pages/Ask.tsx
+msgid "Показать {total}"
+msgstr "Показати {total}"
+
 #: src/pages/Mine.tsx
 msgid "Мои заявки"
 msgstr "Мої заявки"
@@ -218,6 +230,10 @@ msgstr "Їх видно на твоїй сторінці."
 #: src/components/Phrase.tsx
 msgid "Не понял запрос. Попробуй назвать предмет — «матан», «čeština B2», «сопромат»."
 msgstr "Не зрозумів запит. Спробуй назвати предмет — «матан», «čeština B2», «сопромат»."
+
+#: src/pages/Ask.tsx
+msgid "Напиши как думаешь. Поймём предмет, вуз, срок и бюджет."
+msgstr "Напиши як думаєш. Зрозуміємо предмет, вуз, строк і бюджет."
 
 #: src/components/Phrase.tsx
 msgid "сдали"
@@ -280,6 +296,10 @@ msgstr "І так, і так"
 #~ msgid "опубликована"
 #~ msgstr "опублікована"
 
+#: src/pages/Ask.tsx
+msgid "Убери что-нибудь из уточнений выше или напиши иначе."
+msgstr "Прибери щось з уточнень вище або напиши інакше."
+
 #: src/pages/OfferPrices.tsx
 msgid "Анкета скрыта — услуги сохранятся, но в каталоге их не будет. Включить видимость можно в анкете."
 msgstr "Анкета прихована — послуги збережуться, але в каталозі їх не буде. Увімкнути видимість можна в анкеті."
@@ -328,14 +348,18 @@ msgid "И то, и другое"
 msgstr "І те, і інше"
 
 #: src/pages/Ask.tsx
-msgid "нужен матан на ČVUT, экзамен 14 февраля"
-msgstr "потрібен матан на ČVUT, іспит 14 лютого"
+#~ msgid "нужен матан на ČVUT, экзамен 14 февраля"
+#~ msgstr "потрібен матан на ČVUT, іспит 14 лютого"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
 msgid "за час"
 msgstr "за годину"
+
+#: src/pages/Ask.tsx
+msgid "матан на ČVUT к 14 февраля, до 600 Kč"
+msgstr "матан на ČVUT до 14 лютого, до 600 Kč"
 
 #: src/pages/Profile.tsx
 msgid "Предлагать услуги"
@@ -363,6 +387,10 @@ msgstr "Спершу опублікуй профіль"
 #: src/pages/OfferPrices.tsx
 msgid "за штуку"
 msgstr "за штуку"
+
+#: src/pages/Ask.tsx
+msgid "přijímačky на медицину"
+msgstr "přijímačky на медицину"
 
 #: src/pages/MyHelper.tsx
 msgid "В каталоге"
@@ -417,8 +445,8 @@ msgid "Мои услуги"
 msgstr "Мої послуги"
 
 #: src/pages/Ask.tsx
-msgid "Искать всё равно"
-msgstr "Шукати попри це"
+#~ msgid "Искать всё равно"
+#~ msgstr "Шукати попри це"
 
 #: src/components/TabBar.tsx
 msgid "опиши задачу — придут отклики"
@@ -427,6 +455,14 @@ msgstr "опиши завдання — прийдуть відгуки"
 #: src/pages/Request.tsx
 msgid "Заявку видят те, кто ведёт этот предмет. Обычно отвечают в течение дня."
 msgstr "Заявку бачать ті, хто веде цей предмет. Зазвичай відповідають протягом дня."
+
+#: src/pages/Ask.tsx
+msgid "Кого тут можно найти"
+msgstr "Кого тут можна знайти"
+
+#: src/pages/Ask.tsx
+msgid "Кто найдётся"
+msgstr "Хто знайдеться"
 
 #: src/components/Phrase.tsx
 msgid "Ведёт предмет, но не привязан к этому вузу"
@@ -514,6 +550,7 @@ msgstr "Мені потрібна допомога"
 msgid "Оформление. Нажми, чтобы сменить; удерживай, чтобы вернуть системное"
 msgstr "Оформлення. Натисни, щоб змінити, утримуй, щоб повернути системне"
 
+#: src/pages/Ask.tsx
 #: src/pages/Home.tsx
 msgid "Что нужно?"
 msgstr "Що потрібно?"
@@ -566,10 +603,18 @@ msgstr "Дешевше"
 msgid "Загружаем"
 msgstr "Завантажуємо"
 
+#: src/pages/Ask.tsx
+msgid "матан ČVUT"
+msgstr "матан ČVUT"
+
 #. placeholder {0}: data.total
 #: src/pages/Results.tsx
 msgid "всего {0}"
 msgstr "всього {0}"
+
+#: src/pages/Ask.tsx
+msgid "нострификация аттестата"
+msgstr "нострифікація атестата"
 
 #: src/components/Phrase.tsx
 msgid "Вуз, с которым ты работаешь"
@@ -665,6 +710,10 @@ msgstr "Надіслати"
 msgid "У этого человека нет @username — написать не получится"
 msgstr "У цієї людини немає @username — написати не вийде"
 
+#: src/pages/Ask.tsx
+msgid "Например"
+msgstr "Наприклад"
+
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
@@ -716,6 +765,10 @@ msgstr "На цю заявку ти вже відповідав"
 #: src/pages/Helper.tsx
 msgid "У этого человека нет открытого username в Telegram, написать не получится."
 msgstr "У цієї людини немає відкритого username в Telegram, написати не вийде."
+
+#: src/pages/Ask.tsx
+msgid "По этому запросу пока никого"
+msgstr "За цим запитом поки нікого"
 
 #. placeholder {0}: formatMoney(price.amount)
 #: src/pages/Helper.tsx
@@ -797,6 +850,10 @@ msgstr "{0, plural, one {Відповідає приблизно за # хвил
 msgid "Ты отказался"
 msgstr "Ти відмовив"
 
+#: src/pages/Ask.tsx
+msgid "čeština B2"
+msgstr "čeština B2"
+
 #: src/pages/Profile.tsx
 #~ msgid "Как в системе"
 #~ msgstr "Як у системі"
@@ -824,8 +881,8 @@ msgstr "Написати"
 
 #. placeholder {0}: parsed.matches
 #: src/pages/Ask.tsx
-msgid "Показать {0}"
-msgstr "Показати {0}"
+#~ msgid "Показать {0}"
+#~ msgstr "Показати {0}"
 
 #: src/pages/MyHelper.tsx
 msgid "Моя анкета"
@@ -856,6 +913,7 @@ msgstr "Що викладаєш, де вчишся, як проходять за
 msgid "Отклики"
 msgstr "Відгуки"
 
+#: src/pages/Ask.tsx
 #: src/pages/Results.tsx
 msgid "Ищем…"
 msgstr "Шукаємо…"

--- a/apps/web/src/locales/uk/messages.po
+++ b/apps/web/src/locales/uk/messages.po
@@ -52,10 +52,6 @@ msgstr "Перевір з'єднання і спробуй ще раз."
 msgid "Онлайн"
 msgstr "Онлайн"
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Напиши хотя бы пару предложений — предметы, цену и как удобно заниматься."
-#~ msgstr "Напиши хоча б кілька речень — предмети, ціну і як тобі зручно займатися."
-
 #: src/pages/Request.tsx
 msgid "Такой заявки нет"
 msgstr "Такої заявки немає"
@@ -72,10 +68,6 @@ msgstr "Видимість"
 msgid "Поиск"
 msgstr "Пошук"
 
-#: src/pages/MyHelper.tsx
-#~ msgid "Предметы и цены"
-#~ msgstr "Предмети та ціни"
-
 #: src/components/Incoming.tsx
 msgid "Не сейчас"
 msgstr "Не зараз"
@@ -83,10 +75,6 @@ msgstr "Не зараз"
 #: src/pages/MyHelper.tsx
 msgid "Kč"
 msgstr "Kč"
-
-#: src/pages/Ask.tsx
-#~ msgid "страховка на год"
-#~ msgstr "страховка на рік"
 
 #: src/pages/MyHelper.tsx
 msgid "Скрыть"
@@ -118,10 +106,6 @@ msgstr "за тиждень"
 msgid "Откликнуться"
 msgstr "Відгукнутися"
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Когда ты свободен"
-#~ msgstr "Коли ти вільний"
-
 #: src/pages/MyHelper.tsx
 msgid "Где"
 msgstr "Де"
@@ -134,10 +118,6 @@ msgstr "Додати послугу"
 msgid "Это не наши услуги. Мы получаем комиссию с партнёра, со студента — ничего."
 msgstr "Це не наші послуги. Комісію ми отримуємо від партнера, зі студента — нічого."
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Какие предметы"
-#~ msgstr "Які предмети"
-
 #: src/pages/Home.tsx
 msgid "Вещи"
 msgstr "Речі"
@@ -145,10 +125,6 @@ msgstr "Речі"
 #: src/pages/MyHelper.tsx
 msgid "Всё можно менять когда угодно. Пустые поля просто не показываем."
 msgstr "Усе можна змінити будь-коли. Порожні поля просто не показуємо."
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Одним куском, как другу. Анкету соберём сами."
-#~ msgstr "Одним шматком, як другу. Анкету складемо самі."
 
 #: src/pages/Profile.tsx
 msgid "На каких языках тебе удобно"
@@ -166,10 +142,6 @@ msgstr "За цим запитом поки нікого немає. Створ�
 msgid "Оформление: как в системе. Нажми, чтобы сменить"
 msgstr "Оформлення: як у системі. Натисни, щоб змінити"
 
-#: src/pages/Profile.tsx
-#~ msgid "Хочу помогать"
-#~ msgstr "Хочу допомагати"
-
 #: src/components/AppHeader.tsx
 msgid "Язык"
 msgstr "Мова"
@@ -178,10 +150,6 @@ msgstr "Мова"
 #: src/components/Phrase.tsx
 msgid "Твой предмет — {0}"
 msgstr "Твій предмет — {0}"
-
-#: src/pages/Profile.tsx
-#~ msgid "Тёмное"
-#~ msgstr "Темне"
 
 #. placeholder {0}: picked.size
 #: src/pages/Offer.tsx
@@ -199,10 +167,6 @@ msgstr "розкажи своїми словами, анкету складем�
 #: src/components/Incoming.tsx
 msgid "Заявку уже закрыли"
 msgstr "Заявку вже закрили"
-
-#: src/pages/Ask.tsx
-msgid "всего {total}"
-msgstr "усього {total}"
 
 #: src/components/Incoming.tsx
 #: src/pages/Mine.tsx
@@ -279,27 +243,6 @@ msgstr "Ціна"
 msgid "И так, и так"
 msgstr "І так, і так"
 
-#: src/components/TabBar.tsx
-#: src/pages/Chats.tsx
-#~ msgid "Чаты"
-#~ msgstr "Чати"
-
-#: src/pages/MyHelper.tsx
-#~ msgid "Без предмета"
-#~ msgstr "Без предмета"
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Сколько берёшь"
-#~ msgstr "Скільки береш"
-
-#: src/pages/Landing.tsx
-#~ msgid "Работы и материалы"
-#~ msgstr "Роботи та матеріали"
-
-#: src/pages/Profile.tsx
-#~ msgid "опубликована"
-#~ msgstr "опублікована"
-
 #: src/pages/Ask.tsx
 msgid "Убери что-нибудь из уточнений выше или напиши иначе."
 msgstr "Прибери щось з уточнень вище або напиши інакше."
@@ -316,10 +259,6 @@ msgstr "Відмовити"
 msgid "Пока без откликов"
 msgstr "Поки без відгуків"
 
-#: src/pages/Chats.tsx
-#~ msgid "Разговоры мы не храним"
-#~ msgstr "Розмови ми не зберігаємо"
-
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
 msgid "За что цена"
@@ -330,10 +269,6 @@ msgstr "За що ціна"
 #: src/pages/OfferPrices.tsx
 msgid "за работу"
 msgstr "за роботу"
-
-#: src/pages/MyHelper.tsx
-#~ msgid "Пока ни одного. Найди предмет ниже — без них тебя не найдут по поиску."
-#~ msgstr "Поки жодного. Знайди предмет нижче — без них тебе не знайдуть у пошуку."
 
 #: src/pages/MyHelper.tsx
 msgid "Тебя видят в поиске и могут написать."
@@ -350,10 +285,6 @@ msgstr "у каталозі"
 #: src/components/Phrase.tsx
 msgid "И то, и другое"
 msgstr "І те, і інше"
-
-#: src/pages/Ask.tsx
-#~ msgid "нужен матан на ČVUT, экзамен 14 февраля"
-#~ msgstr "потрібен матан на ČVUT, іспит 14 лютого"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -414,10 +345,6 @@ msgstr "репетиторство, роботи, допомога"
 msgid "Дальше вопросов не будет."
 msgstr "Далі питань не буде."
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Получилось так"
-#~ msgstr "Вийшло так"
-
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
 #: src/pages/OfferPrices.tsx
@@ -447,10 +374,6 @@ msgstr "Як займаєшся"
 #: src/pages/Profile.tsx
 msgid "Мои услуги"
 msgstr "Мої послуги"
-
-#: src/pages/Ask.tsx
-#~ msgid "Искать всё равно"
-#~ msgstr "Шукати попри це"
 
 #: src/components/TabBar.tsx
 msgid "опиши задачу — придут отклики"
@@ -488,10 +411,6 @@ msgstr "Профіль"
 #: src/pages/Helper.tsx
 msgid "Возможно, человек скрыл его."
 msgstr "Можливо, людина його приховала."
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Без расписания анкету покажем, но реже — люди чаще пишут тем, у кого видно свободные дни."
-#~ msgstr "Без розкладу анкету покажемо, але рідше — люди частіше пишуть тим, у кого видно вільні дні."
 
 #: src/pages/MyHelper.tsx
 msgid "Строчка под именем"
@@ -534,17 +453,9 @@ msgstr "Хто може допомогти"
 msgid "Это первое, что читают. Пара живых предложений работает лучше списка."
 msgstr "Це перше, що читають. Пара живих речень працює краще за список."
 
-#: src/pages/Profile.tsx
-#~ msgid "По этому мы отсеиваем тех, с кем вы друг друга не поймёте."
-#~ msgstr "За цим ми відсіюємо тих, з ким ви не порозумієтесь."
-
 #: src/pages/Results.tsx
 msgid "изменить"
 msgstr "змінити"
-
-#: src/pages/Profile.tsx
-#~ msgid "Светлое"
-#~ msgstr "Світле"
 
 #: src/components/TabBar.tsx
 msgid "Мне нужна помощь"
@@ -563,18 +474,6 @@ msgstr "Що потрібно?"
 msgid "Не удалось загрузить каталог"
 msgstr "Не вдалося завантажити каталог"
 
-#: src/pages/Chats.tsx
-#~ msgid "Мы сводим людей и запоминаем, что контакт состоялся — по этому считается время ответа. Сама переписка остаётся в Telegram."
-#~ msgstr "Ми зводимо людей і фіксуємо, що контакт відбувся — за цим рахується час відповіді. Сама переписка залишається в Telegram."
-
-#: src/pages/Home.tsx
-#~ msgid "Люди"
-#~ msgstr "Люди"
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Онлайн или очно"
-#~ msgstr "Онлайн чи очно"
-
 #: src/pages/Landing.tsx
 msgid "Кто поможет с учёбой в Чехии"
 msgstr "Хто допоможе з навчанням у Чехії"
@@ -582,10 +481,6 @@ msgstr "Хто допоможе з навчанням у Чехії"
 #: src/pages/Helper.tsx
 msgid "Свободные окна"
 msgstr "Вільні вікна"
-
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Не хватает"
-#~ msgstr "Не вистачає"
 
 #: src/pages/Profile.tsx
 msgid "черновик — не видна в каталоге"
@@ -612,6 +507,7 @@ msgid "матан ČVUT"
 msgstr "матан ČVUT"
 
 #. placeholder {0}: data.total
+#: src/pages/Ask.tsx
 #: src/pages/Results.tsx
 msgid "всего {0}"
 msgstr "всього {0}"
@@ -632,10 +528,6 @@ msgstr "Обери, чим можеш допомогти"
 msgid "Чем ты можешь помочь?"
 msgstr "Чим ти можеш допомогти?"
 
-#: src/pages/Chats.tsx
-#~ msgid "Открыть переписку в Telegram"
-#~ msgstr "Відкрити переписку в Telegram"
-
 #: src/pages/MyHelper.tsx
 msgid "Город"
 msgstr "Місто"
@@ -655,10 +547,6 @@ msgstr "Чим допомагає"
 #: src/components/TabBar.tsx
 msgid "Закрыть"
 msgstr "Закрити"
-
-#: src/pages/Profile.tsx
-#~ msgid "Оформление"
-#~ msgstr "Оформлення"
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx
@@ -732,10 +620,6 @@ msgstr "страхування, віза, банк, перекази"
 #: src/components/Phrase.tsx
 msgid "{0, plural, one {Готовил к этому же экзамену # человека} few {Готовил к этому же экзамену # человек} many {Готовил к этому же экзамену # человек} other {Готовил к этому же экзамену # человека}}"
 msgstr "{0, plural, one {Готував до цього ж іспиту # людину} few {Готував до цього ж іспиту # людини} many {Готував до цього ж іспиту # людей} other {Готував до цього ж іспиту # людини}}"
-
-#: src/pages/Chats.tsx
-#~ msgid "там же, где и все остальные разговоры"
-#~ msgstr "там само, де й усі інші розмови"
 
 #: src/pages/MyHelper.tsx
 msgid "ČVUT FEL, 3 курс"
@@ -863,10 +747,6 @@ msgstr "čeština B2"
 msgid "Не получилось посчитать"
 msgstr "Не вдалося порахувати"
 
-#: src/pages/Profile.tsx
-#~ msgid "Как в системе"
-#~ msgstr "Як у системі"
-
 #: src/components/Phrase.tsx
 msgid "Документы и жизнь"
 msgstr "Документи і життя"
@@ -884,15 +764,6 @@ msgstr "Необов'язково. Порожнє поле означає «до
 msgid "Написать"
 msgstr "Написати"
 
-#: src/pages/BecomeHelper.tsx
-#~ msgid "Расскажи своими словами"
-#~ msgstr "Розкажи своїми словами"
-
-#. placeholder {0}: parsed.matches
-#: src/pages/Ask.tsx
-#~ msgid "Показать {0}"
-#~ msgstr "Показати {0}"
-
 #: src/pages/MyHelper.tsx
 msgid "Моя анкета"
 msgstr "Моя анкета"
@@ -908,11 +779,6 @@ msgstr "Відгуків поки немає"
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"
 msgstr "Допомога потрібна до іспиту чи на ньому?"
-
-#: src/components/TabBar.tsx
-#: src/pages/Mine.tsx
-#~ msgid "Мои"
-#~ msgstr "Мої"
 
 #: src/pages/MyHelper.tsx
 msgid "Что преподаёшь, где учишься, как проходят занятия. Своими словами."
@@ -948,10 +814,6 @@ msgstr "Репетитори"
 #: src/components/Phrase.tsx
 msgid "лет на площадке"
 msgstr "років на майданчику"
-
-#: src/pages/Ask.tsx
-#~ msgid "Дальше вопросов не будет — остальное отфильтруешь прямо в списке."
-#~ msgstr "Далі питань не буде — решту відфільтруєш прямо у списку."
 
 #: src/components/Phrase.tsx
 #: src/pages/MyHelper.tsx

--- a/apps/web/src/locales/uk/messages.po
+++ b/apps/web/src/locales/uk/messages.po
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
+#: src/pages/Ask.tsx
+msgid "курсовая по экономике"
+msgstr "курсова з економіки"
+
 #: src/components/Incoming.tsx
 msgid "Заведи в Telegram публичный @username — иначе тебе не ответят"
 msgstr "Заведи в Telegram публічний @username — інакше тобі не відповідять"
@@ -81,8 +85,8 @@ msgid "Kč"
 msgstr "Kč"
 
 #: src/pages/Ask.tsx
-msgid "страховка на год"
-msgstr "страховка на рік"
+#~ msgid "страховка на год"
+#~ msgstr "страховка на рік"
 
 #: src/pages/MyHelper.tsx
 msgid "Скрыть"
@@ -791,6 +795,7 @@ msgstr "Працює саме з цим вишем"
 msgid "Открыть в Telegram"
 msgstr "Відкрити в Telegram"
 
+#: src/pages/Ask.tsx
 #: src/pages/Results.tsx
 msgid "Проверь соединение и попробуй ещё раз."
 msgstr "Перевір з'єднання і спробуй ще раз."
@@ -853,6 +858,10 @@ msgstr "Ти відмовив"
 #: src/pages/Ask.tsx
 msgid "čeština B2"
 msgstr "čeština B2"
+
+#: src/pages/Ask.tsx
+msgid "Не получилось посчитать"
+msgstr "Не вдалося порахувати"
 
 #: src/pages/Profile.tsx
 #~ msgid "Как в системе"

--- a/apps/web/src/pages/Ask.tsx
+++ b/apps/web/src/pages/Ask.tsx
@@ -30,21 +30,25 @@ import {
   Title,
   ui,
 } from '@/components/Ui';
+import { useSearchFilters } from '@/hooks/useSearchFilters';
 import { useMainButton } from '@/hooks/useTelegram';
 import { api } from '@/lib/api';
-import type {
-  Chip,
-  ParseResult,
-  SearchParams,
-  SearchResult,
-  ServiceType,
-} from '@/lib/types';
+import type { Chip, ParseResult, SearchResult } from '@/lib/types';
 
 const OPTION_ICON: Record<string, typeof CheckIcon> = {
   exam_prep: CheckIcon,
   exam_live_help: ClockIcon,
   both: PlusIcon,
 };
+
+/**
+ * How much text counts as a query.
+ *
+ * Shared by the parse and by the empty state below it, which must agree about
+ * when a query has begun: two literals would let the examples disappear while
+ * nothing had been asked yet.
+ */
+const MIN_QUERY = 3;
 
 /** How many of the results to show before the person has asked for them. */
 const PREVIEW = 2;
@@ -90,7 +94,7 @@ export default function AskPage() {
   // biome-ignore lint/correctness/useExhaustiveDependencies: see above
   useEffect(() => {
     const value = text.trim();
-    if (value.length < 3) {
+    if (value.length < MIN_QUERY) {
       setParsed(null);
       return;
     }
@@ -105,23 +109,15 @@ export default function AskPage() {
   const kept = (parsed?.chips ?? []).filter((chip) => !dropped.has(chipKey(chip)));
   const ready = kept.length > 0 || Boolean(answer);
 
-  // The clarifying answer is a service code; the id it maps to lives in the
-  // reference list, which every screen shares and which is cached for an hour.
-  const { data: serviceTypes } = useQuery({
-    queryKey: ['service-types'],
-    queryFn: ({ signal }) => api.getServiceTypes(signal),
-    staleTime: 60 * 60 * 1000,
-  });
-
-  // One string, used for the preview and for the navigation, so the two cannot
-  // describe different searches.
+  // One string, used for the preview, for the filters and for the navigation,
+  // so none of the three can describe a different search.
   const query = useMemo(() => toQuery(kept, answer), [kept, answer]);
-  const params = useMemo(() => searchParams(query, serviceTypes), [query, serviceTypes]);
+  const { filters, isError: filtersFailed } = useSearchFilters(query);
 
   const preview = useQuery({
-    queryKey: ['ask-preview', params],
-    queryFn: ({ signal }) => api.search({ ...params, limit: PREVIEW }, signal),
-    enabled: ready && params !== null,
+    queryKey: ['ask-preview', filters],
+    queryFn: ({ signal }) => api.search({ ...filters, limit: PREVIEW }, signal),
+    enabled: ready && filters !== null,
   });
 
   // The number on the screen is the length of the list behind it, because both
@@ -130,6 +126,10 @@ export default function AskPage() {
   const total = preview.data?.total;
 
   useMainButton(
+    // Only once the count is the count. While a changed query is in flight the
+    // button goes away rather than keeping the previous number under new chips:
+    // a stale number on a button that promises it is the failure this screen was
+    // rebuilt to fix.
     ready && total
       ? {
           text: t`Показать ${total}`,
@@ -176,7 +176,7 @@ export default function AskPage() {
         </div>
       ) : null}
 
-      {text.trim().length < 3 ? <EmptyState onPick={setText} /> : null}
+      {text.trim().length < MIN_QUERY ? <EmptyState onPick={setText} /> : null}
 
       {kept.length > 0 || (parsed?.chips.length ?? 0) > 0 ? (
         <>
@@ -252,7 +252,12 @@ export default function AskPage() {
           answer to that question changes the list, and a list shown above the
           thing that narrows it reads as already final. */}
       {ready ? (
-        <Preview data={preview.data} isPending={preview.isPending} locale={i18n.locale} />
+        <Preview
+          data={preview.data}
+          isPending={preview.isPending}
+          isError={preview.isError || filtersFailed}
+          locale={i18n.locale}
+        />
       ) : null}
     </Screen>
   );
@@ -280,7 +285,7 @@ function EmptyState({ onPick }: { onPick: (text: string) => void }) {
     t`čeština B2`,
     t`přijímačky на медицину`,
     t`нострификация аттестата`,
-    t`страховка на год`,
+    t`курсовая по экономике`,
   ];
 
   // Only what someone is actually offering. An empty shelf here would be the
@@ -349,13 +354,27 @@ function EmptyState({ onPick }: { onPick: (text: string) => void }) {
 function Preview({
   data,
   isPending,
+  isError,
   locale,
 }: {
   data: SearchResult | undefined;
   isPending: boolean;
+  isError: boolean;
   locale: string;
 }) {
   const navigate = useNavigate();
+
+  // Before the skeleton: a failed lookup of the reference list leaves the
+  // request disabled and therefore pending for ever, so an error checked second
+  // would never be reached.
+  if (isError) {
+    return (
+      <Empty
+        title={<Trans>Не получилось посчитать</Trans>}
+        body={<Trans>Проверь соединение и попробуй ещё раз.</Trans>}
+      />
+    );
+  }
 
   if (isPending) {
     return (
@@ -368,9 +387,6 @@ function Preview({
     );
   }
 
-  // Nothing at all rather than an error state: the chips above already say what
-  // was understood, and the main button is gone, so the screen is honest about
-  // having nothing to promise.
   if (!data) return null;
 
   const { total, results } = data;
@@ -427,34 +443,4 @@ function toQuery(chips: Chip[], answer: string | null): string {
   // results screen resolves it, because it already loads the list.
   if (answer && answer !== 'both') params.set('service', answer);
   return params.toString();
-}
-
-/**
- * The same query string, as the arguments the search endpoint takes.
- *
- * Null while a service code is still waiting for the reference list: searching
- * without it would count everyone who teaches the subject, show that number,
- * and then hand over to a screen that filters by kind of help.
- */
-function searchParams(
-  query: string,
-  serviceTypes: ServiceType[] | undefined,
-): SearchParams | null {
-  const params = new URLSearchParams(query);
-  const code = params.get('service');
-  const byCode = code ? serviceTypes?.find((type) => type.code === code)?.id : undefined;
-  if (code && byCode === undefined) return null;
-
-  return {
-    subject_id: numeric(params.get('subject_id')),
-    institution_id: numeric(params.get('institution_id')),
-    service_type_id: numeric(params.get('service_type_id')) ?? byCode,
-    max_price: numeric(params.get('max_price')),
-  };
-}
-
-function numeric(value: string | null): number | undefined {
-  if (!value) return undefined;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
 }

--- a/apps/web/src/pages/Ask.tsx
+++ b/apps/web/src/pages/Ask.tsx
@@ -299,12 +299,20 @@ function EmptyState({ onPick }: { onPick: (text: string) => void }) {
   // example is there to show the shape of a query, and the shapes are true even
   // where nobody offers that yet. The shelves are the half that promises supply,
   // and those are counted.
+  //
+  // What an example must do is parse to what it says. Two of these have been
+  // replaced for failing that: «страховка на год» parsed to nothing at all, and
+  // «přijímačky на медицину» answered with the technical-university subject at
+  // full confidence, because the parser reads the first word and has nothing to
+  // say about medicine. Check a new one against /search/parse before adding it —
+  // an example that misreads itself is a demonstration of the failure this
+  // screen exists to remove.
   const examples = [
     t`матан ČVUT`,
     t`čeština B2`,
-    t`přijímačky на медицину`,
+    t`помощь на экзамене по матану`,
     t`нострификация аттестата`,
-    t`курсовая по экономике`,
+    t`курсовая работа`,
   ];
 
   // Only what someone is actually offering. An empty shelf here would be the

--- a/apps/web/src/pages/Ask.tsx
+++ b/apps/web/src/pages/Ask.tsx
@@ -14,7 +14,6 @@ import {
 import { ClarifyOptionLabel, formatDay, PhraseView } from '@/components/Phrase';
 import {
   Cards,
-  Chevron,
   Chips,
   ChipView,
   Count,
@@ -337,12 +336,10 @@ function EmptyState({ onPick }: { onPick: (text: string) => void }) {
                   }
                   title={section.name}
                   hint={section.hint}
-                  trailing={
-                    <>
-                      <Count>{section.count}</Count>
-                      <Chevron />
-                    </>
-                  }
+                  // A count and no chevron, which is what the same shelf
+                  // wears on the home screen. One row in two places has to
+                  // look like one row.
+                  trailing={<Count>{section.count}</Count>}
                 />
               );
             })}
@@ -411,6 +408,11 @@ function Preview({
 
   return (
     <>
+      {/* `data.total` rather than the `total` destructured above, deliberately:
+          Lingui keys a message by its placeholders, and the member expression
+          gives `всего {0}` — the message the results screen already has. A bare
+          `total` would give `всего {total}` and split one sentence into two
+          catalog entries to translate in four files. */}
       <Label aside={<Trans>всего {data.total}</Trans>}>
         <Trans>Кто найдётся</Trans>
       </Label>

--- a/apps/web/src/pages/Ask.tsx
+++ b/apps/web/src/pages/Ask.tsx
@@ -116,6 +116,10 @@ export default function AskPage() {
   // it to. Counting that would count the whole catalog and put the number under
   // a chip that had no part in it.
   const ready = query !== '';
+
+  // Understood something, but nothing to search on. Saying nothing here would be
+  // a dead end: chips on the screen, no count, no button, no explanation.
+  const stuck = !ready && kept.length > 0;
   const { filters, isError: filtersFailed } = useSearchFilters(query);
 
   const preview = useQuery({
@@ -255,6 +259,13 @@ export default function AskPage() {
       {/* Last, and after the clarifying question rather than before it: the
           answer to that question changes the list, and a list shown above the
           thing that narrows it reads as already final. */}
+      {stuck ? (
+        <Empty
+          title={<Trans>По этому пока не найти</Trans>}
+          body={<Trans>Добавь предмет — по одному сроку искать нечего.</Trans>}
+        />
+      ) : null}
+
       {ready ? (
         <Preview
           data={preview.data}

--- a/apps/web/src/pages/Ask.tsx
+++ b/apps/web/src/pages/Ask.tsx
@@ -107,11 +107,16 @@ export default function AskPage() {
   }, []);
 
   const kept = (parsed?.chips ?? []).filter((chip) => !dropped.has(chipKey(chip)));
-  const ready = kept.length > 0 || Boolean(answer);
 
   // One string, used for the preview, for the filters and for the navigation,
   // so none of the three can describe a different search.
   const query = useMemo(() => toQuery(kept, answer), [kept, answer]);
+
+  // Empty when nothing the parse understood is something the search can filter
+  // on — a lone deadline is the real case, since there is no date filter to send
+  // it to. Counting that would count the whole catalog and put the number under
+  // a chip that had no part in it.
+  const ready = query !== '';
   const { filters, isError: filtersFailed } = useSearchFilters(query);
 
   const preview = useQuery({
@@ -280,6 +285,10 @@ function EmptyState({ onPick }: { onPick: (text: string) => void }) {
     queryFn: ({ signal }) => api.getHome(signal),
   });
 
+  // Not filtered by what the catalog holds, unlike the shelves below: an
+  // example is there to show the shape of a query, and the shapes are true even
+  // where nobody offers that yet. The shelves are the half that promises supply,
+  // and those are counted.
   const examples = [
     t`матан ČVUT`,
     t`čeština B2`,
@@ -402,7 +411,7 @@ function Preview({
 
   return (
     <>
-      <Label aside={<Trans>всего {total}</Trans>}>
+      <Label aside={<Trans>всего {data.total}</Trans>}>
         <Trans>Кто найдётся</Trans>
       </Label>
       <Cards>

--- a/apps/web/src/pages/Ask.tsx
+++ b/apps/web/src/pages/Ask.tsx
@@ -1,24 +1,44 @@
 import { Trans, useLingui } from '@lingui/react/macro';
-import { useMutation } from '@tanstack/react-query';
-import { useEffect, useRef, useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
-import { CheckIcon, ClockIcon, PlusIcon, SearchIcon } from '@/components/icons';
+import { AppHeader } from '@/components/AppHeader';
+import { HelperCardView } from '@/components/HelperCard';
+import {
+  CheckIcon,
+  ClockIcon,
+  iconForService,
+  PlusIcon,
+  SearchIcon,
+} from '@/components/icons';
 import { ClarifyOptionLabel, formatDay, PhraseView } from '@/components/Phrase';
 import {
+  Cards,
+  Chevron,
   Chips,
   ChipView,
+  Count,
+  Empty,
   Hint,
   Label,
   Row,
   Rows,
   Screen,
+  SkeletonRows,
   Sub,
   Tile,
+  Title,
   ui,
 } from '@/components/Ui';
 import { useMainButton } from '@/hooks/useTelegram';
 import { api } from '@/lib/api';
-import type { Chip, ParseResult } from '@/lib/types';
+import type {
+  Chip,
+  ParseResult,
+  SearchParams,
+  SearchResult,
+  ServiceType,
+} from '@/lib/types';
 
 const OPTION_ICON: Record<string, typeof CheckIcon> = {
   exam_prep: CheckIcon,
@@ -26,12 +46,24 @@ const OPTION_ICON: Record<string, typeof CheckIcon> = {
   both: PlusIcon,
 };
 
+/** How many of the results to show before the person has asked for them. */
+const PREVIEW = 2;
+
+/** How many kinds of help to name while the field is still empty. */
+const SHELVES = 3;
+
 /**
  * One field, then what we made of it.
  *
  * This screen exists so the catalog can have a single input instead of a
  * category tree. It shows the parse back as chips the person can remove, and
  * asks at most one question — and only when the answer changes the result.
+ *
+ * It also has to answer, before anything is typed and again after, the question
+ * a bare text field never answers: what comes out of this? Empty, it names what
+ * can be asked for and what the catalog holds. Filled, it shows the count and
+ * the first two people on the screen itself. That count used to exist only on
+ * Telegram's main button, which no browser has.
  */
 export default function AskPage() {
   const navigate = useNavigate();
@@ -73,30 +105,59 @@ export default function AskPage() {
   const kept = (parsed?.chips ?? []).filter((chip) => !dropped.has(chipKey(chip)));
   const ready = kept.length > 0 || Boolean(answer);
 
+  // The clarifying answer is a service code; the id it maps to lives in the
+  // reference list, which every screen shares and which is cached for an hour.
+  const { data: serviceTypes } = useQuery({
+    queryKey: ['service-types'],
+    queryFn: ({ signal }) => api.getServiceTypes(signal),
+    staleTime: 60 * 60 * 1000,
+  });
+
+  // One string, used for the preview and for the navigation, so the two cannot
+  // describe different searches.
+  const query = useMemo(() => toQuery(kept, answer), [kept, answer]);
+  const params = useMemo(() => searchParams(query, serviceTypes), [query, serviceTypes]);
+
+  const preview = useQuery({
+    queryKey: ['ask-preview', params],
+    queryFn: ({ signal }) => api.search({ ...params, limit: PREVIEW }, signal),
+    enabled: ready && params !== null,
+  });
+
+  // The number on the screen is the length of the list behind it, because both
+  // come out of this one request. Taking it from the parse instead would make
+  // the screen right only for as long as the two endpoints agree.
+  const total = preview.data?.total;
+
   useMainButton(
-    ready
+    ready && total
       ? {
-          text:
-            parsed && parsed.matches > 0
-              ? t`Показать ${parsed.matches}`
-              : t`Искать всё равно`,
+          text: t`Показать ${total}`,
           isVisible: true,
           isEnabled: true,
-          isLoaderVisible: parse.isPending,
-          onClick: () => navigate(`/results?${toQuery(kept, answer)}`),
+          isLoaderVisible: parse.isPending || preview.isFetching,
+          onClick: () => navigate(`/results?${query}`),
         }
       : null,
   );
 
   return (
     <Screen>
-      <div className={ui.field} style={{ alignItems: 'flex-start' }}>
+      <AppHeader />
+      <Title>
+        <Trans>Что нужно?</Trans>
+      </Title>
+      <Sub>
+        <Trans>Напиши как думаешь. Поймём предмет, вуз, срок и бюджет.</Trans>
+      </Sub>
+
+      <div className={ui.field} style={{ alignItems: 'flex-start', marginTop: 16 }}>
         <SearchIcon size={18} className={ui.fieldIcon} />
         <textarea
           ref={inputRef}
           value={text}
           onChange={(event) => setText(event.target.value)}
-          placeholder={t`нужен матан на ČVUT, экзамен 14 февраля`}
+          placeholder={t`матан на ČVUT к 14 февраля, до 600 Kč`}
           rows={2}
           style={{
             all: 'unset',
@@ -114,6 +175,8 @@ export default function AskPage() {
           </Sub>
         </div>
       ) : null}
+
+      {text.trim().length < 3 ? <EmptyState onPick={setText} /> : null}
 
       {kept.length > 0 || (parsed?.chips.length ?? 0) > 0 ? (
         <>
@@ -184,7 +247,159 @@ export default function AskPage() {
           </div>
         </>
       ) : null}
+
+      {/* Last, and after the clarifying question rather than before it: the
+          answer to that question changes the list, and a list shown above the
+          thing that narrows it reads as already final. */}
+      {ready ? (
+        <Preview data={preview.data} isPending={preview.isPending} locale={i18n.locale} />
+      ) : null}
     </Screen>
+  );
+}
+
+/**
+ * What to type, and what is here to be found.
+ *
+ * The examples are the cheap half: a person who has just left a screen of
+ * categories needs to be told that this field takes a sentence, not a keyword.
+ * The shelves under them are the honest half — three kinds of help that
+ * actually have someone behind them today.
+ */
+function EmptyState({ onPick }: { onPick: (text: string) => void }) {
+  const navigate = useNavigate();
+  const { t } = useLingui();
+
+  const { data } = useQuery({
+    queryKey: ['home'],
+    queryFn: ({ signal }) => api.getHome(signal),
+  });
+
+  const examples = [
+    t`матан ČVUT`,
+    t`čeština B2`,
+    t`přijímačky на медицину`,
+    t`нострификация аттестата`,
+    t`страховка на год`,
+  ];
+
+  // Only what someone is actually offering. An empty shelf here would be the
+  // screen advertising a thing it cannot deliver, which is the failure this
+  // whole change is about.
+  const shelves = [...(data?.people ?? [])]
+    .filter((section) => section.count > 0)
+    .sort((a, b) => b.count - a.count)
+    .slice(0, SHELVES);
+
+  return (
+    <>
+      <Label>
+        <Trans>Например</Trans>
+      </Label>
+      <Chips>
+        {examples.map((example) => (
+          <ChipView key={example} ghost onClick={() => onPick(example)}>
+            {example}
+          </ChipView>
+        ))}
+      </Chips>
+
+      {shelves.length > 0 ? (
+        <>
+          <Label>
+            <Trans>Кого тут можно найти</Trans>
+          </Label>
+          <Rows>
+            {shelves.map((section) => {
+              const Icon = iconForService(section.code);
+              return (
+                <Row
+                  key={section.code}
+                  onClick={() => navigate(`/results?service=${section.code}`)}
+                  leading={
+                    <Tile tone={section.tone}>
+                      <Icon size={19} />
+                    </Tile>
+                  }
+                  title={section.name}
+                  hint={section.hint}
+                  trailing={
+                    <>
+                      <Count>{section.count}</Count>
+                      <Chevron />
+                    </>
+                  }
+                />
+              );
+            })}
+          </Rows>
+        </>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * The first people the query finds, before the person has asked to see them.
+ *
+ * Two cards, because the point is not the list — it is that there is one, and
+ * what the rows in it look like. Zero is said out loud here rather than left
+ * to a main button reading "искать всё равно".
+ */
+function Preview({
+  data,
+  isPending,
+  locale,
+}: {
+  data: SearchResult | undefined;
+  isPending: boolean;
+  locale: string;
+}) {
+  const navigate = useNavigate();
+
+  if (isPending) {
+    return (
+      <>
+        <Label>
+          <Trans>Ищем…</Trans>
+        </Label>
+        <SkeletonRows count={PREVIEW} />
+      </>
+    );
+  }
+
+  // Nothing at all rather than an error state: the chips above already say what
+  // was understood, and the main button is gone, so the screen is honest about
+  // having nothing to promise.
+  if (!data) return null;
+
+  const { total, results } = data;
+
+  if (total === 0) {
+    return (
+      <Empty
+        title={<Trans>По этому запросу пока никого</Trans>}
+        body={<Trans>Убери что-нибудь из уточнений выше или напиши иначе.</Trans>}
+      />
+    );
+  }
+
+  return (
+    <>
+      <Label aside={<Trans>всего {total}</Trans>}>
+        <Trans>Кто найдётся</Trans>
+      </Label>
+      <Cards>
+        {results.map((card) => (
+          <HelperCardView
+            key={card.user_id}
+            card={card}
+            locale={locale}
+            onClick={() => navigate(`/helper/${card.user_id}`)}
+          />
+        ))}
+      </Cards>
+    </>
   );
 }
 
@@ -212,4 +427,34 @@ function toQuery(chips: Chip[], answer: string | null): string {
   // results screen resolves it, because it already loads the list.
   if (answer && answer !== 'both') params.set('service', answer);
   return params.toString();
+}
+
+/**
+ * The same query string, as the arguments the search endpoint takes.
+ *
+ * Null while a service code is still waiting for the reference list: searching
+ * without it would count everyone who teaches the subject, show that number,
+ * and then hand over to a screen that filters by kind of help.
+ */
+function searchParams(
+  query: string,
+  serviceTypes: ServiceType[] | undefined,
+): SearchParams | null {
+  const params = new URLSearchParams(query);
+  const code = params.get('service');
+  const byCode = code ? serviceTypes?.find((type) => type.code === code)?.id : undefined;
+  if (code && byCode === undefined) return null;
+
+  return {
+    subject_id: numeric(params.get('subject_id')),
+    institution_id: numeric(params.get('institution_id')),
+    service_type_id: numeric(params.get('service_type_id')) ?? byCode,
+    max_price: numeric(params.get('max_price')),
+  };
+}
+
+function numeric(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }

--- a/apps/web/src/pages/Ask.tsx
+++ b/apps/web/src/pages/Ask.tsx
@@ -300,13 +300,20 @@ function EmptyState({ onPick }: { onPick: (text: string) => void }) {
   // where nobody offers that yet. The shelves are the half that promises supply,
   // and those are counted.
   //
-  // What an example must do is parse to what it says. Two of these have been
+  // What an example must do is parse to what it says. Four of these have been
   // replaced for failing that: «страховка на год» parsed to nothing at all, and
   // «přijímačky на медицину» answered with the technical-university subject at
   // full confidence, because the parser reads the first word and has nothing to
-  // say about medicine. Check a new one against /search/parse before adding it —
-  // an example that misreads itself is a demonstration of the failure this
-  // screen exists to remove.
+  // say about medicine.
+  //
+  // The same bar applies to each **translation**, and it is not met by
+  // translating the words: the parser matches against subject names in the
+  // reader's language, so the Czech «matika» found linear algebra where the
+  // Russian «матан» finds calculus, and the English «a term paper» found
+  // mechanics. Every example, in all four catalogs, was checked by posting it to
+  // /search/parse as a user of that language. Do that before changing one — an
+  // example that misreads itself is a demonstration of the failure this screen
+  // exists to remove.
   const examples = [
     t`матан ČVUT`,
     t`čeština B2`,
@@ -469,8 +476,9 @@ function toQuery(chips: Chip[], answer: string | null): string {
     if (chip.kind === 'service_type') params.set('service_type_id', String(chip.value));
     if (chip.kind === 'budget') params.set('max_price', String(chip.value));
   }
-  // The answer to the clarifying question is a service type by name; the
-  // results screen resolves it, because it already loads the list.
+  // The answer to the clarifying question is a service type by name. Resolving
+  // it to an id belongs to `useSearchFilters`, which both this screen and the
+  // results screen read the string through.
   if (answer && answer !== 'both') params.set('service', answer);
   return params.toString();
 }

--- a/apps/web/src/pages/Results.tsx
+++ b/apps/web/src/pages/Results.tsx
@@ -1,6 +1,6 @@
 import { Trans, useLingui } from '@lingui/react/macro';
 import { useQuery } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 
 import { HelperCardView } from '@/components/HelperCard';
@@ -15,6 +15,7 @@ import {
   Segmented,
   SkeletonRows,
 } from '@/components/Ui';
+import { useSearchFilters } from '@/hooks/useSearchFilters';
 import { hapticSelection } from '@/hooks/useTelegram';
 import { api } from '@/lib/api';
 import type { SearchSort } from '@/lib/types';
@@ -32,40 +33,18 @@ export default function ResultsPage() {
   const { t, i18n } = useLingui();
   const [sort, setSort] = useState<SearchSort>('relevance');
 
-  const filters = useMemo(
-    () => ({
-      subject_id: numeric(params.get('subject_id')),
-      institution_id: numeric(params.get('institution_id')),
-      service_type_id: numeric(params.get('service_type_id')),
-      max_price: numeric(params.get('max_price')),
-      sort,
-    }),
-    [params, sort],
-  );
-
-  // The clarifying answer arrives as a service code; the id it maps to lives
-  // in the reference list this screen would load anyway.
-  const serviceCode = params.get('service');
-  const { data: serviceTypes } = useQuery({
-    queryKey: ['service-types'],
-    queryFn: ({ signal }) => api.getServiceTypes(signal),
-    enabled: Boolean(serviceCode) && !filters.service_type_id,
-    staleTime: 60 * 60 * 1000,
-  });
-  const serviceTypeId =
-    filters.service_type_id ??
-    serviceTypes?.find((type) => type.code === serviceCode)?.id;
-
-  const waitingForServiceId = Boolean(serviceCode) && serviceTypeId === undefined;
+  // The same reading of the query string the search screen used to count and
+  // preview this list, so the number it showed is the number that arrives here.
+  const { filters, isError: filtersFailed } = useSearchFilters(params);
 
   const { data, isPending, isError } = useQuery({
-    queryKey: ['search', { ...filters, service_type_id: serviceTypeId }],
-    queryFn: ({ signal }) =>
-      api.search({ ...filters, service_type_id: serviceTypeId }, signal),
-    enabled: !waitingForServiceId,
+    queryKey: ['search', { ...filters, sort }],
+    queryFn: ({ signal }) => api.search({ ...filters, sort }, signal),
+    enabled: filters !== null,
   });
 
-  const loading = isPending || waitingForServiceId;
+  const loading = isPending && !filtersFailed;
+  const failed = isError || filtersFailed;
 
   return (
     <>
@@ -106,7 +85,7 @@ export default function ResultsPage() {
             </Label>
             <SkeletonRows count={4} />
           </>
-        ) : isError ? (
+        ) : failed || !data ? (
           <Empty
             title={<Trans>Не получилось загрузить</Trans>}
             body={<Trans>Проверь соединение и попробуй ещё раз.</Trans>}
@@ -141,10 +120,4 @@ export default function ResultsPage() {
       <TabBar />
     </>
   );
-}
-
-function numeric(value: string | null): number | undefined {
-  if (!value) return undefined;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
 }

--- a/apps/web/src/pages/Results.tsx
+++ b/apps/web/src/pages/Results.tsx
@@ -3,26 +3,21 @@ import { useQuery } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 
-import { PhraseView, PriceUnitLabel } from '@/components/Phrase';
+import { HelperCardView } from '@/components/HelperCard';
 import { TabBar } from '@/components/TabBar';
 import {
-  AvatarView,
-  Card,
   Cards,
   Chips,
   ChipView,
   Empty,
-  Free,
   Label,
-  PriceView,
-  Reason,
   Screen,
   Segmented,
   SkeletonRows,
 } from '@/components/Ui';
 import { hapticSelection } from '@/hooks/useTelegram';
 import { api } from '@/lib/api';
-import type { HelperCard, SearchSort } from '@/lib/types';
+import type { SearchSort } from '@/lib/types';
 
 /**
  * The results list.
@@ -145,56 +140,6 @@ export default function ResultsPage() {
       </Screen>
       <TabBar />
     </>
-  );
-}
-
-function HelperCardView({
-  card,
-  locale,
-  onClick,
-}: {
-  card: HelperCard;
-  locale: string;
-  onClick: () => void;
-}) {
-  // "Cheaper but unproven" is the one reason that should not wear the same
-  // confident green dot as the others.
-  const weak = card.reason?.code === 'reason.cheapest_but_unproven';
-
-  return (
-    <Card onClick={onClick}>
-      <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
-        <AvatarView avatar={card.avatar} size={40} square />
-        <div style={{ minWidth: 0 }}>
-          <div style={{ fontSize: 14.5, fontWeight: 680, letterSpacing: '-0.015em' }}>
-            {card.name}
-          </div>
-          {card.affiliation ? (
-            <div style={{ marginTop: 2, fontSize: 12, color: 'var(--muted)' }}>
-              {card.affiliation}
-            </div>
-          ) : null}
-        </div>
-        {card.price ? (
-          <PriceView
-            price={card.price}
-            unitLabel={<PriceUnitLabel unit={card.price.unit} />}
-          />
-        ) : null}
-      </div>
-
-      {card.reason ? (
-        <Reason weak={weak}>
-          <PhraseView phrase={card.reason} locale={locale} />
-        </Reason>
-      ) : null}
-
-      {card.availability ? (
-        <Free>
-          <PhraseView phrase={card.availability} locale={locale} />
-        </Free>
-      ) : null}
-    </Card>
   );
 }
 

--- a/apps/web/src/pages/Results.tsx
+++ b/apps/web/src/pages/Results.tsx
@@ -37,14 +37,21 @@ export default function ResultsPage() {
   // preview this list, so the number it showed is the number that arrives here.
   const { filters, isError: filtersFailed } = useSearchFilters(params);
 
+  // `filters` and not `{...filters}`: spread onto an object, a null — the
+  // service code has not been resolved yet — becomes the same key as a search
+  // with no filters at all. A warm cache from an unfiltered visit would then be
+  // handed over as this query's answer, and the screen would show the whole
+  // catalog under one person's query before quietly swapping it out.
   const { data, isPending, isError } = useQuery({
-    queryKey: ['search', { ...filters, sort }],
+    queryKey: ['search', filters, sort],
     queryFn: ({ signal }) => api.search({ ...filters, sort }, signal),
     enabled: filters !== null,
   });
 
-  const loading = isPending && !filtersFailed;
+  // Unknown filters are still loading, not loaded. The error takes precedence,
+  // or a failed lookup would keep the skeleton up for ever.
   const failed = isError || filtersFailed;
+  const loading = (isPending || filters === null) && !failed;
 
   return (
     <>

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -144,6 +144,12 @@ zero results are a ranked list of what the catalog is missing; raw text paired
 with the parse is training data for making the parser better. It is the cheapest
 table in the schema and the most valuable.
 
+That count is computed with every filter the parse produced, the budget
+included — the same filters the search behind it applies. A count that ignores
+one of them is wrong in both directions at once: it promises the reader a
+number the next screen will not deliver, and it records a result for a query
+nobody ran, which is the one thing the zero-result list must not contain.
+
 ## Services, things, materials
 
 Three tables because three sets of rules:

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -144,11 +144,11 @@ zero results are a ranked list of what the catalog is missing; raw text paired
 with the parse is training data for making the parser better. It is the cheapest
 table in the schema and the most valuable.
 
-That count is computed with every parsed filter the search can apply — subject,
-institution, kind of help and budget. Dropping one of them is wrong in both
-directions at once: it promises the reader a number the next screen will not
-deliver, and it records a result for a query nobody ran, which is the one thing
-the zero-result list must not contain.
+That count — returned to the caller as `matches` and stored as
+`results_count` — is computed with every parsed filter the search can apply:
+subject, institution, kind of help and budget. Dropping one of them records a
+result for a query nobody ran, which is the one thing the zero-result list must
+not contain, and hands the same wrong number to anyone who shows it.
 
 The deadline is the parsed value with nowhere to go: it becomes a chip and is
 logged in the parse, but the search has no date filter, so a query that says

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -144,11 +144,18 @@ zero results are a ranked list of what the catalog is missing; raw text paired
 with the parse is training data for making the parser better. It is the cheapest
 table in the schema and the most valuable.
 
-That count is computed with every filter the parse produced, the budget
-included — the same filters the search behind it applies. A count that ignores
-one of them is wrong in both directions at once: it promises the reader a
-number the next screen will not deliver, and it records a result for a query
-nobody ran, which is the one thing the zero-result list must not contain.
+That count is computed with every parsed filter the search can apply — subject,
+institution, kind of help and budget. Dropping one of them is wrong in both
+directions at once: it promises the reader a number the next screen will not
+deliver, and it records a result for a query nobody ran, which is the one thing
+the zero-result list must not contain.
+
+The deadline is the parsed value with nowhere to go: it becomes a chip and is
+logged in the parse, but the search has no date filter, so a query that says
+nothing except a date counts the whole catalog. The screen does not show that
+number — it shows a count only when something is being filtered — but the logged
+`results_count` is still the size of the catalog rather than an answer, so
+date-only rows do not belong in the zero-result list either way.
 
 ## Services, things, materials
 


### PR DESCRIPTION
Docs updated first: docs/data-model.md

`/ask` was one text field and nothing else. It never said what the parser reads,
what the catalog holds, or how many people a query finds. The count existed, but
it lived only on Telegram's main button — which no browser has — and at zero that
button offered to search anyway rather than admit the zero.

Variant B of three mockups, chosen by the user.

## What the screen does now

**Empty:** the app header it was one of only two screens to be missing, a title,
and a line naming what the parser reads. Then five example queries as tappable
chips, and the three kinds of help somebody is actually offering, each with its
count, taken from the `/home` response already in the React Query cache.

**Filled:** the count and the first two people, on the screen. Both come out of
one `/search` call with `limit=2`, so the number and the list behind it cannot
disagree. The preview sits below the clarifying question rather than above it —
the answer to that question changes the list, and a list drawn above the control
that narrows it reads as already final.

**Zero:** says so. **A query the parser read only as a date:** says that a
subject is needed, instead of counting the whole catalog under a chip that had no
part in it.

## The count had to be true first

`/search/parse` drew a budget chip and then computed its number by calling
`catalog.search` without `max_price`, while `/results` applies it. "матан до 500"
promised five people and listed two. Same number goes into
`search_queries.results_count`, which `docs/data-model.md` calls the ranked list
of what the catalog is missing — so the row recorded a result for a query nobody
ran. One argument, pinned by
`test_parse_counts_only_what_the_search_will_show`, which asserts the parse count
against the search's own total rather than a literal (the seed brings its own
helpers on that subject) and separately that the filter is doing something.

## Also, because two screens had to agree

`HelperCardView` moved out of `Results.tsx` into `components/HelperCard.tsx`, and
the mapping from query string to search filters became one `useSearchFilters`
hook that both screens read through. A preview of a list stops being worth
anything the moment it stops looking like the list, and the agreement between the
count and the list was otherwise two hand-maintained copies.

## Verification

- `make check`: ruff, ruff format, ty, biome, tsc, 254 API tests.
- `pnpm check:scroll` at 390×664, 360×640 and 390×568 — every screen ends on
  content. `/ask` was already measured and now measures a much fuller screen.
- Screenshots at 390px in both themes, plus the zero and date-only states.
- All 24 example and placeholder strings posted to `/search/parse` as a user of
  each of the four languages; every one echoes a subject matching what it says at
  confidence 0.72 or better.
- Eight independent review rounds. Findings fixed: an example that parsed to
  nothing; two that echoed a subject contradicting the query; the same defect in
  the Czech and English catalogs, which translating the words did not carry over;
  a shared query key that let one screen's failure speak for another; a cache
  collision that served an unfiltered search as a filtered one; a docs sentence
  that overclaimed; and a silent dead end.

## Out of scope

- **A request cannot be created anywhere in the app.** `api.createRequest` is
  called by nothing, while the tab bar's round button ("опиши задачу — придут
  отклики") and the empty results screen ("создай заявку") both promise it. Its
  own change — variant C of the mockups.
- The parser reads none of the five kinds of help that are not about studying:
  `SERVICE_KEYWORDS` has no entry for insurance, a bank statement, a translation,
  residence paperwork or housing, so they can be offered and never searched for
  in words.
- There is no date filter on the server, so a deadline is parsed, shown and
  logged but never applied. Now stated in `docs/data-model.md`.
- The English nostrification example produces no kind-of-help chip — no English
  stem for it in `SERVICE_KEYWORDS`. The subject is right, so nothing false is
  claimed.
- `/results` still has no `AppHeader`; only `/ask` gained one here.
- `/results?category=...` is read by nothing, so the home screen's "Вещи" rows
  land on an unfiltered list.
- The forward action is still Telegram's main button, absent in a browser. True
  of every screen in the app.
- Carried from the previous change: CI never checks `apps/web/src/lib/generated`
  against the OpenAPI document; `test_health.py` does not pin the
  `elsewhere: <url>` webhook state; the function-level `services.lookup` import in
  `api/v1/taxonomy.py` is unhoisted; avatar stacks appear only in a wide cell, so
  the four-tile study shelf never shows faces; `requires_institution` is read by
  nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL
