### PR TITLE
Let the parser read what it is shown

### DIFF
--- a/apps/api/src/students_cz/services/lookup.py
+++ b/apps/api/src/students_cz/services/lookup.py
@@ -199,7 +199,11 @@ _INSTITUTION_SQL = text(
     f"""
     WITH q AS (
         SELECT {_NORM.format(expr="CAST(:qnorm AS text)")} AS raw,
-               {_NORM.format(expr="CAST(:qlat AS text)")} AS latin
+               {_NORM.format(expr="CAST(:qlat AS text)")} AS latin,
+               {_TOKENS.format(expr=_NORM.format(expr="CAST(:qnorm AS text)"))}
+                   AS tokens,
+               {_TOKENS.format(expr=_NORM.format(expr="CAST(:qlat AS text)"))}
+                   AS latin_tokens
     )
     SELECT n.id, n.label, n.score
       FROM (
@@ -215,12 +219,31 @@ _INSTITUTION_SQL = text(
                                         || replace(inst.code, '_', '[ _-]?')
                                         || '([^a-z0-9]|$)')
                         THEN 1.0 ELSE 0.0 END,
+                   -- A short faculty name is a whole word or it is nothing.
+                   -- "FI", "UK" and "JU" are two letters, and trigram
+                   -- similarity puts any word containing them over the
+                   -- threshold: "по физике" came back naming the faculty FI at
+                   -- 0.67. Matched against the query's tokens, the same way
+                   -- subject synonyms are two functions up, so there is one
+                   -- idea of "whole word" here and no second regex to escape.
+                   COALESCE(MAX(CASE WHEN length(i.short_name) < 4 AND (
+                            strpos(q.tokens, ' ' || {_NORM.format(expr="i.short_name")}
+                                   || ' ') > 0
+                         OR strpos(q.latin_tokens,
+                                   ' ' || {_NORM.format(expr="i.short_name")}
+                                   || ' ') > 0)
+                       THEN 1.0 ELSE 0.0 END), 0.0),
                    COALESCE(MAX(word_similarity(
                        immutable_unaccent(lower(i.name)), q.raw)), 0.0),
-                   COALESCE(MAX(word_similarity(
-                       immutable_unaccent(lower(i.short_name)), q.raw)), 0.0),
-                   COALESCE(MAX(word_similarity(
-                       immutable_unaccent(lower(i.short_name)), q.latin)), 0.0)
+                   -- Long enough for a trigram score to mean something.
+                   COALESCE(MAX(CASE WHEN length(i.short_name) >= 4
+                       THEN word_similarity(
+                           immutable_unaccent(lower(i.short_name)), q.raw)
+                       END), 0.0),
+                   COALESCE(MAX(CASE WHEN length(i.short_name) >= 4
+                       THEN word_similarity(
+                           immutable_unaccent(lower(i.short_name)), q.latin)
+                       END), 0.0)
                ) AS score
           FROM institutions inst
           CROSS JOIN q
@@ -233,7 +256,8 @@ _INSTITUTION_SQL = text(
           ) any_name ON TRUE
          WHERE inst.is_active
          GROUP BY inst.id, inst.code, pref.short_name, pref.name,
-                  any_name.short_name, any_name.name, q.raw, q.latin
+                  any_name.short_name, any_name.name,
+                  q.raw, q.latin, q.tokens, q.latin_tokens
       ) n
      WHERE n.score >= :threshold
      ORDER BY n.score DESC

--- a/apps/api/src/students_cz/services/lookup.py
+++ b/apps/api/src/students_cz/services/lookup.py
@@ -219,14 +219,21 @@ _INSTITUTION_SQL = text(
                                         || replace(inst.code, '_', '[ _-]?')
                                         || '([^a-z0-9]|$)')
                         THEN 1.0 ELSE 0.0 END,
-                   -- A short faculty name is a whole word or it is nothing.
-                   -- "FI", "UK" and "JU" are two letters, and trigram
+                   -- A two-letter faculty name is a whole word or it is
+                   -- nothing. "FI", "UK" and "JU" are two letters, and trigram
                    -- similarity puts any word containing them over the
                    -- threshold: "по физике" came back naming the faculty FI at
                    -- 0.67. Matched against the query's tokens, the same way
                    -- subject synonyms are two functions up, so there is one
                    -- idea of "whole word" here and no second regex to escape.
-                   COALESCE(MAX(CASE WHEN length(i.short_name) < 4 AND (
+                   --
+                   -- Two and not three: Czech declines the abbreviation itself,
+                   -- and "na FELu", "na FITu", "na MFFce" are how people write
+                   -- it. Cutting at three characters cost all 57 three-letter
+                   -- faculties every inflected form they had, and bought
+                   -- nothing — every false positive worth killing here is two
+                   -- letters long.
+                   COALESCE(MAX(CASE WHEN length(i.short_name) < 3 AND (
                             strpos(q.tokens, ' ' || {_NORM.format(expr="i.short_name")}
                                    || ' ') > 0
                          OR strpos(q.latin_tokens,
@@ -236,11 +243,11 @@ _INSTITUTION_SQL = text(
                    COALESCE(MAX(word_similarity(
                        immutable_unaccent(lower(i.name)), q.raw)), 0.0),
                    -- Long enough for a trigram score to mean something.
-                   COALESCE(MAX(CASE WHEN length(i.short_name) >= 4
+                   COALESCE(MAX(CASE WHEN length(i.short_name) >= 3
                        THEN word_similarity(
                            immutable_unaccent(lower(i.short_name)), q.raw)
                        END), 0.0),
-                   COALESCE(MAX(CASE WHEN length(i.short_name) >= 4
+                   COALESCE(MAX(CASE WHEN length(i.short_name) >= 3
                        THEN word_similarity(
                            immutable_unaccent(lower(i.short_name)), q.latin)
                        END), 0.0)

--- a/apps/api/src/students_cz/services/lookup.py
+++ b/apps/api/src/students_cz/services/lookup.py
@@ -229,8 +229,9 @@ _INSTITUTION_SQL = text(
                    --
                    -- Two and not three: Czech declines the abbreviation itself,
                    -- and "na FELu", "na FITu", "na MFFce" are how people write
-                   -- it. Cutting at three characters cost all 57 three-letter
-                   -- faculties every inflected form they had, and bought
+                   -- it. Cutting at three characters cost the 69 institutions
+                   -- with a three-character short name every inflected form
+                   -- they had — 60 of them faculties — and bought
                    -- nothing — every false positive worth killing here is two
                    -- letters long.
                    --

--- a/apps/api/src/students_cz/services/lookup.py
+++ b/apps/api/src/students_cz/services/lookup.py
@@ -317,7 +317,11 @@ async def find_institutions(
             id=r.id,
             label=r.label,
             score=float(r.score),
-            matched_on="code" if r.score >= 1.0 else "name",
+            # "exact" rather than "code": since short names are matched as
+            # whole words, a 1.0 can come from the code or from a short name,
+            # and only the SQL knows which. Neither is a guess, which is all
+            # this field is read for.
+            matched_on="exact" if r.score >= 1.0 else "name",
         )
         for r in rows
     ]

--- a/apps/api/src/students_cz/services/lookup.py
+++ b/apps/api/src/students_cz/services/lookup.py
@@ -233,6 +233,13 @@ _INSTITUTION_SQL = text(
                    -- faculties every inflected form they had, and bought
                    -- nothing — every false positive worth killing here is two
                    -- letters long.
+                   --
+                   -- The two-letter names pay that price instead: "na UKu" and
+                   -- "na FIu" used to resolve at 0.67 and now resolve to
+                   -- nothing. That is the trade, taken deliberately. A missing
+                   -- institution filter shows a wider list than the person
+                   -- asked for; a wrong one silently narrows the catalog to a
+                   -- faculty nobody named, which is what "по физике" did.
                    COALESCE(MAX(CASE WHEN length(i.short_name) < 3 AND (
                             strpos(q.tokens, ' ' || {_NORM.format(expr="i.short_name")}
                                    || ' ') > 0
@@ -324,10 +331,10 @@ async def find_institutions(
             id=r.id,
             label=r.label,
             score=float(r.score),
-            # "exact" rather than "code": since short names are matched as
-            # whole words, a 1.0 can come from the code or from a short name,
-            # and only the SQL knows which. Neither is a guess, which is all
-            # this field is read for.
+            # "exact" rather than "code": a 1.0 can come from the code, from a
+            # whole-word short name, or from a full name the query reproduced
+            # exactly, and which of the three is not carried back. What the
+            # field is read for is whether the match was a guess.
             matched_on="exact" if r.score >= 1.0 else "name",
         )
         for r in rows

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -82,6 +82,31 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "osp",
         "nastupni",
     ),
+    # Above the study kinds, unlike the rest of the non-study block below: every
+    # keyword here is a two-word document phrase, so nothing a study query says
+    # can trip it — while "присяжный перевод диплома" was answered as thesis
+    # writing on the strength of the word "диплом", and "перевод аттестата" as
+    # nostrification.
+    "translation": (
+        "перевод документ",
+        "перевод атт",
+        "перевод дипл",
+        "нотариальный перевод",
+        "переводом документ",
+        "судебный перевод",
+        "перевод с печат",
+        "присяжный перевод",
+        "переклад документ",
+        "переклад атт",
+        "судовий переклад",
+        "soudni preklad",
+        "uredni preklad",
+        "preklad dokument",
+        "s razitkem",
+        "sworn translation",
+        "certified translation",
+        "official translation",
+    ),
     "nostrification": (
         "нострифик",
         "nostrifik",
@@ -135,7 +160,7 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "страховк",
         "страхован",
         "страхуван",
-        "pojiste",
+        "pojist",
         "insurance",
     ),
     "bank_letter": (
@@ -148,38 +173,28 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "довідку з банк",
         "з банку",
         "vypis z ban",
+        "vypis z uct",
         "potvrzeni z ban",
         "potvrzeni o vedeni",
+        "zustatk",
         "bank statement",
         "bank letter",
         "proof of funds",
     ),
-    "translation": (
-        "перевод документ",
-        "переводом документ",
-        "судебный перевод",
-        "перевод с печат",
-        "присяжный перевод",
-        "переклад документ",
-        "судовий переклад",
-        "soudni preklad",
-        "uredni preklad",
-        "preklad dokument",
-        "s razitkem",
-        "sworn translation",
-        "certified translation",
-        "official translation",
-    ),
     "residence": (
         "внж",
         "вид на жительство",
-        "долгосрочная виза",
-        "продлить визу",
+        # Stems, not phrases: a multi-word keyword tolerates inflection only on
+        # its last word, so "prodlouzeni dlouhodobeho pobytu" — the standard
+        # Czech phrase — reached none of the three that used to be listed here.
+        "виза",
+        "визы",
+        "визу",
+        "визой",
         "посвідка на проживанн",
-        "pobytov",
-        "prodlouzeni pobytu",
-        "povoleni k pobytu",
-        "dlouhodoby pobyt",
+        "pobyt",
+        "dlouhodob",
+        "povoleni k pobyt",
         "residence permit",
         "long term visa",
     ),
@@ -198,9 +213,17 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
     ),
 }
 
+# The kinds of help that never carry a subject: `service_types.requires_subject`
+# is false for all five, and `offers` rows in the non-study group have a null
+# subject. Named here because the parser has to know it without loading the
+# table — see the rule in `parse`.
+SUBJECTLESS = frozenset(
+    {"insurance", "bank_letter", "translation", "residence", "housing"}
+)
+
 # "помочь с X" is the commonest phrasing there is, but on its own it says
 # nothing about *which* kind of help. It counts as tutoring only when the text
-# gives no other clue — see _match_service.
+# gives no other clue — see _service_match.
 WEAK_HELP: tuple[str, ...] = ("помо", "pomo", "help", "допомо", "нужен", "потрібн")
 
 # Words that put an exam in the picture without saying whether the help is
@@ -265,7 +288,7 @@ async def parse(
     norm = normalise(text)
     result = ParsedQuery(raw=text)
 
-    result.service_type, matched_on = _service_match(norm)
+    result.service_type, keyword = _service_match(norm)
 
     subjects = await find_subjects(session, text, lang, limit=4)
     # When the words naming the kind of help were the whole query, there is no
@@ -274,8 +297,18 @@ async def parse(
     # Statistics at 0.61. A synonym hit survives, because that is not a guess —
     # "курсовая" and "нострификация" are curated names for real subjects, and
     # dropping them would lose a certainty to protect against a maybe.
-    if matched_on and not _without(norm, matched_on):
+    if keyword and not _without(norm, keyword):
         subjects = [match for match in subjects if match.matched_on == "synonym"]
+
+    # A kind of help that never carries a subject cannot be the answer to a
+    # query that names one. `catalog.search` ANDs the two, and no offer in the
+    # non-study group has a subject, so the pair matches nobody: "нужен матан,
+    # живу в общежитии" is a question about calculus with an aside in it, and
+    # reading it as housing turned a list of tutors into an empty screen. Read
+    # again as if those kinds did not exist.
+    if subjects and result.service_type in SUBJECTLESS:
+        result.service_type, _ = _service_match(norm, ignore=SUBJECTLESS)
+
     institutions = await find_institutions(session, text, lang, limit=3)
 
     if subjects:
@@ -294,12 +327,9 @@ async def parse(
     return result
 
 
-def _match_service(norm: str) -> str | None:
-    """Which kind of help the text names, if any."""
-    return _service_match(norm)[0]
-
-
-def _service_match(norm: str) -> tuple[str | None, str | None]:
+def _service_match(
+    norm: str, *, ignore: frozenset[str] = frozenset()
+) -> tuple[str | None, str | None]:
     """The kind of help, and the keyword that decided it.
 
     First keyword wins, and the dictionary is ordered by specificity. "помощь на
@@ -307,13 +337,17 @@ def _service_match(norm: str) -> tuple[str | None, str | None]:
     checked before exam_prep and generic tutoring last. Weak verbs are
     considered only after every specific rule has passed.
 
-    The keyword comes back because the caller takes it out of the query before
-    looking for a subject. A weak verb yields no keyword: "помоги" says nothing
-    about which kind of help, so there is nothing to remove that would sharpen
-    anything.
+    The keyword comes back so the caller can ask whether anything else was in the
+    query at all. A weak verb yields none: "помоги" names no kind of help by
+    itself, so there is nothing to say it took the whole sentence.
+
+    `ignore` re-reads the same text as if some kinds did not exist — see
+    SUBJECTLESS at the call site.
     """
     tokens = tokenise(norm)
     for code, keywords in SERVICE_KEYWORDS.items():
+        if code in ignore:
+            continue
         for keyword in keywords:
             if starts_a_word(tokens, keyword):
                 return code, keyword
@@ -329,8 +363,8 @@ def _without(norm: str, keyword: str) -> str:
     """`norm` minus the words the keyword touched.
 
     Whole words, not the keyword's characters: the keywords are stems, so
-    removing "нострифик" from "нострификация" would leave "ация" and hand the
-    subject lookup a fragment to score against.
+    removing "нострифик" from "нострификация" would leave "ация", and the caller
+    is asking whether anything is left — a fragment would answer yes.
     """
     tokens = tokenise(norm)
     needle = tokenise(keyword).rstrip()

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -110,13 +110,6 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
     # "присяжный перевод диплома" was answered as thesis writing on the strength
     # of the word "диплом", and "перевод аттестата" as nostrification, and the
     # only thing that fixes those is order.
-    #
-    # Most of these are two-word document phrases that no study query contains.
-    # The last three are not, and they cost something: "translation studies
-    # tutor" reads as a document translation. Taken deliberately — a foreign
-    # student in Czechia asking for "a translation" wants a stamped document far
-    # more often than a seminar on translation theory, and that field is not in
-    # the catalog at all.
     "translation": (
         # Stems for the noun in each language, because a multi-word keyword
         # tolerates inflection only on its last word — so "присяжного перевода

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -106,11 +106,17 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "osp",
         "nastupni",
     ),
-    # Above the study kinds, unlike the rest of the non-study block below: every
-    # keyword here is a two-word document phrase, so nothing a study query says
-    # can trip it — while "присяжный перевод диплома" was answered as thesis
-    # writing on the strength of the word "диплом", and "перевод аттестата" as
-    # nostrification.
+    # Above the study kinds, unlike the rest of the non-study block below.
+    # "присяжный перевод диплома" was answered as thesis writing on the strength
+    # of the word "диплом", and "перевод аттестата" as nostrification, and the
+    # only thing that fixes those is order.
+    #
+    # Most of these are two-word document phrases that no study query contains.
+    # The last three are not, and they cost something: "translation studies
+    # tutor" reads as a document translation. Taken deliberately — a foreign
+    # student in Czechia asking for "a translation" wants a stamped document far
+    # more often than a seminar on translation theory, and that field is not in
+    # the catalog at all.
     "translation": (
         "перевод документ",
         "перевод атт",
@@ -132,6 +138,7 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "official translation",
         # The plainest English phrasings, and the seed's own English label.
         Word("translation"),
+        Word("translations"),
         "translate",
         "translating",
     ),
@@ -217,9 +224,10 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
     "residence": (
         "внж",
         "вид на жительство",
-        # Stems, not phrases: a multi-word keyword tolerates inflection only on
-        # its last word, so "prodlouzeni dlouhodobeho pobytu" — the standard
-        # Czech phrase — reached none of the three that used to be listed here.
+        # Words for the visa, and a stem for the stay. A multi-word keyword
+        # tolerates inflection only on its last word, so the three phrases that
+        # used to be here reached none of "prodlouzeni dlouhodobeho pobytu" —
+        # the standard Czech phrasing — which "pobyt" does.
         Word("виза"),
         Word("визы"),
         Word("визу"),
@@ -260,6 +268,14 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
 SUBJECTLESS = frozenset(
     {"insurance", "bank_letter", "translation", "residence", "housing"}
 )
+
+# The four of those whose keywords are ordinary words that turn up as asides —
+# where somebody lives, what they are insured for. A subject named beside one of
+# these is the question, and the aside is not. `translation` is deliberately not
+# here: "присяжный перевод диплома" is not something anybody writes in passing,
+# so when it appears the document is the request and a subject beside it is not
+# one this kind of help can be filtered by.
+ASIDES = SUBJECTLESS - {"translation"}
 
 # "помочь с X" is the commonest phrasing there is, but on its own it says
 # nothing about *which* kind of help. It counts as tutoring only when the text
@@ -347,8 +363,9 @@ async def parse(
     # reading it as housing turned a list of tutors into an empty screen. Read
     # again as if those kinds did not exist.
     #
-    # Which of the two gives way depends on whether the subject was named. A
-    # named subject wins: read the kind of help again as if the
+    # Which of the two gives way depends on whether the subject was named, and on
+    # whether the kind of help could have been an aside. A named subject beside
+    # an aside wins: read the kind of help again as if the
     # non-study ones did not exist. A trigram score is a guess, and a guess
     # cannot narrow a kind of help that has no subjects to narrow by — so the
     # guess goes instead. Keeping both was a guaranteed empty screen, and
@@ -356,7 +373,7 @@ async def parse(
     # above the study kinds: "присяжный перевод диплома" scores «Академическое
     # письмо» at 0.55.
     if subjects and result.service_type in SUBJECTLESS:
-        if _is_named(subjects[0]):
+        if _is_named(subjects[0]) and result.service_type in ASIDES:
             result.service_type, _ = _match_service(norm, ignore=SUBJECTLESS)
         else:
             subjects = []

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -191,9 +191,13 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "визы",
         "визу",
         "визой",
+        "візу",
+        "візи",
+        "віза",
         "посвідка на проживанн",
+        "vizum",
+        "viza",
         "pobyt",
-        "dlouhodob",
         "povoleni k pobyt",
         "residence permit",
         "long term visa",
@@ -213,17 +217,19 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
     ),
 }
 
-# The kinds of help that never carry a subject: `service_types.requires_subject`
-# is false for all five, and `offers` rows in the non-study group have a null
-# subject. Named here because the parser has to know it without loading the
-# table — see the rule in `parse`.
+# The kinds of help in the `life` group — the ones that are not about studying
+# and carry no subject at all. Not "requires_subject is false", which is also
+# true of exam help and nostrification and would be the wrong set: it is the
+# group. Written out because the parser reads no tables, and pinned to the seed
+# by test_subjectless_is_exactly_the_life_group so a sixth one cannot be added
+# without this list noticing.
 SUBJECTLESS = frozenset(
     {"insurance", "bank_letter", "translation", "residence", "housing"}
 )
 
 # "помочь с X" is the commonest phrasing there is, but on its own it says
 # nothing about *which* kind of help. It counts as tutoring only when the text
-# gives no other clue — see _service_match.
+# gives no other clue — see _match_service.
 WEAK_HELP: tuple[str, ...] = ("помо", "pomo", "help", "допомо", "нужен", "потрібн")
 
 # Words that put an exam in the picture without saying whether the help is
@@ -288,7 +294,7 @@ async def parse(
     norm = normalise(text)
     result = ParsedQuery(raw=text)
 
-    result.service_type, keyword = _service_match(norm)
+    result.service_type, keyword = _match_service(norm)
 
     subjects = await find_subjects(session, text, lang, limit=4)
     # When the words naming the kind of help were the whole query, there is no
@@ -301,13 +307,22 @@ async def parse(
         subjects = [match for match in subjects if match.matched_on == "synonym"]
 
     # A kind of help that never carries a subject cannot be the answer to a
-    # query that names one. `catalog.search` ANDs the two, and no offer in the
+    # query that *names* one. `catalog.search` ANDs the two, and no offer in the
     # non-study group has a subject, so the pair matches nobody: "нужен матан,
     # живу в общежитии" is a question about calculus with an aside in it, and
     # reading it as housing turned a list of tutors into an empty screen. Read
     # again as if those kinds did not exist.
-    if subjects and result.service_type in SUBJECTLESS:
-        result.service_type, _ = _service_match(norm, ignore=SUBJECTLESS)
+    #
+    # Only for a synonym hit. A trigram score is a guess, and letting a guess
+    # win here undid the whole reason translation sits above the study kinds:
+    # "присяжный перевод диплома" scores «Академическое письмо» at 0.55, and on
+    # the strength of that the kind of help went back to being thesis writing.
+    if (
+        subjects
+        and subjects[0].matched_on == "synonym"
+        and result.service_type in SUBJECTLESS
+    ):
+        result.service_type, _ = _match_service(norm, ignore=SUBJECTLESS)
 
     institutions = await find_institutions(session, text, lang, limit=3)
 
@@ -327,7 +342,7 @@ async def parse(
     return result
 
 
-def _service_match(
+def _match_service(
     norm: str, *, ignore: frozenset[str] = frozenset()
 ) -> tuple[str | None, str | None]:
     """The kind of help, and the keyword that decided it.

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -229,7 +229,6 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         Word("viza"),
         "pobyt",
         "residence permit",
-        "long term visa",
         Word("visa"),
         Word("visas"),
     ),

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -91,85 +91,6 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "нострифік",
         "атестат",
     ),
-    # Help that is not about studying. These come before the study kinds
-    # because they are unambiguous: nobody writing "страховка" means a tutor,
-    # while the weak verbs at the bottom would happily read "помочь снять
-    # квартиру" as tutoring — and did.
-    "insurance": (
-        "страховк",
-        "страхован",
-        "страхуван",
-        "pojisten",
-        "pojiste",
-        "insurance",
-        "vzp",
-        "pvzp",
-    ),
-    "bank_letter": (
-        "справка из банк",
-        "справку из банк",
-        "выписка со счет",
-        "выписку со счет",
-        "из банка",
-        "довидка з банк",
-        "довидку з банк",
-        "з банку",
-        "vypis z ban",
-        "potvrzeni z ban",
-        "potvrzeni o vedeni",
-        "bank statement",
-        "bank letter",
-        "proof of funds",
-    ),
-    "translation": (
-        "перевод документ",
-        "переводом документ",
-        "судебный перевод",
-        "перевод с печат",
-        "присяжный перевод",
-        "переклад документ",
-        "судовий переклад",
-        "soudni preklad",
-        "uredni preklad",
-        "preklad dokument",
-        "s razitkem",
-        "sworn translation",
-        "certified translation",
-        "official translation",
-    ),
-    "residence": (
-        # "внж" and "вnж" are both typed; the transliteration is handled by the
-        # normaliser, not by listing every spelling.
-        "внж",
-        "вид на жительство",
-        "долгосрочная виза",
-        "продлить визу",
-        "продлить внж",
-        "продовження внж",
-        "посвидка на проживанн",
-        "pobytov",
-        "prodlouzeni pobytu",
-        "povoleni k pobytu",
-        "dlouhodoby pobyt",
-        "residence permit",
-        "long term visa",
-        "long-term visa",
-    ),
-    "housing": (
-        "жиль",
-        "квартир",
-        "общежит",
-        "переезд",
-        "житло",
-        "гуртожит",
-        "bydlen",
-        "ubytovan",
-        "kolej",
-        "housing",
-        "accommodation",
-        "dormitory",
-        "flatshare",
-    ),
     "writing": (
         "написать",
         "написа",
@@ -204,6 +125,76 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "пояснити",
         "підтягнути",
         *(),  # weak verbs follow, see WEAK_HELP
+    ),
+    # Help that is not about studying. Last, and after tutoring: an incidental
+    # mention of where somebody lives must not outrank an explicit study word,
+    # and "нужен репетитор, живу в общежитии" did become housing when these sat
+    # first. They still come before the weak verbs below, which is what makes
+    # "помочь снять квартиру" housing rather than tutoring.
+    "insurance": (
+        "страховк",
+        "страхован",
+        "страхуван",
+        "pojiste",
+        "insurance",
+    ),
+    "bank_letter": (
+        "справка из банк",
+        "справку из банк",
+        "выписка со счет",
+        "выписку со счет",
+        "из банка",
+        "довідка з банк",
+        "довідку з банк",
+        "з банку",
+        "vypis z ban",
+        "potvrzeni z ban",
+        "potvrzeni o vedeni",
+        "bank statement",
+        "bank letter",
+        "proof of funds",
+    ),
+    "translation": (
+        "перевод документ",
+        "переводом документ",
+        "судебный перевод",
+        "перевод с печат",
+        "присяжный перевод",
+        "переклад документ",
+        "судовий переклад",
+        "soudni preklad",
+        "uredni preklad",
+        "preklad dokument",
+        "s razitkem",
+        "sworn translation",
+        "certified translation",
+        "official translation",
+    ),
+    "residence": (
+        "внж",
+        "вид на жительство",
+        "долгосрочная виза",
+        "продлить визу",
+        "посвідка на проживанн",
+        "pobytov",
+        "prodlouzeni pobytu",
+        "povoleni k pobytu",
+        "dlouhodoby pobyt",
+        "residence permit",
+        "long term visa",
+    ),
+    "housing": (
+        "жиль",
+        "квартир",
+        "общежит",
+        "переезд",
+        "житло",
+        "гуртожит",
+        "bydlen",
+        "ubytovan",
+        "na koleji",
+        "housing",
+        "dormitory",
     ),
 }
 
@@ -274,25 +265,17 @@ async def parse(
     norm = normalise(text)
     result = ParsedQuery(raw=text)
 
-    # The kind of help first, because the words that name it are not part of the
-    # subject and they bring trigrams of their own: with "помощь на экзамене"
-    # still in the query, «Чешский язык B1» scored 0.59 against a question about
-    # physics while «Физика 1» sat at 0.56.
     result.service_type, matched_on = _service_match(norm)
-    asked = _without(norm, matched_on) if matched_on else norm
 
-    subjects: list[Match] = []
-    if asked:
-        subjects = await find_subjects(session, asked, lang, limit=4)
-        # The remainder is preferred, not trusted: a query can name a subject in
-        # words the kind of help took with it, and the trigram scorer will
-        # happily find something in whatever is left.
-        if not subjects and asked != norm:
-            subjects = await find_subjects(session, norm, lang, limit=4)
-    # Nothing is left when the kind of help was the whole query — "bank
-    # statement", "нострификация". There is no subject in it to find, and
-    # looking anyway is how "bank statement" came back as Probability and
-    # Statistics: a filter narrower than the question, on a subject nobody named.
+    subjects = await find_subjects(session, text, lang, limit=4)
+    # When the words naming the kind of help were the whole query, there is no
+    # subject in it to find, and a trigram guess is the scorer answering a
+    # question nobody asked: "bank statement" came back as Probability and
+    # Statistics at 0.61. A synonym hit survives, because that is not a guess —
+    # "курсовая" and "нострификация" are curated names for real subjects, and
+    # dropping them would lose a certainty to protect against a maybe.
+    if matched_on and not _without(norm, matched_on):
+        subjects = [match for match in subjects if match.matched_on == "synonym"]
     institutions = await find_institutions(session, text, lang, limit=3)
 
     if subjects:

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -26,6 +26,17 @@ def tokenise(value: str) -> str:
     return f" {_NON_WORD.sub(' ', normalise(value)).strip()} "
 
 
+def is_whole_word(haystack: str, needle: str) -> bool:
+    """Does `needle` appear in `haystack` as a word of its own?
+
+    For keywords that are words rather than stems. "визу" is the accusative of
+    "виза" and also the first four letters of "визуализация", and
+    `starts_a_word` deliberately lets a match run into the middle of a word —
+    which read "визуализация данных" as a residence-permit question.
+    """
+    return tokenise(needle) in haystack
+
+
 def starts_a_word(haystack: str, needle: str) -> bool:
     """Does `needle` begin at a word boundary in `haystack`?
 
@@ -40,6 +51,13 @@ def starts_a_word(haystack: str, needle: str) -> bool:
 # Keywords that name a kind of help, across the four interface languages plus
 # the transliterations students actually type. These are matching rules, not
 # display text, so they live in code rather than in the translation catalogue.
+# Keywords that are whole words, not stems. Everything else in the table below
+# may run into the middle of a word, which is what lets "нострифик" reach
+# "нострификации" — and what makes a four-letter word like "визу" a trap.
+WHOLE_WORD_ONLY: frozenset[str] = frozenset(
+    {"виза", "визы", "визу", "визой", "віза", "візи", "візу", "vizum", "viza"}
+)
+
 SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
     "exam_live_help": (
         "на экзамене",
@@ -90,6 +108,7 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
     "translation": (
         "перевод документ",
         "перевод атт",
+        "переклад атест",
         "перевод дипл",
         "нотариальный перевод",
         "переводом документ",
@@ -102,7 +121,6 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "soudni preklad",
         "uredni preklad",
         "preklad dokument",
-        "s razitkem",
         "sworn translation",
         "certified translation",
         "official translation",
@@ -198,7 +216,6 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "vizum",
         "viza",
         "pobyt",
-        "povoleni k pobyt",
         "residence permit",
         "long term visa",
     ),
@@ -364,7 +381,12 @@ def _match_service(
         if code in ignore:
             continue
         for keyword in keywords:
-            if starts_a_word(tokens, keyword):
+            found = (
+                is_whole_word(tokens, keyword)
+                if keyword in WHOLE_WORD_ONLY
+                else starts_a_word(tokens, keyword)
+            )
+            if found:
                 return code, keyword
 
     if any(starts_a_word(tokens, verb) for verb in WEAK_HELP):

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -127,14 +127,15 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "перевод",
         "переклад",
         "preklad",
-        "prekladu",
+        # The English four are what make this block reach past documents:
+        # "translation studies tutor" reads as a document translation. Taken
+        # deliberately — a foreign student in Czechia asking about "translation"
+        # wants a stamped paper far more often than a seminar on translation
+        # theory, and that field is not in the catalog at all.
         Word("translation"),
         Word("translations"),
         "translate",
         "translating",
-        "sworn translation",
-        "certified translation",
-        "official translation",
     ),
     "nostrification": (
         "нострифик",

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -91,6 +91,85 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "нострифік",
         "атестат",
     ),
+    # Help that is not about studying. These come before the study kinds
+    # because they are unambiguous: nobody writing "страховка" means a tutor,
+    # while the weak verbs at the bottom would happily read "помочь снять
+    # квартиру" as tutoring — and did.
+    "insurance": (
+        "страховк",
+        "страхован",
+        "страхуван",
+        "pojisten",
+        "pojiste",
+        "insurance",
+        "vzp",
+        "pvzp",
+    ),
+    "bank_letter": (
+        "справка из банк",
+        "справку из банк",
+        "выписка со счет",
+        "выписку со счет",
+        "из банка",
+        "довидка з банк",
+        "довидку з банк",
+        "з банку",
+        "vypis z ban",
+        "potvrzeni z ban",
+        "potvrzeni o vedeni",
+        "bank statement",
+        "bank letter",
+        "proof of funds",
+    ),
+    "translation": (
+        "перевод документ",
+        "переводом документ",
+        "судебный перевод",
+        "перевод с печат",
+        "присяжный перевод",
+        "переклад документ",
+        "судовий переклад",
+        "soudni preklad",
+        "uredni preklad",
+        "preklad dokument",
+        "s razitkem",
+        "sworn translation",
+        "certified translation",
+        "official translation",
+    ),
+    "residence": (
+        # "внж" and "вnж" are both typed; the transliteration is handled by the
+        # normaliser, not by listing every spelling.
+        "внж",
+        "вид на жительство",
+        "долгосрочная виза",
+        "продлить визу",
+        "продлить внж",
+        "продовження внж",
+        "посвидка на проживанн",
+        "pobytov",
+        "prodlouzeni pobytu",
+        "povoleni k pobytu",
+        "dlouhodoby pobyt",
+        "residence permit",
+        "long term visa",
+        "long-term visa",
+    ),
+    "housing": (
+        "жиль",
+        "квартир",
+        "общежит",
+        "переезд",
+        "житло",
+        "гуртожит",
+        "bydlen",
+        "ubytovan",
+        "kolej",
+        "housing",
+        "accommodation",
+        "dormitory",
+        "flatshare",
+    ),
     "writing": (
         "написать",
         "написа",
@@ -195,7 +274,25 @@ async def parse(
     norm = normalise(text)
     result = ParsedQuery(raw=text)
 
-    subjects = await find_subjects(session, text, lang, limit=4)
+    # The kind of help first, because the words that name it are not part of the
+    # subject and they bring trigrams of their own: with "помощь на экзамене"
+    # still in the query, «Чешский язык B1» scored 0.59 against a question about
+    # physics while «Физика 1» sat at 0.56.
+    result.service_type, matched_on = _service_match(norm)
+    asked = _without(norm, matched_on) if matched_on else norm
+
+    subjects: list[Match] = []
+    if asked:
+        subjects = await find_subjects(session, asked, lang, limit=4)
+        # The remainder is preferred, not trusted: a query can name a subject in
+        # words the kind of help took with it, and the trigram scorer will
+        # happily find something in whatever is left.
+        if not subjects and asked != norm:
+            subjects = await find_subjects(session, norm, lang, limit=4)
+    # Nothing is left when the kind of help was the whole query — "bank
+    # statement", "нострификация". There is no subject in it to find, and
+    # looking anyway is how "bank statement" came back as Probability and
+    # Statistics: a filter narrower than the question, on a subject nobody named.
     institutions = await find_institutions(session, text, lang, limit=3)
 
     if subjects:
@@ -207,7 +304,6 @@ async def parse(
         result.institution = institutions[0]
         result.alternatives["institution"] = institutions[1:]
 
-    result.service_type = _match_service(norm)
     result.deadline = _match_deadline(norm, today or date.today())
     result.budget_max = _match_budget(norm)
 
@@ -216,23 +312,50 @@ async def parse(
 
 
 def _match_service(norm: str) -> str | None:
-    """First keyword wins, and the dictionary is ordered by specificity.
+    """Which kind of help the text names, if any."""
+    return _service_match(norm)[0]
 
-    "помощь на экзамене" must not be read as plain exam preparation, so
-    exam_live_help is checked before exam_prep and generic tutoring last.
-    Weak verbs are considered only after every specific rule has passed.
+
+def _service_match(norm: str) -> tuple[str | None, str | None]:
+    """The kind of help, and the keyword that decided it.
+
+    First keyword wins, and the dictionary is ordered by specificity. "помощь на
+    экзамене" must not be read as plain exam preparation, so exam_live_help is
+    checked before exam_prep and generic tutoring last. Weak verbs are
+    considered only after every specific rule has passed.
+
+    The keyword comes back because the caller takes it out of the query before
+    looking for a subject. A weak verb yields no keyword: "помоги" says nothing
+    about which kind of help, so there is nothing to remove that would sharpen
+    anything.
     """
     tokens = tokenise(norm)
     for code, keywords in SERVICE_KEYWORDS.items():
         for keyword in keywords:
             if starts_a_word(tokens, keyword):
-                return code
+                return code, keyword
 
     if any(starts_a_word(tokens, verb) for verb in WEAK_HELP):
         if any(starts_a_word(tokens, word) for word in EXAM_MENTION):
-            return None  # an exam is mentioned but not placed in time — ask
-        return "tutoring"
-    return None
+            return None, None  # an exam is mentioned but not placed in time
+        return "tutoring", None
+    return None, None
+
+
+def _without(norm: str, keyword: str) -> str:
+    """`norm` minus the words the keyword touched.
+
+    Whole words, not the keyword's characters: the keywords are stems, so
+    removing "нострифик" from "нострификация" would leave "ация" and hand the
+    subject lookup a fragment to score against.
+    """
+    tokens = tokenise(norm)
+    needle = tokenise(keyword).rstrip()
+    at = tokens.find(needle)
+    if at < 0:
+        return norm
+    end = tokens.find(" ", at + len(needle))
+    return (tokens[:at] + (tokens[end:] if end >= 0 else " ")).strip()
 
 
 def _match_deadline(norm: str, today: date) -> date | None:

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -130,6 +130,10 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "sworn translation",
         "certified translation",
         "official translation",
+        # The plainest English phrasings, and the seed's own English label.
+        Word("translation"),
+        "translate",
+        "translating",
     ),
     "nostrification": (
         "нострифик",
@@ -182,9 +186,13 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
     # "помочь снять квартиру" housing rather than tutoring.
     "insurance": (
         "страховк",
-        "страхован",
-        "страхуван",
-        "pojist",
+        # Words, not stems: the genitive "страхования" belongs to a subject —
+        # "экономика страхования" — and "pojistna matematika" is actuarial
+        # mathematics, which the stem "pojist" read as somebody wanting a policy.
+        Word("страхование"),
+        Word("страхування"),
+        "pojisten",
+        "pojistk",
         "insurance",
     ),
     "bank_letter": (
@@ -198,9 +206,10 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "з банку",
         "vypis z ban",
         "vypis z uct",
+        "zustatek",
         "potvrzeni z ban",
         "potvrzeni o vedeni",
-        "zustatk",
+        "zustatku",
         "bank statement",
         "bank letter",
         "proof of funds",
@@ -224,6 +233,8 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "pobyt",
         "residence permit",
         "long term visa",
+        Word("visa"),
+        Word("visas"),
     ),
     "housing": (
         "жиль",
@@ -327,7 +338,7 @@ async def parse(
     # "курсовая" and "нострификация" are curated names for real subjects, and
     # dropping them would lose a certainty to protect against a maybe.
     if keyword and not _without(norm, keyword):
-        subjects = [match for match in subjects if match.matched_on == "synonym"]
+        subjects = [match for match in subjects if _is_named(match)]
 
     # A kind of help that never carries a subject cannot be the answer to a
     # query that *names* one. `catalog.search` ANDs the two, and no offer in the
@@ -336,8 +347,8 @@ async def parse(
     # reading it as housing turned a list of tutors into an empty screen. Read
     # again as if those kinds did not exist.
     #
-    # Which of the two gives way depends on how sure the subject is. A curated
-    # synonym is a named subject and wins: read the kind of help again as if the
+    # Which of the two gives way depends on whether the subject was named. A
+    # named subject wins: read the kind of help again as if the
     # non-study ones did not exist. A trigram score is a guess, and a guess
     # cannot narrow a kind of help that has no subjects to narrow by — so the
     # guess goes instead. Keeping both was a guaranteed empty screen, and
@@ -345,7 +356,7 @@ async def parse(
     # above the study kinds: "присяжный перевод диплома" scores «Академическое
     # письмо» at 0.55.
     if subjects and result.service_type in SUBJECTLESS:
-        if subjects[0].matched_on == "synonym":
+        if _is_named(subjects[0]):
             result.service_type, _ = _match_service(norm, ignore=SUBJECTLESS)
         else:
             subjects = []
@@ -399,6 +410,22 @@ def _match_service(
             return None, None  # an exam is mentioned but not placed in time
         return "tutoring", None
     return None, None
+
+
+def _is_named(match: Match) -> bool:
+    """Did the query name this subject, rather than score against it?
+
+    A 1.0 is either a curated synonym or a name the query reproduced exactly.
+    Everything below it is the trigram scorer's opinion — the external-code
+    branch stops at 0.95 and the synonym-similarity branch at 0.92, so the line
+    is exactly where certainty is.
+
+    `matched_on == "synonym"` was the first spelling of this and it was too
+    narrow: "Чешский язык B1, нужна виза" names the subject in full, scores 1.0,
+    and reports `name` — so the subject the person typed out was thrown away as
+    a guess.
+    """
+    return match.score >= 1.0
 
 
 def _without(norm: str, keyword: str) -> str:

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -118,29 +118,23 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
     # more often than a seminar on translation theory, and that field is not in
     # the catalog at all.
     "translation": (
-        "перевод документ",
-        "перевод атт",
-        "переклад атест",
-        "перевод дипл",
-        "нотариальный перевод",
-        "переводом документ",
-        "судебный перевод",
-        "перевод с печат",
-        "присяжный перевод",
-        "переклад документ",
-        "переклад атт",
-        "судовий переклад",
-        "soudni preklad",
-        "uredni preklad",
-        "preklad dokument",
-        "sworn translation",
-        "certified translation",
-        "official translation",
-        # The plainest English phrasings, and the seed's own English label.
+        # Stems for the noun in each language, because a multi-word keyword
+        # tolerates inflection only on its last word — so "присяжного перевода
+        # диплома", the commonest way to ask, reached none of the phrases that
+        # used to be listed here and fell through to thesis writing on "диплом".
+        # No subject in the catalog is named after translation, in any language,
+        # so the stems cost nothing a phrase would have saved.
+        "перевод",
+        "переклад",
+        "preklad",
+        "prekladu",
         Word("translation"),
         Word("translations"),
         "translate",
         "translating",
+        "sworn translation",
+        "certified translation",
+        "official translation",
     ),
     "nostrification": (
         "нострифик",
@@ -223,7 +217,8 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
     ),
     "residence": (
         "внж",
-        "вид на жительство",
+        # A stem, so the genitive "вида на жительство" is reached too.
+        "жительств",
         # Words for the visa, and a stem for the stay. A multi-word keyword
         # tolerates inflection only on its last word, so the three phrases that
         # used to be here reached none of "prodlouzeni dlouhodobeho pobytu" —
@@ -235,7 +230,7 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         Word("візу"),
         Word("візи"),
         Word("віза"),
-        "посвідка на проживанн",
+        "посвідк",
         Word("vizum"),
         Word("viza"),
         "pobyt",

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -48,16 +48,22 @@ def starts_a_word(haystack: str, needle: str) -> bool:
     return tokenise(needle).rstrip() in haystack
 
 
+class Word(str):
+    """A keyword that has to match a whole word rather than a stem.
+
+    Every other entry below may run into the middle of a word, which is what
+    lets "нострифик" reach "нострификации". For a short ordinary word that is a
+    trap: "визу" is the accusative of "виза" and the first four letters of
+    "визуализация". Written here rather than in a parallel set of strings, so
+    adding a form cannot quietly make it a stem again.
+    """
+
+    __slots__ = ()
+
+
 # Keywords that name a kind of help, across the four interface languages plus
 # the transliterations students actually type. These are matching rules, not
 # display text, so they live in code rather than in the translation catalogue.
-# Keywords that are whole words, not stems. Everything else in the table below
-# may run into the middle of a word, which is what lets "нострифик" reach
-# "нострификации" — and what makes a four-letter word like "визу" a trap.
-WHOLE_WORD_ONLY: frozenset[str] = frozenset(
-    {"виза", "визы", "визу", "визой", "віза", "візи", "візу", "vizum", "viza"}
-)
-
 SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
     "exam_live_help": (
         "на экзамене",
@@ -205,16 +211,16 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         # Stems, not phrases: a multi-word keyword tolerates inflection only on
         # its last word, so "prodlouzeni dlouhodobeho pobytu" — the standard
         # Czech phrase — reached none of the three that used to be listed here.
-        "виза",
-        "визы",
-        "визу",
-        "визой",
-        "візу",
-        "візи",
-        "віза",
+        Word("виза"),
+        Word("визы"),
+        Word("визу"),
+        Word("визой"),
+        Word("візу"),
+        Word("візи"),
+        Word("віза"),
         "посвідка на проживанн",
-        "vizum",
-        "viza",
+        Word("vizum"),
+        Word("viza"),
         "pobyt",
         "residence permit",
         "long term visa",
@@ -330,16 +336,19 @@ async def parse(
     # reading it as housing turned a list of tutors into an empty screen. Read
     # again as if those kinds did not exist.
     #
-    # Only for a synonym hit. A trigram score is a guess, and letting a guess
-    # win here undid the whole reason translation sits above the study kinds:
-    # "присяжный перевод диплома" scores «Академическое письмо» at 0.55, and on
-    # the strength of that the kind of help went back to being thesis writing.
-    if (
-        subjects
-        and subjects[0].matched_on == "synonym"
-        and result.service_type in SUBJECTLESS
-    ):
-        result.service_type, _ = _match_service(norm, ignore=SUBJECTLESS)
+    # Which of the two gives way depends on how sure the subject is. A curated
+    # synonym is a named subject and wins: read the kind of help again as if the
+    # non-study ones did not exist. A trigram score is a guess, and a guess
+    # cannot narrow a kind of help that has no subjects to narrow by — so the
+    # guess goes instead. Keeping both was a guaranteed empty screen, and
+    # keeping the subject over the service undid the reason translation sits
+    # above the study kinds: "присяжный перевод диплома" scores «Академическое
+    # письмо» at 0.55.
+    if subjects and result.service_type in SUBJECTLESS:
+        if subjects[0].matched_on == "synonym":
+            result.service_type, _ = _match_service(norm, ignore=SUBJECTLESS)
+        else:
+            subjects = []
 
     institutions = await find_institutions(session, text, lang, limit=3)
 
@@ -381,12 +390,8 @@ def _match_service(
         if code in ignore:
             continue
         for keyword in keywords:
-            found = (
-                is_whole_word(tokens, keyword)
-                if keyword in WHOLE_WORD_ONLY
-                else starts_a_word(tokens, keyword)
-            )
-            if found:
+            match = is_whole_word if isinstance(keyword, Word) else starts_a_word
+            if match(tokens, keyword):
                 return code, keyword
 
     if any(starts_a_word(tokens, verb) for verb in WEAK_HELP):

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -164,24 +164,16 @@ async def test_a_short_faculty_name_is_not_found_inside_a_word(session):
 
 
 @pytest.mark.asyncio
-async def test_a_named_faculty_is_still_found(session):
-    """The rule above must not cost us the faculty when it really is named."""
-    parsed = await parse(session, "матан на ČVUT FIT", "ru", today=TODAY)
-    assert parsed.institution is not None
+async def test_a_named_short_faculty_is_still_found(session):
+    """The rule above must not cost us the faculty when it really is named.
 
-
-@pytest.mark.asyncio
-async def test_the_subject_is_read_from_what_the_service_left(session):
-    """The words naming the kind of help are not part of the subject.
-
-    They also carry trigrams of their own: with them in the query, «Чешский язык
-    B1» scored 0.59 against a question about physics while «Физика 1» sat at
-    0.56, so the screen answered confidently about the wrong subject.
+    "FIT" alone and not "ČVUT FIT": the second would pass through the
+    institution-code branch whatever the short-name rule does, which makes it no
+    test of the rule at all.
     """
-    parsed = await parse(session, "помощь на экзамене по физике", "ru", today=TODAY)
-    assert parsed.service_type == "exam_live_help"
-    assert parsed.subject is not None
-    assert parsed.subject.label.startswith("Физика")
+    parsed = await parse(session, "матан на FIT", "ru", today=TODAY)
+    assert parsed.institution is not None
+    assert parsed.institution.label == "FIT"
 
 
 @pytest.mark.asyncio
@@ -198,14 +190,34 @@ async def test_a_word_naming_both_the_service_and_the_subject_survives(session):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("text", ["bank statement", "нострификация"])
-async def test_no_subject_is_invented_when_the_service_was_the_whole_query(session, text):
-    """Nothing is left to name a subject, so none is claimed.
+async def test_no_subject_is_guessed_when_the_service_was_the_whole_query(session):
+    """Nothing is left to name a subject, so none is guessed at.
 
-    "bank statement" used to come back as Probability and Statistics at 0.61 —
-    a filter narrower than the question, on a subject nobody had named.
+    "bank statement" came back as Probability and Statistics at 0.61 — a filter
+    narrower than the question, on a subject nobody had named.
     """
-    parsed = await parse(session, text, "en", today=TODAY)
-    assert parsed.service_type is not None
+    parsed = await parse(session, "bank statement", "en", today=TODAY)
+    assert parsed.service_type == "bank_letter"
     assert parsed.subject is None
     assert parsed.unmatched is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("курсовая", "Академическое письмо и дипломная работа"),
+        ("нострификация", "Нострификационные экзамены"),
+    ],
+)
+async def test_a_certain_subject_survives_being_the_whole_query(session, text, expected):
+    """The rule above drops guesses, not curated names.
+
+    These words are synonyms somebody wrote down for exactly this subject, which
+    is not the scorer finding something in noise. Dropping them too would lose a
+    certainty in order to avoid a maybe.
+    """
+    parsed = await parse(session, text, "ru", today=TODAY)
+    assert parsed.subject is not None
+    assert parsed.subject.matched_on == "synonym"
+    assert parsed.subject.label == expected

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -289,3 +289,33 @@ async def test_a_certain_subject_survives_being_the_whole_query(session, text, e
     assert parsed.subject is not None
     assert parsed.subject.matched_on == "synonym"
     assert parsed.subject.label == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # A word, not a stem: "визу" is the accusative of "виза" and the first
+        # four letters of "визуализация". Read as a stem it turned a question
+        # about data visualisation into a residence-permit one, and since the
+        # search applies both filters together the screen went empty.
+        ("нужна виза в Чехию", "residence"),
+        ("визуализация данных", None),
+        ("визуальное программирование", None),
+    ],
+)
+async def test_a_visa_is_a_word_and_not_a_beginning(session, text, expected):
+    parsed = await parse(session, text, "ru", today=TODAY)
+    assert parsed.service_type == expected
+
+
+@pytest.mark.asyncio
+async def test_a_stamped_bank_paper_is_not_a_translation(session):
+    """The stamp is a modifier, not the kind of document.
+
+    Translation is checked before the study kinds, and "s razitkem" sitting in
+    it shadowed bank_letter's own phrases — so the standard stamped bank
+    statement for a Czech visa came back as a document translation.
+    """
+    parsed = await parse(session, "vypis z banky s razitkem", "cs", today=TODAY)
+    assert parsed.service_type == "bank_letter"

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -7,7 +7,7 @@ from students_cz.services.parser import (
     SUBJECTLESS,
     _match_budget,
     _match_deadline,
-    _service_match,
+    _match_service,
     _without,
     parse,
 )
@@ -33,13 +33,13 @@ TODAY = date(2026, 1, 20)
     ],
 )
 def test_service_keywords(text, expected):
-    assert _service_match(normalise(text))[0] == expected
+    assert _match_service(normalise(text))[0] == expected
 
 
 def test_keyword_must_start_a_word():
     """ "osp" is a Scio test; it is also inside "gospodarka"."""
-    assert _service_match(normalise("gospodarka a osnovy"))[0] is None
-    assert _service_match(normalise("готовлюсь к osp"))[0] == "entrance_prep"
+    assert _match_service(normalise("gospodarka a osnovy"))[0] is None
+    assert _match_service(normalise("готовлюсь к osp"))[0] == "entrance_prep"
 
 
 @pytest.mark.parametrize(
@@ -151,7 +151,7 @@ async def test_unmatched_is_reported_not_guessed(session):
     ],
 )
 def test_help_that_is_not_about_studying_is_recognised(text, expected):
-    assert _service_match(normalise(text))[0] == expected
+    assert _match_service(normalise(text))[0] == expected
 
 
 @pytest.mark.asyncio
@@ -221,16 +221,27 @@ async def test_an_aside_about_life_does_not_replace_the_subject(session, text):
     assert parsed.service_type not in SUBJECTLESS
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("text", "expected"),
+    "text",
     [
-        # Single-word study stems used to win these on dictionary order alone.
-        ("присяжный перевод диплома", "translation"),
-        ("нужен перевод аттестата", "translation"),
+        # Single-word study stems used to win these on dictionary order alone:
+        # "диплом" made the first thesis writing, "аттестат" made the second
+        # nostrification.
+        "присяжный перевод диплома",
+        "нужен перевод аттестата",
+        "i need a bank statement",
     ],
 )
-def test_translating_a_document_is_not_writing_or_nostrification(text, expected):
-    assert _service_match(normalise(text))[0] == expected
+async def test_document_work_survives_the_whole_parse(session, text):
+    """Through `parse`, not through the matcher.
+
+    The matcher had this right while `parse` did not: a 0.55 trigram guess at a
+    subject sent the kind of help back to being thesis writing, and a test on
+    the private function could not see it.
+    """
+    parsed = await parse(session, text, "ru", today=TODAY)
+    assert parsed.service_type in {"translation", "bank_letter"}
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -343,3 +343,48 @@ async def test_a_stamped_bank_paper_is_not_a_translation(session):
     """
     parsed = await parse(session, "vypis z banky s razitkem", "cs", today=TODAY)
     assert parsed.service_type == "bank_letter"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Чешский язык B1, нужна виза",
+        "Математический анализ, живу в общежитии",
+    ],
+)
+async def test_a_subject_typed_out_in_full_is_named(session, text):
+    """A name the query reproduces exactly scores 1.0 and reports "name".
+
+    The first spelling of "was the subject named" asked for a *synonym*, so a
+    subject somebody had typed out in full was thrown away as a guess and the
+    search filtered by insurance or housing instead.
+    """
+    parsed = await parse(session, text, "ru", today=TODAY)
+    assert parsed.subject is not None
+    assert parsed.subject.score == 1.0
+    assert parsed.service_type not in SUBJECTLESS
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # Words rather than stems, because the stems reached into subjects:
+        # "pojist" prefixes "pojistna matematika" (actuarial mathematics) and
+        # "страхован" prefixes the genitive in "экономика страхования".
+        ("нужно страхование", "insurance"),
+        ("pojistna matematika", None),
+        ("экономика страхования", None),
+        # And "zustat" is "to stay", so the bank balance is spelled out.
+        ("zustatek na ucte", "bank_letter"),
+        ("chci zustat v Praze", None),
+        # English could not say two of these five in the plainest way.
+        ("i need a visa", "residence"),
+        ("student visa", "residence"),
+        ("visualisation of data", None),
+        ("document translation", "translation"),
+        ("translate my diploma", "translation"),
+    ],
+)
+def test_the_plainest_phrasing_reaches_the_right_kind(text, expected):
+    assert _match_service(normalise(text))[0] == expected

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -117,3 +117,95 @@ async def test_unmatched_is_reported_not_guessed(session):
     parsed = await parse(session, "asdfgh qwerty", "ru", today=TODAY)
     assert parsed.unmatched is True
     assert parsed.subject is None
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # Help that is not about studying. Offerable since PR #29 and, until
+        # these keywords existed, unfindable in words — a listing nobody could
+        # reach. One phrasing per language per kind, because the catalog is read
+        # in four languages and the parser is not told which one was typed.
+        ("нужна страховка для визы", "insurance"),
+        ("pojisteni na rok", "insurance"),
+        ("insurance for a visa", "insurance"),
+        ("страховка на рік", "insurance"),
+        ("справка из банка", "bank_letter"),
+        ("vypis z banky", "bank_letter"),
+        ("bank statement", "bank_letter"),
+        ("довідка з банку", "bank_letter"),
+        ("перевод документов с печатью", "translation"),
+        ("soudni preklad", "translation"),
+        ("sworn translation", "translation"),
+        ("переклад документів", "translation"),
+        ("продлить ВНЖ", "residence"),
+        ("prodlouzeni pobytu", "residence"),
+        ("residence permit", "residence"),
+        ("продовження ВНЖ", "residence"),
+        ("жильё в Праге", "housing"),
+        ("hledam bydleni", "housing"),
+        ("looking for housing", "housing"),
+        ("житло у Празі", "housing"),
+    ],
+)
+def test_help_that_is_not_about_studying_is_recognised(text, expected):
+    assert _match_service(normalise(text)) == expected
+
+
+@pytest.mark.asyncio
+async def test_a_short_faculty_name_is_not_found_inside_a_word(session):
+    """`FI` is a faculty. It is also the first two letters of "физике".
+
+    Trigram similarity scored that at 0.67 — above the threshold — so a query
+    about physics came back naming a faculty nobody had mentioned.
+    """
+    parsed = await parse(session, "репетитор по физике", "ru", today=TODAY)
+    assert parsed.institution is None
+
+
+@pytest.mark.asyncio
+async def test_a_named_faculty_is_still_found(session):
+    """The rule above must not cost us the faculty when it really is named."""
+    parsed = await parse(session, "матан на ČVUT FIT", "ru", today=TODAY)
+    assert parsed.institution is not None
+
+
+@pytest.mark.asyncio
+async def test_the_subject_is_read_from_what_the_service_left(session):
+    """The words naming the kind of help are not part of the subject.
+
+    They also carry trigrams of their own: with them in the query, «Чешский язык
+    B1» scored 0.59 against a question about physics while «Физика 1» sat at
+    0.56, so the screen answered confidently about the wrong subject.
+    """
+    parsed = await parse(session, "помощь на экзамене по физике", "ru", today=TODAY)
+    assert parsed.service_type == "exam_live_help"
+    assert parsed.subject is not None
+    assert parsed.subject.label.startswith("Физика")
+
+
+@pytest.mark.asyncio
+async def test_a_word_naming_both_the_service_and_the_subject_survives(session):
+    """ "нострификация аттестата" names the kind of help in one word and the
+    subject in the other, and the stem taken out is inside the first.
+
+    Whole words, so what is left is "аттестата" rather than the fragment "ация".
+    """
+    parsed = await parse(session, "нострификация аттестата", "ru", today=TODAY)
+    assert parsed.service_type == "nostrification"
+    assert parsed.subject is not None
+    assert parsed.subject.label == "Нострификационные экзамены"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("text", ["bank statement", "нострификация"])
+async def test_no_subject_is_invented_when_the_service_was_the_whole_query(session, text):
+    """Nothing is left to name a subject, so none is claimed.
+
+    "bank statement" used to come back as Probability and Statistics at 0.61 —
+    a filter narrower than the question, on a subject nobody had named.
+    """
+    parsed = await parse(session, text, "en", today=TODAY)
+    assert parsed.service_type is not None
+    assert parsed.subject is None
+    assert parsed.unmatched is False

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -223,17 +223,19 @@ async def test_an_aside_about_life_does_not_replace_the_subject(session, text):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "text",
+    ("text", "expected"),
     [
         # Single-word study stems used to win these on dictionary order alone:
         # "диплом" made the first thesis writing, "аттестат" made the second
         # nostrification.
-        "присяжный перевод диплома",
-        "нужен перевод аттестата",
-        "i need a bank statement",
+        ("присяжный перевод диплома", "translation"),
+        ("нужен перевод аттестата", "translation"),
+        ("нотариальный перевод диплома", "translation"),
+        ("i need a bank statement", "bank_letter"),
+        ("bank statement for the visa", "bank_letter"),
     ],
 )
-async def test_document_work_survives_the_whole_parse(session, text):
+async def test_document_work_survives_the_whole_parse(session, text, expected):
     """Through `parse`, not through the matcher.
 
     The matcher had this right while `parse` did not: a 0.55 trigram guess at a
@@ -241,7 +243,29 @@ async def test_document_work_survives_the_whole_parse(session, text):
     the private function could not see it.
     """
     parsed = await parse(session, text, "ru", today=TODAY)
-    assert parsed.service_type in {"translation", "bank_letter"}
+    assert parsed.service_type == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "нотариальный перевод диплома",
+        "bank statement for the visa",
+        "нужна страховка, учусь на физике",
+    ],
+)
+async def test_a_guessed_subject_is_dropped_not_the_kind_of_help(session, text):
+    """Both filters are applied together, and these offers have no subject.
+
+    Keeping a 0.55 trigram guess beside the kind of help is a pair that matches
+    nobody, so the count and the preview on the search screen are zero for
+    exactly the queries this change exists to make findable. The guess goes; a
+    named subject is the other rule, two tests up.
+    """
+    parsed = await parse(session, text, "ru", today=TODAY)
+    assert parsed.service_type in SUBJECTLESS
+    assert parsed.subject is None
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -4,9 +4,11 @@ import pytest
 
 from students_cz.services.lookup import normalise
 from students_cz.services.parser import (
+    SUBJECTLESS,
     _match_budget,
     _match_deadline,
-    _match_service,
+    _service_match,
+    _without,
     parse,
 )
 
@@ -31,13 +33,13 @@ TODAY = date(2026, 1, 20)
     ],
 )
 def test_service_keywords(text, expected):
-    assert _match_service(normalise(text)) == expected
+    assert _service_match(normalise(text))[0] == expected
 
 
 def test_keyword_must_start_a_word():
     """ "osp" is a Scio test; it is also inside "gospodarka"."""
-    assert _match_service(normalise("gospodarka a osnovy")) is None
-    assert _match_service(normalise("готовлюсь к osp")) == "entrance_prep"
+    assert _service_match(normalise("gospodarka a osnovy"))[0] is None
+    assert _service_match(normalise("готовлюсь к osp"))[0] == "entrance_prep"
 
 
 @pytest.mark.parametrize(
@@ -149,7 +151,7 @@ async def test_unmatched_is_reported_not_guessed(session):
     ],
 )
 def test_help_that_is_not_about_studying_is_recognised(text, expected):
-    assert _match_service(normalise(text)) == expected
+    assert _service_match(normalise(text))[0] == expected
 
 
 @pytest.mark.asyncio
@@ -164,16 +166,71 @@ async def test_a_short_faculty_name_is_not_found_inside_a_word(session):
 
 
 @pytest.mark.asyncio
-async def test_a_named_short_faculty_is_still_found(session):
+async def test_a_named_two_letter_faculty_is_still_found(session):
     """The rule above must not cost us the faculty when it really is named.
 
-    "FIT" alone and not "ČVUT FIT": the second would pass through the
-    institution-code branch whatever the short-name rule does, which makes it no
-    test of the rule at all.
+    Two letters, and no university beside it: "ČVUT FI" would pass through the
+    institution-code branch whatever the short-name rule does, and a three-letter
+    name goes back to trigram matching, so neither would test the rule.
     """
-    parsed = await parse(session, "матан на FIT", "ru", today=TODAY)
+    parsed = await parse(session, "матан на FI", "ru", today=TODAY)
     assert parsed.institution is not None
-    assert parsed.institution.label == "FIT"
+    assert parsed.institution.label == "FI"
+
+
+@pytest.mark.asyncio
+async def test_an_inflected_three_letter_faculty_still_matches(session):
+    """Czech declines the abbreviation itself: nobody writes "na FEL".
+
+    The whole-word rule is deliberately two letters wide and not three. At three
+    it took every inflected form off all 57 three-letter faculties.
+    """
+    parsed = await parse(session, "doucovani matematiky na FELu", "cs", today=TODAY)
+    assert parsed.institution is not None
+    assert parsed.institution.label == "FEL"
+
+
+def test_a_keyword_takes_whole_words_with_it():
+    """What is left has to be words, or the caller cannot ask if anything is.
+
+    The keywords are stems: taking the characters of "нострифик" out of
+    "нострификация" leaves "ация", which is not nothing and is not a word either.
+    """
+    assert _without(normalise("нострификация"), "нострифик") == ""
+    assert _without(normalise("нострификация аттестата"), "нострифик") == "аттестата"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "нужен матан, живу в общежитии",
+        "матан, снимаю квартиру на Виноградах",
+    ],
+)
+async def test_an_aside_about_life_does_not_replace_the_subject(session, text):
+    """Both filters are applied together, and no such offer has a subject.
+
+    Reading these as housing produced subject + housing, which `catalog.search`
+    ANDs into a pair matching nobody — a list of calculus tutors became an empty
+    screen.
+    """
+    parsed = await parse(session, text, "ru", today=TODAY)
+    assert parsed.subject is not None
+    assert parsed.subject.label == "Математический анализ"
+    assert parsed.service_type not in SUBJECTLESS
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # Single-word study stems used to win these on dictionary order alone.
+        ("присяжный перевод диплома", "translation"),
+        ("нужен перевод аттестата", "translation"),
+    ],
+)
+def test_translating_a_document_is_not_writing_or_nostrification(text, expected):
+    assert _service_match(normalise(text))[0] == expected
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -183,7 +183,8 @@ async def test_an_inflected_three_letter_faculty_still_matches(session):
     """Czech declines the abbreviation itself: nobody writes "na FEL".
 
     The whole-word rule is deliberately two letters wide and not three. At three
-    it took every inflected form off all 57 three-letter faculties.
+    it took every inflected form off the 69 institutions whose short name is
+    three characters, 60 of them faculties.
     """
     parsed = await parse(session, "doucovani matematiky na FELu", "cs", today=TODAY)
     assert parsed.institution is not None

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -412,3 +412,21 @@ async def test_a_document_phrase_is_the_request_even_beside_a_named_subject(
     """
     parsed = await parse(session, text, "ru", today=TODAY)
     assert parsed.service_type == "translation"
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # The genitive is how these are actually asked, and a multi-word keyword
+        # tolerates inflection only on its last word — so the phrases that used
+        # to be here reached none of them, and the first fell through to thesis
+        # writing on "диплом".
+        ("присяжного перевода диплома", "translation"),
+        ("нотариального перевода документов", "translation"),
+        ("soudniho prekladu", "translation"),
+        ("продление вида на жительство", "residence"),
+        ("продовження посвідки на проживання", "residence"),
+    ],
+)
+def test_the_genitive_reaches_the_same_kind_as_the_nominative(text, expected):
+    assert _match_service(normalise(text))[0] == expected

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -388,3 +388,27 @@ async def test_a_subject_typed_out_in_full_is_named(session, text):
 )
 def test_the_plainest_phrasing_reaches_the_right_kind(text, expected):
     assert _match_service(normalise(text))[0] == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "перевод диплома, матан",
+        "присяжный перевод диплома по матану",
+        "перевод аттестата, линал",
+        "document translations",
+    ],
+)
+async def test_a_document_phrase_is_the_request_even_beside_a_named_subject(
+    session, text
+):
+    """Translation is not an aside, so a named subject does not displace it.
+
+    The rule that lets a named subject win re-reads the text with the non-study
+    kinds removed — and with translation among them the study stem it was
+    ordered above won again, so "перевод диплома, матан" came back as thesis
+    writing. Nobody writes "присяжный перевод диплома" in passing.
+    """
+    parsed = await parse(session, text, "ru", today=TODAY)
+    assert parsed.service_type == "translation"

--- a/apps/api/tests/test_service_groups.py
+++ b/apps/api/tests/test_service_groups.py
@@ -24,6 +24,7 @@ from sqlalchemy import select
 from students_cz.db.models import ServiceType
 from students_cz.db.models.enums import ServiceGroup
 from students_cz.db.seed import SERVICE_TYPES
+from students_cz.services.parser import SUBJECTLESS
 
 VERSIONS = Path(__file__).resolve().parents[1] / "src/students_cz/db/migrations/versions"
 
@@ -177,8 +178,5 @@ def test_subjectless_is_exactly_the_life_group():
     Not `requires_subject`: exam help and nostrification have that false too and
     must stay out of this set.
     """
-    from students_cz.db.seed import SERVICE_TYPES
-    from students_cz.services.parser import SUBJECTLESS
-
     life = {spec["code"] for spec in SERVICE_TYPES if spec["group"] == "life"}
     assert life == SUBJECTLESS

--- a/apps/api/tests/test_service_groups.py
+++ b/apps/api/tests/test_service_groups.py
@@ -164,3 +164,21 @@ def test_seed_and_migrations_agree_on_what_those_types_say() -> None:
     migrated = _migrated_rows()
     seeded = _seeded_rows()
     assert migrated == {code: seeded[code] for code in migrated}
+
+
+def test_subjectless_is_exactly_the_life_group():
+    """The parser's own list of subjectless kinds, against the seed.
+
+    `SUBJECTLESS` is written out in the parser because it reads no tables, and a
+    sixth kind of help in the `life` group would otherwise be added without the
+    rule that protects it — a query naming a subject would come back with that
+    kind beside it, and the two filters together match nobody.
+
+    Not `requires_subject`: exam help and nostrification have that false too and
+    must stay out of this set.
+    """
+    from students_cz.db.seed import SERVICE_TYPES
+    from students_cz.services.parser import SUBJECTLESS
+
+    life = {spec["code"] for spec in SERVICE_TYPES if spec["group"] == "life"}
+    assert life == SUBJECTLESS

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -154,12 +154,15 @@ something else:
   search by a subject nobody named. A synonym hit is kept, because a curated
   synonym is not a guess — "курсовая" and "нострификация" are written down
   against real subjects.
-- **A kind of help that never carries a subject is not the answer to a query
-  that names one.** The five non-study kinds have `requires_subject = false` and
-  their `offers` rows have a null subject, while the search applies subject and
-  kind of help together — so the pair matches nobody. "нужен матан, живу в
-  общежитии" is a question about calculus with an aside in it, and reading it as
-  housing turned a list of tutors into an empty screen.
+- **A kind of help from the `life` group is not the answer to a query that
+  names a subject.** Those offers carry no subject at all, while the search
+  applies subject and kind of help together — so the pair matches nobody.
+  "нужен матан, живу в общежитии" is a question about calculus with an aside in
+  it, and reading it as housing turned a list of tutors into an empty screen.
+  The subject has to be *named*, not guessed at: deferring to a trigram score
+  here sent "присяжный перевод диплома" back to being thesis writing on a 0.55
+  match. The group, and not `requires_subject`, is what identifies the set —
+  exam help and nostrification have that false as well and belong outside it.
 
 A kind of help that cannot be named in words cannot be found, in any of the four
 languages. The five that are not about studying — insurance, a bank statement,

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -157,15 +157,26 @@ something else:
   search by a subject nobody named. A synonym hit is kept, because a curated
   synonym is not a guess — "курсовая" and "нострификация" are written down
   against real subjects.
-- **A kind of help from the `life` group is not the answer to a query that
-  names a subject.** Those offers carry no subject at all, while the search
-  applies subject and kind of help together — so the pair matches nobody.
-  "нужен матан, живу в общежитии" is a question about calculus with an aside in
-  it, and reading it as housing turned a list of tutors into an empty screen.
-  The subject has to be *named*, not guessed at: deferring to a trigram score
-  here sent "присяжный перевод диплома" back to being thesis writing on a 0.55
-  match. The group, and not `requires_subject`, is what identifies the set —
-  exam help and nostrification have that false as well and belong outside it.
+- **A subject and a kind of help that carries none cannot both survive.** The
+  `life` group's offers have no subject at all, while the search applies subject
+  and kind of help together — so the pair matches nobody, and one of the two has
+  to go. Which one depends on whether the kind of help could have been mentioned
+  in passing:
+
+  Insurance, a bank statement, residence and housing are ordinary words that
+  turn up as asides. Beside a *named* subject — a curated synonym, or a name the
+  query reproduced exactly — the subject is the question and the aside is not:
+  "нужен матан, живу в общежитии" is about calculus, and reading it as housing
+  turned a list of tutors into an empty screen. Beside a *guessed* subject the
+  guess goes instead, because a score of 0.55 cannot narrow a kind of help that
+  has no subjects to narrow by.
+
+  A document translation is the exception, and always wins: nobody writes
+  "присяжный перевод диплома" in passing, so when that phrase appears it is the
+  request, and any subject beside it is dropped whether it was named or not.
+
+  The group, and not `requires_subject`, is what identifies this set — exam help
+  and nostrification have that false as well and belong outside it.
 
 A kind of help that cannot be named in words cannot be found, in any of the four
 languages. The five that are not about studying — insurance, a bank statement,

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -136,15 +136,17 @@ wrong language, misspelled. Three mechanisms handle it, cheapest first:
 Verified against a live database: `prijimacky` scores 1.00 against `Přijímačky`,
 `matematicka analyza` scores 1.00 against `Matematická analýza`.
 
-Two rules keep the trigram half of that from answering confidently about
+Three rules keep the trigram half of that from answering confidently about
 something else:
 
-- **A short name matches as a whole word or not at all.** Faculty short names
-  are two and three letters — `FI`, `UK`, `JU` — and trigram similarity puts
-  any word containing those letters above the threshold, so "по физике" found
-  the faculty FI and "uklidit" would find Charles University. Below four
-  characters a short name is compared against the query's tokens, the same
-  whole-word test the synonym branch uses.
+- **A two-letter short name matches as a whole word or not at all.** `FI`, `UK`
+  and `JU` are two letters, and trigram similarity puts any word containing them
+  above the threshold, so "по физике" found the faculty FI and "uklidit" would
+  find Charles University. Those are compared against the query's tokens, the
+  same whole-word test the synonym branch uses. Three letters stay on the
+  trigram path deliberately: Czech declines the abbreviation itself — "na FELu",
+  "na MFFce" — and the whole-word rule would cost all 57 three-letter faculties
+  every inflected form they have.
 - **When the words naming the kind of help were the whole query, only a certain
   subject survives.** There is no subject left in the text to find, so a trigram
   score is the scorer answering a question nobody asked: "bank statement" came
@@ -152,6 +154,12 @@ something else:
   search by a subject nobody named. A synonym hit is kept, because a curated
   synonym is not a guess — "курсовая" and "нострификация" are written down
   against real subjects.
+- **A kind of help that never carries a subject is not the answer to a query
+  that names one.** The five non-study kinds have `requires_subject = false` and
+  their `offers` rows have a null subject, while the search applies subject and
+  kind of help together — so the pair matches nobody. "нужен матан, живу в
+  общежитии" is a question about calculus with an aside in it, and reading it as
+  housing turned a list of tutors into an empty screen.
 
 A kind of help that cannot be named in words cannot be found, in any of the four
 languages. The five that are not about studying — insurance, a bank statement,

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -147,10 +147,10 @@ something else:
   trigram path deliberately: Czech declines the abbreviation itself — "na FELu",
   "na MFFce" — and the whole-word rule would cost every one of the 69
   institutions with a three-character short name, 60 of them faculties, the
-  inflected forms they have. The two-letter names do lose theirs: "na UKu"
-  no longer resolves. That is the trade — a missing institution filter shows a
-  wider list than was asked for, a wrong one narrows the catalog to a faculty
-  nobody named.
+  inflected forms they have. The two-letter names pay that price instead: an
+  inflected "na UKu" resolves to nothing. That is the trade — a missing
+  institution filter shows a wider list than was asked for, a wrong one narrows
+  the catalog to a faculty nobody named.
 - **When the words naming the kind of help were the whole query, only a certain
   subject survives.** There is no subject left in the text to find, so a trigram
   score is the scorer answering a question nobody asked: "bank statement" came

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -136,6 +136,27 @@ wrong language, misspelled. Three mechanisms handle it, cheapest first:
 Verified against a live database: `prijimacky` scores 1.00 against `Přijímačky`,
 `matematicka analyza` scores 1.00 against `Matematická analýza`.
 
+Two rules keep the trigram half of that from answering confidently about
+something else:
+
+- **A short name matches as a whole word or not at all.** Faculty short names
+  are two and three letters — `FI`, `UK`, `JU` — and trigram similarity puts
+  any word containing those letters above the threshold, so "по физике" found
+  the faculty FI and "uklidit" would find Charles University. Below four
+  characters a short name is compared the way an institution code is: bounded by
+  non-alphanumerics on both sides.
+- **The subject is looked up in what is left after the kind of help has been
+  taken out.** The words that name the kind of help are not part of the subject
+  and they carry trigrams that outrank it: "помощь на экзамене по физике"
+  answered «Чешский язык B1» at 0.59 while «Физика 1» sat at 0.56. If the
+  remainder names no subject, the whole query is tried again — a word can name
+  both, as "нострификация" names the service and the exam.
+
+Every kind of help in the catalog must be reachable in words, in all four
+languages. The five that are not about studying — insurance, a bank statement,
+a document translation, residence paperwork, housing — were offerable and
+unfindable, which is a listing nobody can reach.
+
 Above all this sits the query parser, which turns free text into ids. Because it
 does, the database rarely has to do linguistic work at all — it looks up
 canonical ids and filters. `search_queries` logs every query with the parse, the

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -146,7 +146,10 @@ something else:
   same whole-word test the synonym branch uses. Three letters stay on the
   trigram path deliberately: Czech declines the abbreviation itself — "na FELu",
   "na MFFce" — and the whole-word rule would cost all 57 three-letter faculties
-  every inflected form they have.
+  every inflected form they have. The two-letter names do lose theirs: "na UKu"
+  no longer resolves. That is the trade — a missing institution filter shows a
+  wider list than was asked for, a wrong one narrows the catalog to a faculty
+  nobody named.
 - **When the words naming the kind of help were the whole query, only a certain
   subject survives.** There is no subject left in the text to find, so a trigram
   score is the scorer answering a question nobody asked: "bank statement" came

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -143,19 +143,21 @@ something else:
   are two and three letters — `FI`, `UK`, `JU` — and trigram similarity puts
   any word containing those letters above the threshold, so "по физике" found
   the faculty FI and "uklidit" would find Charles University. Below four
-  characters a short name is compared the way an institution code is: bounded by
-  non-alphanumerics on both sides.
-- **The subject is looked up in what is left after the kind of help has been
-  taken out.** The words that name the kind of help are not part of the subject
-  and they carry trigrams that outrank it: "помощь на экзамене по физике"
-  answered «Чешский язык B1» at 0.59 while «Физика 1» sat at 0.56. If the
-  remainder names no subject, the whole query is tried again — a word can name
-  both, as "нострификация" names the service and the exam.
+  characters a short name is compared against the query's tokens, the same
+  whole-word test the synonym branch uses.
+- **When the words naming the kind of help were the whole query, only a certain
+  subject survives.** There is no subject left in the text to find, so a trigram
+  score is the scorer answering a question nobody asked: "bank statement" came
+  back as `Probability and Statistics` at 0.61, which would then filter the
+  search by a subject nobody named. A synonym hit is kept, because a curated
+  synonym is not a guess — "курсовая" and "нострификация" are written down
+  against real subjects.
 
-Every kind of help in the catalog must be reachable in words, in all four
+A kind of help that cannot be named in words cannot be found, in any of the four
 languages. The five that are not about studying — insurance, a bank statement,
 a document translation, residence paperwork, housing — were offerable and
-unfindable, which is a listing nobody can reach.
+unfindable, which is a listing nobody can reach. `language_tutoring` still has
+no keywords of its own and is reachable only as plain tutoring.
 
 Above all this sits the query parser, which turns free text into ids. Because it
 does, the database rarely has to do linguistic work at all — it looks up

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -145,8 +145,9 @@ something else:
   find Charles University. Those are compared against the query's tokens, the
   same whole-word test the synonym branch uses. Three letters stay on the
   trigram path deliberately: Czech declines the abbreviation itself — "na FELu",
-  "na MFFce" — and the whole-word rule would cost all 57 three-letter faculties
-  every inflected form they have. The two-letter names do lose theirs: "na UKu"
+  "na MFFce" — and the whole-word rule would cost every one of the 69
+  institutions with a three-character short name, 60 of them faculties, the
+  inflected forms they have. The two-letter names do lose theirs: "na UKu"
   no longer resolves. That is the trade — a missing institution filter shows a
   wider list than was asked for, a wrong one narrows the catalog to a faculty
   nobody named.


### PR DESCRIPTION
Docs updated first: docs/data-model.md

Three defects in the free-text query parser, one theme: it answered confidently
about things nobody typed, and said nothing about things they did.

## What was wrong

**The five kinds of help that are not about studying could not be named.**
Insurance, a bank statement, a document translation, residence paperwork and
housing have been offerable since PR #29 and had no keywords at all — a listing
nobody could reach. 22 realistic queries across the four languages found nothing.

**A short faculty name matched by trigram.** `FI`, `UK` and `JU` are two
letters, and any word containing them scored above the threshold, so "по физике"
came back naming the faculty FI at 0.67 and "uklidit byt" found Charles
University.

**A kind of help with no subjects could come back beside one.** The search
applies subject and kind of help together and no non-study offer carries a
subject, so the pair matches nobody.

## What it does now

Keywords for all five, in all four languages. Short names under three
characters are matched against the query's tokens — the same whole-word test the
synonym branch already uses — and three and over stay on the trigram path
because Czech declines the abbreviation itself ("na FELu"). And when a subject
and a subjectless kind of help both come out of one query, whichever is less
certain gives way: a named subject re-reads the kind of help without the
non-study ones, a guessed one is dropped. A document translation is the
exception and always wins — nobody writes "присяжный перевод диплома" in
passing.

## Verification

- `make check`: ruff, ruff format, ty, biome, tsc, 318 API tests (74 new).
- A 62-query matrix in four languages, measured before and after every round.
  The closing review re-ran it against `origin/main` side by side, plus all 1604
  catalog subject names, synonyms and institution names through the old and new
  matcher: zero unintended classification changes.
- Both structural rules mutation-tested: reverting either fails its own test.
- **Twelve independent review rounds.** They earned their keep. The first found
  that reading the subject from what the kind of help left behind fixes "помощь
  на экзамене по физике" and breaks "nostrifikacni zkouska z matematiky" — the
  same shape with the opposite right answer — so that idea was measured and
  dropped. Later rounds found the four-character cutoff losing every inflected
  three-letter faculty; the housing rule cancelling the translation fix; "визу"
  firing on "визуализация"; a life-group kind surviving beside a guessed subject
  into a guaranteed empty screen; and the canonical doc contradicting the code
  once the translation exception existed. Two of those were invisible from the
  private matcher and only showed through `parse`, which is where the tests go
  now.

## Out of scope

- **The trigram scorer.** "помощь на экзамене по физике" still answers «Чешский
  язык B1» at 0.59 while «Физика 1» sits at 0.56. Removing the kind-of-help
  words first fixes it and costs "nostrifikacni zkouska z matematiky" its 0.91
  correct match, because a subject name can legitimately contain those words. It
  needs a scoring change, not word removal, and the measurements are in the plan.
- **The `prijimacky` synonym** is attached to «Поступление в технические вузы»,
  so a bare "přijímačky" resolves to technical entrance exams at 1.00. The word
  names the category, not that member of it — reference data, so it needs a
  migration.
- `language_tutoring` has no keywords and is reachable only as plain tutoring.
- Insurer names (VZP, PVZP) are not keywords. `Word` now exists for exactly the
  whole-word matching they need, so this is cheap when somebody wants it.
- Two-letter faculties lose their inflected forms: "na UKu" no longer resolves.
  A deliberate trade, written into the code and the docs — a missing institution
  filter shows a wider list than was asked for, a wrong one narrows the catalog
  to a faculty nobody named.
- "translation studies tutor" reads as a document translation, for the same kind
  of reason and written down beside the keywords that cause it.
- Carried from earlier changes: CI never checks `apps/web/src/lib/generated`
  against the OpenAPI document; `test_health.py` does not pin the
  `elsewhere: <url>` webhook state; the function-level `services.lookup` import
  in `api/v1/taxonomy.py` is unhoisted; avatar stacks appear only in a wide cell;
  `requires_institution` is read by nothing; and the «přijímačky на медицину»
  example on `/ask`, replaced for misparsing, can come back now that the parser
  reads it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL
