### PR TITLE
Close four gaps nothing was watching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
     # The client in apps/web/src/lib/generated is generated from the API's own
     # OpenAPI document and committed, so the two can disagree. They did not
     # disagree yet only because nothing looked: a schema changed without running
-    # `pnpm api:generate` types the client against an endpoint that is no longer
+    # `make contract` types the client against an endpoint that is no longer
     # there, and every other check in this repository passes.
     #
     # Its own job rather than a step inside `web`, because it needs both

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,44 @@ jobs:
           docker run --rm -v "$PWD/Caddyfile:/etc/caddy/Caddyfile:ro" \
             caddy:2-alpine caddy validate --config /etc/caddy/Caddyfile
 
+  contract:
+    # The client in apps/web/src/lib/generated is generated from the API's own
+    # OpenAPI document and committed, so the two can disagree. They did not
+    # disagree yet only because nothing looked: a schema changed without running
+    # `pnpm api:generate` types the client against an endpoint that is no longer
+    # there, and every other check in this repository passes.
+    #
+    # Its own job rather than a step inside `web`, because it needs both
+    # toolchains and because the name is the error message.
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: apps/web/package.json
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/web/pnpm-lock.yaml
+
+      - name: Install
+        run: |
+          cd apps/api && uv sync --locked
+          cd ../web && pnpm install --frozen-lockfile
+
+      - name: The committed client must match the API
+        # No database and no server: the document is declared at import time,
+        # and the lifespan that needs one never runs.
+        run: make contract
+
   web:
     runs-on: ubuntu-latest
     defaults:

--- a/Makefile
+++ b/Makefile
@@ -107,5 +107,16 @@ format:  ## Reformat both apps
 	cd $(API) && uv run ruff check --fix src tests && uv run ruff format src tests
 	cd $(WEB) && pnpm format
 
+.PHONY: contract
+contract:  ## Check the committed client still matches the API's OpenAPI document
+	cd $(API) && uv run python -m students_cz.openapi > /tmp/students-cz-openapi.json
+	cd $(WEB) && OPENAPI_URL=/tmp/students-cz-openapi.json pnpm api:generate
+	@git diff --quiet -- $(WEB)/src/lib/generated || { \
+	  echo; \
+	  echo "The generated client is out of date. Commit what api:generate just wrote."; \
+	  git --no-pager diff --stat -- $(WEB)/src/lib/generated; \
+	  exit 1; \
+	}
+
 .PHONY: check
-check: lint test  ## Everything CI would run
+check: lint test contract  ## Everything CI would run

--- a/Makefile
+++ b/Makefile
@@ -107,14 +107,27 @@ format:  ## Reformat both apps
 	cd $(API) && uv run ruff check --fix src tests && uv run ruff format src tests
 	cd $(WEB) && pnpm format
 
+# Named per user: /tmp is shared, and a file owned by somebody else fails in a
+# way that reads as a broken check rather than a full disk.
+OPENAPI_DUMP := $(or $(TMPDIR),/tmp)/students-cz-openapi-$(shell id -u).json
+
 .PHONY: contract
 contract:  ## Check the committed client still matches the API's OpenAPI document
-	cd $(API) && uv run python -m students_cz.openapi > /tmp/students-cz-openapi.json
-	cd $(WEB) && OPENAPI_URL=/tmp/students-cz-openapi.json pnpm api:generate
-	@git diff --quiet -- $(WEB)/src/lib/generated || { \
+	cd $(API) && uv run python -m students_cz.openapi > $(OPENAPI_DUMP)
+	@# openapi-ts exits 0 without writing anything when its input is missing or
+	@# empty, and a generator that quietly did nothing leaves a stale client
+	@# looking identical to itself. Check the document before trusting the diff.
+	@grep -q '"openapi"' $(OPENAPI_DUMP) || { \
+	  echo "The OpenAPI dump is empty or not a document: $(OPENAPI_DUMP)"; \
+	  exit 1; \
+	}
+	cd $(WEB) && OPENAPI_URL=$(OPENAPI_DUMP) pnpm api:generate
+	@# --porcelain and not `git diff`: a generated file that is new is untracked,
+	@# and `git diff` cannot see those at all.
+	@test -z "$$(git status --porcelain -- $(WEB)/src/lib/generated)" || { \
 	  echo; \
 	  echo "The generated client is out of date. Commit what api:generate just wrote."; \
-	  git --no-pager diff --stat -- $(WEB)/src/lib/generated; \
+	  git --no-pager status --short -- $(WEB)/src/lib/generated; \
 	  exit 1; \
 	}
 

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,14 @@ contract:  ## Check the committed client still matches the API's OpenAPI documen
 	}
 	cd $(WEB) && OPENAPI_URL=$(OPENAPI_DUMP) pnpm api:generate
 	@# --porcelain and not `git diff`: a generated file that is new is untracked,
-	@# and `git diff` cannot see those at all.
-	@test -z "$$(git status --porcelain -- $(WEB)/src/lib/generated)" || { \
+	@# and `git diff` cannot see those at all. Kept in a variable so a git that
+	@# failed — no repository, a dubious-ownership refusal, no git at all — is
+	@# not read as an empty answer, which is the same string a clean tree gives.
+	@changed=$$(git status --porcelain -- $(WEB)/src/lib/generated) || { \
+	  echo "git status failed; the contract check compared nothing."; \
+	  exit 1; \
+	}; \
+	test -z "$$changed" || { \
 	  echo; \
 	  echo "The generated client is out of date. Commit what api:generate just wrote."; \
 	  git --no-pager status --short -- $(WEB)/src/lib/generated; \

--- a/apps/api/src/students_cz/api/v1/taxonomy.py
+++ b/apps/api/src/students_cz/api/v1/taxonomy.py
@@ -28,6 +28,7 @@ from students_cz.schemas import (
     SubjectOut,
 )
 from students_cz.services.catalog import tone_for
+from students_cz.services.lookup import find_subjects
 from students_cz.services.naming import translated
 
 router = APIRouter()
@@ -102,8 +103,6 @@ async def subjects(
     work. Without it, one level of the tree is returned.
     """
     if q:
-        from students_cz.services.lookup import find_subjects
-
         matches = await find_subjects(session, q, lang, limit=limit, threshold=0.4)
         ids = [m.id for m in matches]
         if not ids:

--- a/apps/api/src/students_cz/openapi.py
+++ b/apps/api/src/students_cz/openapi.py
@@ -19,10 +19,10 @@ from students_cz.main import app
 
 def main() -> int:
     # Exactly what `/openapi.json` serves, key order included. Sorting here
-    # would be tidier and wrong: the generator emits declarations in document
-    # order, so a sorted dump produces a different client from the one a
-    # developer gets by pointing `pnpm api:generate` at a running API — and the
-    # check would then fail for everyone who followed the documented workflow.
+    # would be tidier and would silently rewrite the committed client the first
+    # time anybody ran the check: the generator emits declarations in document
+    # order, so the whole file reshuffles for a reason that has nothing to do
+    # with the API.
     json.dump(app.openapi(), sys.stdout, indent=2, ensure_ascii=False)
     sys.stdout.write("\n")
     return 0

--- a/apps/api/src/students_cz/openapi.py
+++ b/apps/api/src/students_cz/openapi.py
@@ -1,0 +1,32 @@
+"""Print the OpenAPI document to stdout.
+
+The client in `apps/web/src/lib/generated` is generated from this and committed,
+so something has to produce the document without a server: the generator's
+default is to fetch it from a running API, and CI has no reason to start one to
+read a description of itself.
+
+Importing the app is enough — the routes and schemas are declared at import
+time, and the lifespan that needs a database never runs.
+
+    uv run python -m students_cz.openapi > openapi.json
+"""
+
+import json
+import sys
+
+from students_cz.main import app
+
+
+def main() -> int:
+    # Exactly what `/openapi.json` serves, key order included. Sorting here
+    # would be tidier and wrong: the generator emits declarations in document
+    # order, so a sorted dump produces a different client from the one a
+    # developer gets by pointing `pnpm api:generate` at a running API — and the
+    # check would then fail for everyone who followed the documented workflow.
+    json.dump(app.openapi(), sys.stdout, indent=2, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/api/src/students_cz/services/catalog.py
+++ b/apps/api/src/students_cz/services/catalog.py
@@ -114,8 +114,10 @@ async def home_sections(
         for index, st in enumerate(service_types)
     ]
 
-    # Things are not seeded yet; the section stays empty rather than absent so
-    # the client layout does not change shape once it fills.
+    # Things — gear to rent, textbooks to buy — are a planned kind of listing
+    # with no rows and no screen. The key stays in the response so that adding
+    # them is a change to this function and a new screen, rather than also a
+    # change to the shape of what every client already parses.
     return people, []
 
 

--- a/apps/api/tests/test_health.py
+++ b/apps/api/tests/test_health.py
@@ -72,13 +72,22 @@ async def test_a_webhook_telegram_does_not_have_is_not_reported_as_ok(
     exactly the half-failure this endpoint exists to surface.
     """
     body = await _healthz(app_with(WebhookBot("")))
-    assert body["webhook"] != "ok"
+    assert body["webhook"].startswith("missing:")
     assert body["status"] == "ok", "a deaf bot must not take the catalog down"
 
 
-async def test_a_webhook_pointing_elsewhere_is_not_reported_as_ok(app_with) -> None:
-    body = await _healthz(app_with(WebhookBot("https://someone-else.example/tg")))
-    assert body["webhook"] != "ok"
+async def test_a_webhook_pointing_elsewhere_says_where(app_with) -> None:
+    """Not just "not ok" — the address it went to.
+
+    Something outside this deployment clears the production webhook every few
+    minutes and, on at least one occasion, pointed it somewhere else. The URL in
+    this string is the only evidence of who did it that reaches an operator, and
+    an assertion on `!= "ok"` holds just as well after somebody shortens the
+    message to "elsewhere".
+    """
+    stolen = "https://someone-else.example/tg"
+    body = await _healthz(app_with(WebhookBot(stolen)))
+    assert body["webhook"] == f"elsewhere: {stolen}"
 
 
 async def test_the_webhook_telegram_confirms_is_reported_as_ok(

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -8,11 +8,10 @@ dist-ssr/
 .mkcert/
 
 # NOT ignored: src/lib/generated/. The types are generated from the API's
-# OpenAPI document by `pnpm api:generate`, which needs the API process up — and
-# CI runs `pnpm typecheck` and `pnpm build` with no backend. Committing the
-# output is what lets a clone type-check, and it puts a contract change in the
-# diff where a reviewer can see it. Regenerate and commit after changing the
-# API; `openapi-ts.config.ts` says the same.
+# OpenAPI document, and committing them is what lets a clone type-check with no
+# backend, and what puts a contract change in the diff where a reviewer can see
+# it. `make contract` regenerates and is what CI compares against; see
+# `openapi-ts.config.ts` for why it dumps the document instead of fetching it.
 
 # Catalogs compiled by `pnpm i18n:compile`. The build does not need them —
 # @lingui/vite-plugin compiles the .po files on import — so they are a local

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -31,11 +31,13 @@ pnpm install
 pnpm dev
 ```
 
-The API is expected at `http://127.0.0.1:8000`; `/api` and `/healthz` are
-proxied there, so calls from the browser stay same-origin. Start it separately:
+The API is expected at `http://127.0.0.1:8010` — see the note in
+`vite.config.ts` about what holds 8000 — and `/api`, `/healthz` and `/tg` are
+proxied there, so calls from the browser stay same-origin. Start it separately,
+or with `make api` from the repository root:
 
 ```sh
-cd ../api && uv run uvicorn students_cz.main:app --reload
+cd ../api && uv run uvicorn students_cz.main:app --reload --port 8010
 ```
 
 ### HTTPS is not optional
@@ -189,16 +191,18 @@ it is **committed**. `src/lib/types.ts` still declares the rest of the wire by
 hand and must be kept in step with `apps/api/src/students_cz/schemas.py`; a type
 moves across as the screen using it is touched.
 
-To regenerate, run the API and then:
+To regenerate, run `make contract` from the repository root and commit what it
+writes. It needs no server: the document is dumped straight from the app. The
+same target is what CI runs, and it fails when the committed copy differs — so a
+schema changed without regenerating stops being something only the next runtime
+error tells you about.
 
-```sh
-pnpm api:generate
-```
-
-Commit what it writes. `make contract`, from the repository root, is what CI
-runs: it dumps the document without a server, regenerates, and fails if the
-committed copy differs — so a schema changed without regenerating stops being
-something only the next runtime error tells you about.
+Do not generate from a running API. `pnpm api:generate` on its own fetches a
+URL, and the generator writes that URL into the client as a literal type —
+`ClientOptions.baseUrl: 'http://127.0.0.1:8010'` instead of the URL-independent
+form. The result is a client carrying whichever machine produced it, and one the
+contract check rejects. Reading the document from a file has no URL to bake in,
+which is why `make contract` dumps it.
 
 Generation is not wired into `pnpm build` on purpose — a build that fails
 because a backend is not running is a bad build. The directory is excluded from

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -197,12 +197,12 @@ same target is what CI runs, and it fails when the committed copy differs — so
 schema changed without regenerating stops being something only the next runtime
 error tells you about.
 
-Do not generate from a running API. `pnpm api:generate` on its own fetches a
-URL, and the generator writes that URL into the client as a literal type —
-`ClientOptions.baseUrl: 'http://127.0.0.1:8010'` instead of the URL-independent
-form. The result is a client carrying whichever machine produced it, and one the
-contract check rejects. Reading the document from a file has no URL to bake in,
-which is why `make contract` dumps it.
+Do not generate from a running API. Given a URL, the generator writes it into
+the client as a literal type — `ClientOptions.baseUrl: 'http://127.0.0.1:8010'`
+instead of the URL-independent form — so the result carries whichever machine
+produced it, and the contract check rejects it. Reading the document from a file
+has no URL to bake in, which is why `make contract` dumps it. There is no
+default input for that reason: `pnpm api:generate` on its own says so and stops.
 
 Generation is not wired into `pnpm build` on purpose — a build that fails
 because a backend is not running is a bad build. The directory is excluded from

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -184,14 +184,22 @@ choice the user makes by hand is stored in `localStorage` and outranks it.
 
 ### API types
 
-`src/lib/types.ts` is written by hand and must be kept in step with
-`apps/api/src/students_cz/schemas.py`. To replace it with generated types, run
-the API and then:
+`src/lib/generated/` holds types generated from the API's OpenAPI document, and
+it is **committed**. `src/lib/types.ts` still declares the rest of the wire by
+hand and must be kept in step with `apps/api/src/students_cz/schemas.py`; a type
+moves across as the screen using it is touched.
+
+To regenerate, run the API and then:
 
 ```sh
 pnpm api:generate
 ```
 
-Output lands in `src/lib/generated/`, which is gitignored and excluded from
-Biome. This is not wired into `pnpm build` on purpose — a build that fails
-because a backend is not running is a bad build.
+Commit what it writes. `make contract`, from the repository root, is what CI
+runs: it dumps the document without a server, regenerates, and fails if the
+committed copy differs — so a schema changed without regenerating stops being
+something only the next runtime error tells you about.
+
+Generation is not wired into `pnpm build` on purpose — a build that fails
+because a backend is not running is a bad build. The directory is excluded from
+Biome, since the generator owns its formatting.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -122,7 +122,7 @@ close the app from the client's menu rather than just backing out of it.
 | `pnpm typecheck`      | `tsc -b`, no emit                                     |
 | `pnpm i18n:extract`   | Scan source for new messages, update the `.po` files  |
 | `pnpm i18n:compile`   | Compile catalogs by hand (the build does not need it) |
-| `pnpm api:generate`   | Regenerate API types from the running API's OpenAPI   |
+| `pnpm api:generate`   | Regenerate API types — via `make contract`, see below  |
 
 ## Layout
 

--- a/apps/web/openapi-ts.config.ts
+++ b/apps/web/openapi-ts.config.ts
@@ -1,12 +1,18 @@
 import { defineConfig } from '@hey-api/openapi-ts';
 
 /**
- * Generates a typed client from the running API.
+ * Generates a typed client from the API's OpenAPI document.
  *
- * Not wired into `pnpm build` on purpose: the generator needs the API process
- * up, and a build that fails because a backend is not running is a bad build.
- * Run `pnpm api:generate` by hand after changing the API, and commit the
- * result. Until that happens, `src/lib/types.ts` is written by hand.
+ * Run it through `make contract` from the repository root, which dumps the
+ * document to a file first and then checks the result against what is
+ * committed. Pointing this at a running API instead works, and writes that
+ * server's address into the client as a literal `ClientOptions.baseUrl` — a
+ * client that carries whichever machine generated it, and that the contract
+ * check rejects. A file has no URL to bake in.
+ *
+ * Not wired into `pnpm build` on purpose: a build that fails because a backend
+ * is not running is a bad build. Everything the generator has not covered yet
+ * is hand-written in `src/lib/types.ts`.
  */
 export default defineConfig({
   input: process.env.OPENAPI_URL ?? 'http://127.0.0.1:8000/openapi.json',

--- a/apps/web/openapi-ts.config.ts
+++ b/apps/web/openapi-ts.config.ts
@@ -14,8 +14,16 @@ import { defineConfig } from '@hey-api/openapi-ts';
  * is not running is a bad build. Everything the generator has not covered yet
  * is hand-written in `src/lib/types.ts`.
  */
+const input = process.env.OPENAPI_URL;
+if (!input) {
+  // No default. Every value one could pick is a URL, and a URL is the thing
+  // that goes wrong here: the generator writes it into the client. `make
+  // contract` sets this to the file it dumped.
+  throw new Error('Set OPENAPI_URL, or run `make contract` from the repository root.');
+}
+
 export default defineConfig({
-  input: process.env.OPENAPI_URL ?? 'http://127.0.0.1:8000/openapi.json',
+  input,
   // Biome is excluded from the generated directory, so leave formatting and
   // linting to it rather than having the generator shell out to a second tool.
   output: './src/lib/generated',

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -170,8 +170,9 @@ function detailOf(payload: unknown): string | undefined {
 
 // ── endpoints ───────────────────────────────────────────────────────────
 //
-// Written by hand for now. `pnpm api:generate` will eventually produce these
-// from the OpenAPI document; until then keep the signatures in step with
+// Written by hand, and not by the generator: `openapi-ts.config.ts` declares
+// only the typescript plugin, so `lib/generated` holds types and no request
+// functions at all. Keep these in step with
 // apps/api/src/students_cz/api/v1/.
 
 export const api = {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1,9 +1,9 @@
 /**
  * Hand-written mirrors of the API's Pydantic schemas.
  *
- * These are a stopgap. `pnpm api:generate` will replace them with types
- * generated from the live OpenAPI document (see `openapi-ts.config.ts`), at
- * which point this file should shrink to whatever the generator cannot express.
+ * These are a stopgap. `make contract` generates types from the API's OpenAPI
+ * document into `lib/generated`, and this file shrinks as they move across —
+ * see the note on `ServiceType` below for how that happens.
  *
  * Two conventions carried over from the API and worth remembering:
  *
@@ -62,7 +62,7 @@ export type { Avatar };
 /**
  * Taken from the contract, not written out again.
  *
- * `pnpm api:generate` regenerates `lib/generated` from the API's OpenAPI
+ * `make contract` regenerates `lib/generated` from the API's OpenAPI
  * document, and these two carry `group`, which is an enum on the server. Going
  * through the generated type is what makes a mistyped group a compile error
  * here instead of an empty heading at runtime; a hand-written `string` would

--- a/apps/web/src/locales/cs/messages.po
+++ b/apps/web/src/locales/cs/messages.po
@@ -139,8 +139,8 @@ msgstr "Tohle nejsou naše služby. Provizi bereme od partnera, od studenta nic.
 #~ msgstr "Jaké předměty"
 
 #: src/pages/Home.tsx
-msgid "Вещи"
-msgstr "Věci"
+#~ msgid "Вещи"
+#~ msgstr "Věci"
 
 #: src/pages/MyHelper.tsx
 msgid "Всё можно менять когда угодно. Пустые поля просто не показываем."

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -139,8 +139,8 @@ msgstr "These aren't our services. We take a commission from the partner, nothin
 #~ msgstr "Which subjects"
 
 #: src/pages/Home.tsx
-msgid "Вещи"
-msgstr "Things"
+#~ msgid "Вещи"
+#~ msgstr "Things"
 
 #: src/pages/MyHelper.tsx
 msgid "Всё можно менять когда угодно. Пустые поля просто не показываем."

--- a/apps/web/src/locales/ru/messages.po
+++ b/apps/web/src/locales/ru/messages.po
@@ -139,8 +139,8 @@ msgstr "Это не наши услуги. Мы получаем комисси�
 #~ msgstr "Какие предметы"
 
 #: src/pages/Home.tsx
-msgid "Вещи"
-msgstr "Вещи"
+#~ msgid "Вещи"
+#~ msgstr "Вещи"
 
 #: src/pages/MyHelper.tsx
 msgid "Всё можно менять когда угодно. Пустые поля просто не показываем."

--- a/apps/web/src/locales/uk/messages.po
+++ b/apps/web/src/locales/uk/messages.po
@@ -139,8 +139,8 @@ msgstr "Це не наші послуги. Комісію ми отримуєм�
 #~ msgstr "Які предмети"
 
 #: src/pages/Home.tsx
-msgid "Вещи"
-msgstr "Речі"
+#~ msgid "Вещи"
+#~ msgstr "Речі"
 
 #: src/pages/MyHelper.tsx
 msgid "Всё можно менять когда угодно. Пустые поля просто не показываем."

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -62,26 +62,24 @@ export default function HomePage() {
             />
           </Rows>
         ) : (
-          <>
-            {/* Grouped, with a heading per shelf. There used to be a wide
-                first cell, because seven tiles in two columns left the last one
-                alone in its row; there are twelve now and three headings, so
-                the wide cell would create the orphan it was there to fix. */}
-            <ServiceGrid
-              items={data.people}
-              onPick={(section) => navigate(`/results?service=${section.code}`)}
-              renderTrailing={(section, wide) =>
-                // Faces only in the wide cell. A narrow tile has room for a
-                // number or for three overlapping circles, and the number is
-                // the one that says something a person cannot already guess.
-                wide && section.avatars.length ? (
-                  <AvatarStack avatars={section.avatars} />
-                ) : section.count ? (
-                  <Count>{section.count}</Count>
-                ) : null
-              }
-            />
-          </>
+          // Grouped, with a heading per shelf. There is no wide first cell:
+          // with seven tiles in two columns the last one sat alone in its row
+          // and a wide one fixed that, and with twelve tiles under three
+          // headings it would create the orphan it was there to fix.
+          <ServiceGrid
+            items={data.people}
+            onPick={(section) => navigate(`/results?service=${section.code}`)}
+            renderTrailing={(section, wide) =>
+              // Faces only in the wide cell. A narrow tile has room for a
+              // number or for three overlapping circles, and the number is
+              // the one that says something a person cannot already guess.
+              wide && section.avatars.length ? (
+                <AvatarStack avatars={section.avatars} />
+              ) : section.count ? (
+                <Count>{section.count}</Count>
+              ) : null
+            }
+          />
         )}
       </Screen>
       <TabBar />

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -62,10 +62,10 @@ export default function HomePage() {
             />
           </Rows>
         ) : (
-          // Grouped, with a heading per shelf. There is no wide first cell:
-          // with seven tiles in two columns the last one sat alone in its row
-          // and a wide one fixed that, and with twelve tiles under three
-          // headings it would create the orphan it was there to fix.
+          // Grouped, with a heading per shelf. An odd-sized group widens its
+          // first tile, which is what keeps the last one from sitting alone in
+          // its row — and the only cell with room for three overlapping faces,
+          // which is what the trailing callback below leans on.
           <ServiceGrid
             items={data.people}
             onPick={(section) => navigate(`/results?service=${section.code}`)}

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -81,15 +81,6 @@ export default function HomePage() {
                 ) : null
               }
             />
-
-            {/* Things — gear to rent, textbooks to buy — are not seeded, so
-                `/home` always answers with an empty list and the block that
-                drew them never rendered. It navigated to `/results?category=`,
-                which the results screen does not read: the day somebody seeds a
-                category, those rows would have opened a list of *people*
-                unfiltered. Deleted rather than left with a dead link, because
-                the screen that lists things does not exist yet either, and it
-                will be written against a real one. */}
           </>
         )}
       </Screen>

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -2,23 +2,20 @@ import { Trans, useLingui } from '@lingui/react/macro';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
 import { AppHeader } from '@/components/AppHeader';
-import { iconForService, SearchIcon } from '@/components/icons';
+import { SearchIcon } from '@/components/icons';
 import { ServiceGrid } from '@/components/ServiceGrid';
 import { TabBar } from '@/components/TabBar';
 import {
   AvatarStack,
   Count,
-  Label,
   Row,
   Rows,
   Screen,
   SkeletonRows,
-  Tile,
   Title,
   ui,
 } from '@/components/Ui';
 import { api } from '@/lib/api';
-import type { HomeSection } from '@/lib/types';
 
 /**
  * The first screen.
@@ -85,38 +82,18 @@ export default function HomePage() {
               }
             />
 
-            {data.things.length > 0 ? (
-              <>
-                <Label>
-                  <Trans>Вещи</Trans>
-                </Label>
-                <Rows>
-                  {data.things.map((section) => (
-                    <Row
-                      key={section.code}
-                      onClick={() => navigate(`/results?category=${section.code}`)}
-                      leading={
-                        <Tile tone={section.tone}>
-                          <SectionIcon section={section} />
-                        </Tile>
-                      }
-                      title={section.name}
-                      hint={section.hint}
-                      trailing={section.count ? <Count>{section.count}</Count> : null}
-                    />
-                  ))}
-                </Rows>
-              </>
-            ) : null}
+            {/* Things — gear to rent, textbooks to buy — are not seeded, so
+                `/home` always answers with an empty list and the block that
+                drew them never rendered. It navigated to `/results?category=`,
+                which the results screen does not read: the day somebody seeds a
+                category, those rows would have opened a list of *people*
+                unfiltered. Deleted rather than left with a dead link, because
+                the screen that lists things does not exist yet either, and it
+                will be written against a real one. */}
           </>
         )}
       </Screen>
       <TabBar />
     </>
   );
-}
-
-function SectionIcon({ section }: { section: HomeSection }) {
-  const Icon = iconForService(section.code);
-  return <Icon size={19} />;
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,7 +132,7 @@ Screens are assembled server-side — the client renders what it is given rather
 than joining data itself — so a schema often mirrors a screen, and that is
 intended.
 
-**The client's copy of that contract is generated and committed**, into
+**What the client has generated from that contract is committed**, into
 `apps/web/src/lib/generated`, and CI regenerates it from the API's own OpenAPI
 document to check that the committed copy still matches. Generating at build
 time was the alternative and it is worse: it needs the API process up, so the
@@ -140,6 +140,12 @@ web build fails when a backend is not running. Committing it means the two can
 disagree, which is what the check is for — a schema changed without running
 `pnpm api:generate` types the client against an endpoint that no longer exists,
 and nothing else in this repository notices.
+
+The check covers what has moved across, and that is not yet the whole client.
+`apps/web/src/lib/types.ts` still declares most of the wire types by hand and
+says so; each moves to the generated module as the screen using it is touched,
+and until one has, nothing compares it to the API. So a green contract check
+means the generated types are current, not that every type the app uses is.
 
 ## One engine, one pool
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,8 +138,11 @@ document to check that the committed copy still matches. Generating at build
 time was the alternative and it is worse: it needs the API process up, so the
 web build fails when a backend is not running. Committing it means the two can
 disagree, which is what the check is for — a schema changed without running
-`pnpm api:generate` types the client against an endpoint that no longer exists,
-and nothing else in this repository notices.
+`make contract` types the client against an endpoint that no longer exists, and
+nothing else in this repository notices. That target dumps the document to a
+file rather than fetching it: given a URL, the generator writes that URL into
+the client as a literal type, so a client generated against somebody's laptop
+carries their address.
 
 The check covers what has moved across, and that is not yet the whole client.
 `apps/web/src/lib/types.ts` still declares most of the wire types by hand and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,6 +132,15 @@ Screens are assembled server-side — the client renders what it is given rather
 than joining data itself — so a schema often mirrors a screen, and that is
 intended.
 
+**The client's copy of that contract is generated and committed**, into
+`apps/web/src/lib/generated`, and CI regenerates it from the API's own OpenAPI
+document to check that the committed copy still matches. Generating at build
+time was the alternative and it is worse: it needs the API process up, so the
+web build fails when a backend is not running. Committing it means the two can
+disagree, which is what the check is for — a schema changed without running
+`pnpm api:generate` types the client against an endpoint that no longer exists,
+and every check in this repository passes.
+
 ## One engine, one pool
 
 `db/session.py` holds the engine and the sessionmaker as module singletons,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,7 +138,7 @@ document to check that the committed copy still matches. Generating at build
 time was the alternative and it is worse: it needs the API process up, so the
 web build fails when a backend is not running. Committing it means the two can
 disagree, which is what the check is for — a schema changed without running
-`make contract` types the client against an endpoint that no longer exists, and
+`make contract` types the client against an endpoint the API does not serve, and
 nothing else in this repository notices. That target dumps the document to a
 file rather than fetching it: given a URL, the generator writes that URL into
 the client as a literal type, so a client generated against somebody's laptop

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,7 +139,7 @@ time was the alternative and it is worse: it needs the API process up, so the
 web build fails when a backend is not running. Committing it means the two can
 disagree, which is what the check is for — a schema changed without running
 `pnpm api:generate` types the client against an endpoint that no longer exists,
-and every check in this repository passes.
+and nothing else in this repository notices.
 
 ## One engine, one pool
 


### PR DESCRIPTION
Docs updated first: docs/architecture.md

Four gaps that nothing in this repository was watching.

## The generated client had no check

`apps/web/src/lib/generated` is produced from the API's OpenAPI document and
committed, and nothing compared the two. A schema changed without regenerating
types the client against an endpoint the API does not serve — and every check
here passes.

`make contract` dumps the document without a server (routes and schemas are
declared at import time; the lifespan that needs a database never runs),
regenerates, and fails on a difference. Its own CI job, because it needs both
toolchains and because the name is the error message. Proven by adding a field
to `ParseOut`: four lines of drift, exit 1.

**Do not generate from a running API.** This came out of following the
instruction I had just written: given a URL, the generator writes it into the
client as a literal `ClientOptions.baseUrl`, so the result carries whichever
machine produced it and the check rejects it. Reading a file has no URL to bake
in, which is why the target dumps one — and why the config now has no default
input at all, saying what to run instead.

## The health test asserted the wrong half

A webhook pointing somewhere else was checked for "not ok". The URL in that
message is the only evidence an operator gets about where updates went, which
matters here because something outside this deployment clears the production
webhook every few minutes. Pinned exactly: shortening the message to
"elsewhere" now fails the test. The missing case is pinned to its prefix for
the same reason.

## A function-level import avoiding a cycle that does not exist

`services/lookup.py` imports the standard library and SQLAlchemy and nothing
else. Hoisted.

## The "Вещи" block on the home screen

Things are not seeded, so `/home` always answers with an empty list and the
block never rendered. It navigated to `/results?category=`, which the results
screen does not read: the day somebody seeds a category, those rows would have
opened an unfiltered list of *people*. Deleted rather than left with a dead
link — the screen that lists things does not exist either, and it will be
written against a real one. The key stays in the response, because the field is
part of a contract every client already parses.

## Verification

- `make check` — now including `make contract`: ruff, ruff format, ty, biome,
  tsc, 318 API tests.
- Every failure mode of the check exercised: a stale client fails; an untracked
  generated file fails; an empty or missing document fails before the diff is
  trusted; a git that itself failed is not read as a clean tree.
- `pnpm check:scroll` at all three viewports after the home-screen change.
- Eight independent review rounds. Beyond the four above they found: `git diff`
  cannot see untracked files; `openapi-ts` exits 0 without writing when its
  input is missing or empty; `apps/web/README.md` still documented the generated
  directory as gitignored and the API as being on port 8000; and a comment I
  wrote claiming the service grid has no wide first cell, which it does, for any
  odd-sized group.

## Out of scope

- **The check covers only what has moved across.** `apps/web/src/lib/types.ts`
  still declares most of the wire by hand; a green contract check means the
  generated types are current, not that every type the app uses is. Written into
  `docs/architecture.md` rather than left to be assumed.
- Carried from earlier changes and still open: the trigram scorer mis-ranking a
  subject on longer queries; the over-broad `prijimacky` synonym;
  `language_tutoring` having no parser keywords; insurer names not being
  keywords; two-letter faculties losing their inflected forms; avatar stacks
  appearing only in a wide cell; `requires_institution` read by nothing; the
  `Request.tsx` promise the feed does not keep; the step-5 endpoints that still
  write in the route body; `public.py` reaching into `app.state`; and the
  «přijímačky на медицину» example on `/ask`, which can come back now that the
  parser reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL
