### PR TITLE
Faces on every shelf, not only where the parity fell right

### DIFF
--- a/apps/web/src/components/ServiceGrid.tsx
+++ b/apps/web/src/components/ServiceGrid.tsx
@@ -50,8 +50,7 @@ export function ServiceGrid<T extends ServiceTile>({
   onPick?: (item: T) => void;
   /**
    * Home puts its counts and faces here without this file knowing about them.
-   * `wide` is passed because a full-width cell has room for three overlapping
-   * faces and a narrow one does not.
+   * `wide` is passed because a full-width cell has room for more of them.
    */
   renderTrailing?: (item: T, wide: boolean) => ReactNode;
   /** Something to say under one group's heading, before its tiles. */
@@ -70,10 +69,9 @@ export function ServiceGrid<T extends ServiceTile>({
               {tiles.map((item, index) => {
                 const Icon = iconForService(item.code);
                 const isOn = selected?.has(item.code) ?? false;
-                // Two columns leave an odd group's last tile alone in its row,
-                // which reads as something having failed to load. Widening the
-                // first one makes the count even again — and the wide cell is
-                // the only one with room for faces.
+                // Two columns leave an odd group's last tile alone in its
+                // row, which reads as something having failed to load.
+                // Widening the first one makes the count even again.
                 const wide = tiles.length % 2 === 1 && index === 0;
                 return (
                   <Cell

--- a/apps/web/src/components/Ui.tsx
+++ b/apps/web/src/components/Ui.tsx
@@ -108,7 +108,10 @@ export function Cell({
       <span className={css.cellName}>{title}</span>
       <span className={css.cellFoot}>
         <span className={css.cellHint}>{hint}</span>
-        {trailing}
+        {/* Wrapped, like the wide cell's: two loose children under
+            space-between put the trailing content in the middle of the tile
+            whenever the hint is short. */}
+        {trailing ? <span className={css.rowTrailing}>{trailing}</span> : null}
       </span>
     </button>
   );
@@ -224,7 +227,12 @@ export function AvatarStack({
   return (
     <div
       className={css.stack}
-      style={ring ? ({ '--stack-ring': ring } as React.CSSProperties) : undefined}
+      style={
+        {
+          '--stack-size': `${size}px`,
+          ...(ring ? { '--stack-ring': ring } : {}),
+        } as React.CSSProperties
+      }
     >
       {/* Reversed here too, so row-reverse puts them back in the given order. */}
       {[...avatars].reverse().map((avatar) => (

--- a/apps/web/src/components/ui.module.css
+++ b/apps/web/src/components/ui.module.css
@@ -332,8 +332,11 @@
   flex-direction: row-reverse;
 }
 
+/* A third of the circle, not a fixed eight pixels: the overlap has to shrink
+   with the avatar or it eats the one thing a small monogram contains. At 19px
+   a fixed -8px left about nine pixels of the covered initial. */
 .stack > * + * {
-  margin-right: -8px;
+  margin-right: calc(var(--stack-size, 24px) / -3);
 }
 
 /* The ring makes overlapping circles legible; it has to match whatever is

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -69,24 +69,27 @@ export default function HomePage() {
           <ServiceGrid
             items={data.people}
             onPick={(section) => navigate(`/results?service=${section.code}`)}
-            renderTrailing={(section, wide) => (
+            renderTrailing={(section, wide) => {
               // Faces on every shelf that has any, not only where a wide cell
               // happened to fall. Which shelf got one was decided by whether
               // its number of tiles is odd, so «Учёба» — the fullest shelf in
               // the catalog — was the one that never showed a face.
               //
               // Two of them in a narrow tile rather than three: they share the
-              // line with the hint, and the third costs about a word of it.
-              <>
-                {section.avatars.length ? (
-                  <AvatarStack
-                    avatars={wide ? section.avatars : section.avatars.slice(0, 2)}
-                    size={wide ? 24 : 19}
-                  />
-                ) : null}
-                {section.count ? <Count>{section.count}</Count> : null}
-              </>
-            )}
+              // line with the hint, and each face costs it about a word.
+              if (!section.avatars.length && !section.count) return null;
+              return (
+                <>
+                  {section.avatars.length ? (
+                    <AvatarStack
+                      avatars={wide ? section.avatars : section.avatars.slice(0, 2)}
+                      size={wide ? 24 : 19}
+                    />
+                  ) : null}
+                  {section.count ? <Count>{section.count}</Count> : null}
+                </>
+              );
+            }}
           />
         )}
       </Screen>

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -69,16 +69,24 @@ export default function HomePage() {
           <ServiceGrid
             items={data.people}
             onPick={(section) => navigate(`/results?service=${section.code}`)}
-            renderTrailing={(section, wide) =>
-              // Faces only in the wide cell. A narrow tile has room for a
-              // number or for three overlapping circles, and the number is
-              // the one that says something a person cannot already guess.
-              wide && section.avatars.length ? (
-                <AvatarStack avatars={section.avatars} />
-              ) : section.count ? (
-                <Count>{section.count}</Count>
-              ) : null
-            }
+            renderTrailing={(section, wide) => (
+              // Faces on every shelf that has any, not only where a wide cell
+              // happened to fall. Which shelf got one was decided by whether
+              // its number of tiles is odd, so «Учёба» — the fullest shelf in
+              // the catalog — was the one that never showed a face.
+              //
+              // Two of them in a narrow tile rather than three: they share the
+              // line with the hint, and the third costs about a word of it.
+              <>
+                {section.avatars.length ? (
+                  <AvatarStack
+                    avatars={wide ? section.avatars : section.avatars.slice(0, 2)}
+                    size={wide ? 24 : 19}
+                  />
+                ) : null}
+                {section.count ? <Count>{section.count}</Count> : null}
+              </>
+            )}
           />
         )}
       </Screen>

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -64,8 +64,7 @@ export default function HomePage() {
         ) : (
           // Grouped, with a heading per shelf. An odd-sized group widens its
           // first tile, which is what keeps the last one from sitting alone in
-          // its row — and the only cell with room for three overlapping faces,
-          // which is what the trailing callback below leans on.
+          // its row.
           <ServiceGrid
             items={data.people}
             onPick={(section) => navigate(`/results?service=${section.code}`)}
@@ -75,8 +74,13 @@ export default function HomePage() {
               // its number of tiles is odd, so «Учёба» — the fullest shelf in
               // the catalog — was the one that never showed a face.
               //
-              // Two of them in a narrow tile rather than three: they share the
-              // line with the hint, and each face costs it about a word.
+              // Two of them in a narrow tile rather than three: they share
+              // the line with the hint, and each face costs it about a word.
+              // On the narrowest phone that is most of the hint — "матан,
+              // физика, экономика, программирование" keeps its first word.
+              // Taken: a hint that lists examples of a category the name
+              // already gives is worth less than the faces of people offering
+              // it.
               if (!section.avatars.length && !section.count) return null;
               return (
                 <>


### PR DESCRIPTION
Docs not applicable: the grid's trailing content is visual composition, and the web-shell section of docs/architecture.md describes scrolling and layout rather than what a tile shows.

The home screen showed avatar stacks only in a "wide" cell, and a group gets a
wide cell only when it holds an odd number of tiles — that rule exists so the
last tile of an odd group is not left alone in its row. Study holds four, so the
fullest shelf in the catalog was the one that never showed a face. Not a
decision, an accident of arithmetic.

Every shelf with helpers shows them now. Two faces at 19px in a narrow tile
rather than three, because they share the line with the hint and the third costs
about a word of it; a wide cell keeps its three at 24px.

## Verification

- `make check` — ruff, ruff format, ty, biome, tsc, the contract check, 318 API
  tests.
- `pnpm check:scroll` at 390×664, 360×640 and 390×568: every screen still ends
  on content.
- Screenshots at 390px before and after.

## Out of scope

`requires_institution` was going to ride along in this batch — it is read by
nothing, because no screen asks for a school. It is not here: the offer flow is
about to be reshaped around what each kind of help actually needs asking, and
the institution question belongs to that change rather than to this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL
