### PR TITLE
Ask a written work when it will be done, and what it takes on

### DIFF
--- a/apps/api/src/students_cz/api/v1/cabinet.py
+++ b/apps/api/src/students_cz/api/v1/cabinet.py
@@ -94,6 +94,7 @@ async def my_helper(session: SessionDep, lang: LangDep, user: UserDep) -> MyHelp
                 langs=list(offer.langs),
                 option_ids=list(offer.option_ids),
                 note=offer.note,
+                turnaround_days=offer.turnaround_days,
             )
             for offer in offers
         ],

--- a/apps/api/src/students_cz/db/migrations/versions/20260731_c37f5a8e2b14_ask_a_written_work_when_and_what.py
+++ b/apps/api/src/students_cz/db/migrations/versions/20260731_c37f5a8e2b14_ask_a_written_work_when_and_what.py
@@ -1,0 +1,144 @@
+"""Ask a written work when it will be done, and what is taken on
+
+The `work` shape asked for a price and nothing else, so two people who write
+theses were one row read twice. Two answers fill it: `offers.turnaround_days`,
+and the checklist tables that already exist — the checklist belongs to the
+service type rather than to the shape, so written work gets one the same way
+the seven errands did.
+
+The rows are spelled out here and not imported from `db/seed.py` for the reason
+the previous options migration gives: the deploy runs `alembic upgrade head` and
+never the seed, and a migration that follows a constant changes meaning the next
+time that constant does. `tests/test_service_groups.py` fails when the two
+disagree.
+
+Revision ID: c37f5a8e2b14
+Revises: 8c41d2f6b9a7
+Create Date: 2026-07-31
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c37f5a8e2b14"
+down_revision: str | Sequence[str] | None = "8c41d2f6b9a7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Service type code -> its checklist, each line as (code, ru, cs, en, uk).
+SERVICE_OPTIONS: dict[str, list[tuple[str, str, str, str, str]]] = {
+    "writing": [
+        (
+            "semester",
+            "Семестровая и реферат",
+            "Semestrální práce a referát",
+            "Term papers and essays",
+            "Семестрова та реферат",
+        ),
+        (
+            "bachelor",
+            "Бакалаврская",
+            "Bakalářská práce",
+            "A bachelor's thesis",
+            "Бакалаврська",
+        ),
+        (
+            "master",
+            "Дипломная и магистерская",
+            "Diplomová práce",
+            "A master's thesis",
+            "Дипломна та магістерська",
+        ),
+        (
+            "presentation",
+            "Презентация к защите",
+            "Prezentace k obhajobě",
+            "Slides for the defence",
+            "Презентація до захисту",
+        ),
+        (
+            "edits",
+            "Правки после проверки",
+            "Úpravy po připomínkách",
+            "Revisions after feedback",
+            "Правки після перевірки",
+        ),
+        (
+            "formatting",
+            "Оформление по нормам вуза",
+            "Formátování dle norem školy",
+            "Formatting to the school's rules",
+            "Оформлення за нормами вишу",
+        ),
+    ],
+}
+
+
+def upgrade() -> None:
+    op.add_column(
+        "offers", sa.Column("turnaround_days", sa.SmallInteger(), nullable=True)
+    )
+    # NULL already says "we will agree", which is the thing somebody might
+    # otherwise reach for a zero to say.
+    op.create_check_constraint(
+        "turnaround_positive",
+        "offers",
+        "turnaround_days IS NULL OR turnaround_days > 0",
+    )
+
+    bind = op.get_bind()
+    for service_code, rows in SERVICE_OPTIONS.items():
+        service_id = bind.execute(
+            sa.text("SELECT id FROM service_types WHERE code = :code"),
+            {"code": service_code},
+        ).scalar()
+        # Skipped, not asserted, and `writing` is one of the seven that make
+        # this necessary: only the five `life` service types are ever created by
+        # a migration, so on a migrations-only database (CI, `make db-reset`, a
+        # fresh clone) this finds nothing and the seed that runs next creates
+        # both the type and its checklist. Asserting aborts the upgrade there.
+        if service_id is None:
+            continue
+        for sort, (option_code, ru, cs, en, uk) in enumerate(rows, start=1):
+            option_id = bind.execute(
+                sa.text(
+                    "INSERT INTO service_options"
+                    " (service_type_id, code, sort, is_active, created_at, updated_at)"
+                    " VALUES (:service_id, :code, :sort, true, now(), now())"
+                    " ON CONFLICT (service_type_id, code) DO UPDATE"
+                    "    SET sort = EXCLUDED.sort, is_active = true, updated_at = now()"
+                    " RETURNING id"
+                ),
+                {"service_id": service_id, "code": option_code, "sort": sort},
+            ).scalar()
+            for lang, label in (("ru", ru), ("cs", cs), ("en", en), ("uk", uk)):
+                bind.execute(
+                    sa.text(
+                        "INSERT INTO service_option_i18n (option_id, lang, label)"
+                        " VALUES (:option_id, CAST(:lang AS ui_lang), :label)"
+                        " ON CONFLICT (option_id, lang) DO UPDATE"
+                        "    SET label = EXCLUDED.label"
+                    ),
+                    {"option_id": option_id, "lang": lang, "label": label},
+                )
+
+
+def downgrade() -> None:
+    op.drop_constraint("turnaround_positive", "offers", type_="check")
+    op.drop_column("offers", "turnaround_days")
+    # The i18n rows go with them: the foreign key cascades.
+    bind = op.get_bind()
+    for service_code, rows in SERVICE_OPTIONS.items():
+        bind.execute(
+            sa.text(
+                "DELETE FROM service_options"
+                " WHERE code = ANY(:codes)"
+                "   AND service_type_id IN"
+                "       (SELECT id FROM service_types WHERE code = :service)"
+            ),
+            {"codes": [row[0] for row in rows], "service": service_code},
+        )

--- a/apps/api/src/students_cz/db/models/catalog.py
+++ b/apps/api/src/students_cz/db/models/catalog.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Numeric,
+    SmallInteger,
     String,
     Text,
     UniqueConstraint,
@@ -76,7 +77,7 @@ class Offer(IdMixin, TimestampMixin, Base):
     )
 
     # Per-service-type extras that do not deserve columns: exam board, page
-    # count, turnaround days, whether a trial lesson is free.
+    # count, whether a trial lesson is free.
     attrs: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default="{}")
 
     # Which lines of the service type's checklist this offer covers. Ids rather
@@ -90,6 +91,16 @@ class Offer(IdMixin, TimestampMixin, Base):
     # What the checklist could not say, in the person's own words. Read, not
     # matched — the checklist is the part search can use.
     note: Mapped[str | None] = mapped_column(Text)
+
+    # How long the work takes. Only a written work asks — a lesson happens when
+    # the two of them agree and an errand takes as long as the office queue.
+    # NULL is an answer and not a gap: it says the two of them will agree.
+    #
+    # A column rather than a key in `attrs` above, which names exactly this as
+    # its example, because `attrs` is exposed by no schema and the question
+    # worth asking here is a range: who can do it inside a week. Unindexed until
+    # something asks it — see docs/data-model.md.
+    turnaround_days: Mapped[int | None] = mapped_column(SmallInteger)
 
     is_active: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=True, server_default=text("true")
@@ -130,5 +141,11 @@ class Offer(IdMixin, TimestampMixin, Base):
         Index("ix_offers_price", "price_currency", "price_amount"),
         CheckConstraint(
             "price_amount IS NULL OR price_amount >= 0", name="price_non_negative"
+        ),
+        # Zero days and minus three days are not answers, and NULL already says
+        # the thing somebody might reach for zero to say.
+        CheckConstraint(
+            "turnaround_days IS NULL OR turnaround_days > 0",
+            name="turnaround_positive",
         ),
     )

--- a/apps/api/src/students_cz/db/seed.py
+++ b/apps/api/src/students_cz/db/seed.py
@@ -251,12 +251,58 @@ WORKING_LANGUAGES: list[tuple[str, dict[str, str]]] = [
 ]
 
 
-# What each errand covers, by service type code: (code, ru, cs, en, uk).
+# What a kind of help covers, by service type code: (code, ru, cs, en, uk).
 #
 # An errand has no subject and no institution — the tile is the whole query — so
-# without this a person offering insurance can say nothing beyond the word.
+# without this a person offering insurance can say nothing beyond the word. A
+# written work has a subject and nothing else, and the lines say which works are
+# taken on rather than which errands are run.
 # `test_service_groups.py` fails when this and the migration disagree.
 SERVICE_OPTIONS: dict[str, list[tuple[str, str, str, str, str]]] = {
+    "writing": [
+        (
+            "semester",
+            "Семестровая и реферат",
+            "Semestrální práce a referát",
+            "Term papers and essays",
+            "Семестрова та реферат",
+        ),
+        (
+            "bachelor",
+            "Бакалаврская",
+            "Bakalářská práce",
+            "A bachelor's thesis",
+            "Бакалаврська",
+        ),
+        (
+            "master",
+            "Дипломная и магистерская",
+            "Diplomová práce",
+            "A master's thesis",
+            "Дипломна та магістерська",
+        ),
+        (
+            "presentation",
+            "Презентация к защите",
+            "Prezentace k obhajobě",
+            "Slides for the defence",
+            "Презентація до захисту",
+        ),
+        (
+            "edits",
+            "Правки после проверки",
+            "Úpravy po připomínkách",
+            "Revisions after feedback",
+            "Правки після перевірки",
+        ),
+        (
+            "formatting",
+            "Оформление по нормам вуза",
+            "Formátování dle norem školy",
+            "Formatting to the school's rules",
+            "Оформлення за нормами вишу",
+        ),
+    ],
     "insurance": [
         (
             "vzp_pvzp",

--- a/apps/api/src/students_cz/db/seed.py
+++ b/apps/api/src/students_cz/db/seed.py
@@ -255,8 +255,9 @@ WORKING_LANGUAGES: list[tuple[str, dict[str, str]]] = [
 #
 # An errand has no subject and no institution — the tile is the whole query — so
 # without this a person offering insurance can say nothing beyond the word. A
-# written work has a subject and nothing else, and the lines say which works are
-# taken on rather than which errands are run.
+# written work has no axes either — `requires_subject` is false, so a thesis is
+# offered without naming one — and its lines say which works are taken on rather
+# than which errands are run.
 # `test_service_groups.py` fails when this and the migration disagree.
 SERVICE_OPTIONS: dict[str, list[tuple[str, str, str, str, str]]] = {
     "writing": [

--- a/apps/api/src/students_cz/schemas.py
+++ b/apps/api/src/students_cz/schemas.py
@@ -152,6 +152,9 @@ class OfferOut(BaseModel):
     # Neither carries a default, for the reason `ServiceTypeOut.options` gives.
     options: list[str]
     note: str | None
+    # Only a written work has one; the rest send `null`, which reads as "we
+    # will agree" there and as "nobody asked" everywhere else.
+    turnaround_days: int | None
 
 
 class HelperCardOut(BaseModel):
@@ -346,6 +349,10 @@ class OfferIn(BaseModel):
     # help's checklist to another.
     option_ids: list[int] = Field(default_factory=list, max_length=32)
     note: str | None = Field(default=None, max_length=600)
+    # A year is the outer bound of anything a student would wait for, and the
+    # form offers five presets well inside it. `None` is an answer: the two of
+    # them will agree.
+    turnaround_days: int | None = Field(default=None, ge=1, le=365)
 
 
 class HelperUpsert(BaseModel):
@@ -381,6 +388,7 @@ class MyOfferOut(BaseModel):
     langs: list[str] = Field(default_factory=list)
     option_ids: list[int]
     note: str | None
+    turnaround_days: int | None
 
 
 class MyHelperOut(BaseModel):

--- a/apps/api/src/students_cz/services/catalog.py
+++ b/apps/api/src/students_cz/services/catalog.py
@@ -606,6 +606,7 @@ async def _offers_out(
                     )
                 ],
                 note=offer.note,
+                turnaround_days=offer.turnaround_days,
             )
         )
     return out

--- a/apps/api/src/students_cz/services/helpers.py
+++ b/apps/api/src/students_cz/services/helpers.py
@@ -213,6 +213,11 @@ async def _apply_offers(
                     in options_by_service.get(offer_spec.service_type_id, set())
                 )
             )
+        # Same rule, same reason as the checklist below: `OfferIn` defaults it
+        # to `None`, so an unconditional write moves a writer who said "a week"
+        # to "we will agree" on any save that did not mention it.
+        if "turnaround_days" in offer_spec.model_fields_set:
+            offer.turnaround_days = offer_spec.turnaround_days
         if "note" in offer_spec.model_fields_set:
             offer.note = (offer_spec.note or "").strip() or None
         # Same rule: a caller that said nothing about the format is not saying

--- a/apps/api/src/students_cz/services/helpers.py
+++ b/apps/api/src/students_cz/services/helpers.py
@@ -23,6 +23,7 @@ from students_cz.db.models import (
 from students_cz.db.models.enums import (
     ContentLang,
     PublishStatus,
+    ServiceForm,
     UiLang,
     UserEventKind,
 )
@@ -155,6 +156,16 @@ async def _apply_offers(
     ).all():
         options_by_service.setdefault(service_id, set()).add(option_id)
 
+    # Which kinds of help are asked when, for the same filter the checklist
+    # gets. One query for the whole save.
+    writing_service_ids = set(
+        (
+            await session.scalars(
+                select(ServiceType.id).where(ServiceType.form_shape == ServiceForm.WORK)
+            )
+        ).all()
+    )
+
     seen_axes: set[tuple[int, int | None, int | None]] = set()
     for offer_spec in spec.offers:
         if offer_spec.service_type_id not in valid_service_ids:
@@ -213,11 +224,18 @@ async def _apply_offers(
                     in options_by_service.get(offer_spec.service_type_id, set())
                 )
             )
-        # Same rule, same reason as the checklist below: `OfferIn` defaults it
+        # Same rule, same reason as the checklist above: `OfferIn` defaults it
         # to `None`, so an unconditional write moves a writer who said "a week"
-        # to "we will agree" on any save that did not mention it.
+        # to "we will agree" on any save that did not mention it. And the same
+        # filter: only a written work is asked when, so a turnaround on a lesson
+        # is dropped rather than stored — otherwise the profile reads «Срок:
+        # неделя» under a service whose form never offered the question.
         if "turnaround_days" in offer_spec.model_fields_set:
-            offer.turnaround_days = offer_spec.turnaround_days
+            offer.turnaround_days = (
+                offer_spec.turnaround_days
+                if offer_spec.service_type_id in writing_service_ids
+                else None
+            )
         if "note" in offer_spec.model_fields_set:
             offer.note = (offer_spec.note or "").strip() or None
         # Same rule: a caller that said nothing about the format is not saying

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -1072,6 +1072,104 @@ async def test_the_checklist_reaches_the_screen_that_ticks_it(client, session):
     assert [o["code"] for o in offered] == [r.code for r in stored[1:]]
 
 
+async def test_a_turnaround_reaches_the_person_reading_it(client, session):
+    """The one question a written work is asked that a lesson is not."""
+    from sqlalchemy import select
+
+    from students_cz.db.models import ServiceType
+
+    writing = await session.scalar(
+        select(ServiceType).where(ServiceType.code == "writing")
+    )
+    headers = auth_header(90702)
+    saved = await client.put(
+        "/api/v1/helper",
+        json={
+            "publish": True,
+            "offers": [
+                {
+                    "service_type_id": writing.id,
+                    "price_amount": 3000,
+                    "price_unit": "work",
+                    "turnaround_days": 7,
+                }
+            ],
+        },
+        headers=headers,
+    )
+    assert saved.status_code == 200, saved.text
+
+    mine = (await client.get("/api/v1/helper", headers=headers)).json()
+    assert mine["offers"][0]["turnaround_days"] == 7
+
+    me = (await client.get("/api/v1/me", headers=headers)).json()
+    page = (await client.get(f"/api/v1/helpers/{me['id']}", headers=headers)).json()
+    offer = next(o for o in page["offers"] if o["service_type"] == "writing")
+    assert offer["turnaround_days"] == 7
+
+
+async def test_a_save_that_says_nothing_about_the_turnaround_keeps_it(client, session):
+    """The same rule the checklist follows, and for the same reason.
+
+    `OfferIn` defaults `turnaround_days` to `None`, so a caller that saves an
+    offer without mentioning it would quietly move the writer from "a week" to
+    "we will agree".
+    """
+    from sqlalchemy import select
+
+    from students_cz.db.models import ServiceType
+
+    writing = await session.scalar(
+        select(ServiceType).where(ServiceType.code == "writing")
+    )
+    headers = auth_header(90703)
+    await client.put(
+        "/api/v1/helper",
+        json={
+            "publish": True,
+            "offers": [{"service_type_id": writing.id, "turnaround_days": 14}],
+        },
+        headers=headers,
+    )
+
+    await client.put(
+        "/api/v1/helper",
+        json={
+            "publish": True,
+            "offers": [{"service_type_id": writing.id, "price_amount": 2500}],
+        },
+        headers=headers,
+    )
+
+    mine = (await client.get("/api/v1/helper", headers=headers)).json()
+    assert mine["offers"][0]["turnaround_days"] == 14, "the turnaround was erased"
+
+
+async def test_a_turnaround_must_be_a_real_number_of_days(session):
+    """`NULL` says "we will agree"; zero and minus three say nothing at all.
+
+    The form only ever sends one of five presets, so this is about everything
+    that is not the form — an import, a fixture, a later endpoint.
+    """
+    import sqlalchemy.exc
+    from sqlalchemy import select
+
+    from students_cz.db.models import HelperProfile, Offer, ServiceType, User
+
+    writing = await session.scalar(
+        select(ServiceType).where(ServiceType.code == "writing")
+    )
+    user = User(tg_id=90701, first_name="Zero")
+    session.add(user)
+    await session.flush()
+    session.add(HelperProfile(user_id=user.id))
+    await session.flush()
+
+    session.add(Offer(helper_id=user.id, service_type_id=writing.id, turnaround_days=0))
+    with pytest.raises(sqlalchemy.exc.IntegrityError):
+        await session.flush()
+
+
 async def test_a_withdrawn_checklist_line_survives_an_unrelated_save(client, session):
     """Deactivated is not deleted — that is the whole point of deactivating.
 

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -1145,6 +1145,35 @@ async def test_a_save_that_says_nothing_about_the_turnaround_keeps_it(client, se
     assert mine["offers"][0]["turnaround_days"] == 14, "the turnaround was erased"
 
 
+async def test_a_turnaround_on_a_lesson_is_dropped(client, session):
+    """Only a written work is asked when, so only one can answer.
+
+    The same filter the checklist gets, and for a visible reason: a stale or
+    hand-rolled client could otherwise put «Срок: неделя» under a tutoring
+    offer, on a form that never asked.
+    """
+    from sqlalchemy import select
+
+    from students_cz.db.models import ServiceType
+
+    tutoring = await session.scalar(
+        select(ServiceType).where(ServiceType.code == "tutoring")
+    )
+    headers = auth_header(90704)
+    saved = await client.put(
+        "/api/v1/helper",
+        json={
+            "publish": True,
+            "offers": [{"service_type_id": tutoring.id, "turnaround_days": 7}],
+        },
+        headers=headers,
+    )
+    assert saved.status_code == 200, saved.text
+
+    mine = (await client.get("/api/v1/helper", headers=headers)).json()
+    assert mine["offers"][0]["turnaround_days"] is None
+
+
 async def test_a_turnaround_must_be_a_real_number_of_days(session):
     """`NULL` says "we will agree"; zero and minus three say nothing at all.
 

--- a/apps/api/tests/test_service_groups.py
+++ b/apps/api/tests/test_service_groups.py
@@ -287,6 +287,20 @@ def test_every_errand_says_what_it_covers() -> None:
     assert missing == [], f"errands with no checklist: {missing}"
 
 
+def test_written_work_says_what_it_takes_on() -> None:
+    """The same argument as the errand above, for the one `work` shape.
+
+    A written work has a subject and nothing else — no school, no hourly rate,
+    no question about meeting — so two people who write theses are one row read
+    twice unless they can say which works they take on.
+    """
+    from students_cz.db.seed import SERVICE_OPTIONS
+
+    works = {spec["code"] for spec in SERVICE_TYPES if spec["form"] == "work"}
+    missing = sorted(works - set(SERVICE_OPTIONS))
+    assert missing == [], f"written work with no checklist: {missing}"
+
+
 def test_seed_and_migration_agree_about_options() -> None:
     """The deploy runs migrations and never the seed.
 

--- a/apps/api/tests/test_service_groups.py
+++ b/apps/api/tests/test_service_groups.py
@@ -290,9 +290,10 @@ def test_every_errand_says_what_it_covers() -> None:
 def test_written_work_says_what_it_takes_on() -> None:
     """The same argument as the errand above, for the one `work` shape.
 
-    A written work has a subject and nothing else — no school, no hourly rate,
-    no question about meeting — so two people who write theses are one row read
-    twice unless they can say which works they take on.
+    A written work asks for no subject and no school — `requires_subject` is
+    false — no hourly rate and no question about meeting, so two people who
+    write theses are one row read twice unless they can say which works they
+    take on.
     """
     from students_cz.db.seed import SERVICE_OPTIONS
 

--- a/apps/web/scripts/check-scroll.mjs
+++ b/apps/web/scripts/check-scroll.mjs
@@ -86,11 +86,12 @@ const ROUTES = [
       // Where to push it. `name` is a label — the click routes call themselves
       // "helper detail" — and a label is not a URL.
       path: '/offer/prices',
-      // One that takes subjects and one that does not, so both shapes of card
-      // are on the screen being measured.
-      state: { picked: ['tutoring', 'insurance'] },
+      // One card of each form shape, so every question this screen can ask is
+      // on the screen being measured: a lesson takes subjects, an errand takes
+      // a checklist, and a written work takes a turnaround.
+      state: { picked: ['tutoring', 'insurance', 'writing'] },
       expect: '[class*="svcCard"]',
-      expectCount: 2,
+      expectCount: 3,
     },
   },
   { path: '/my-helper' },

--- a/apps/web/src/lib/generated/types.gen.ts
+++ b/apps/web/src/lib/generated/types.gen.ts
@@ -557,6 +557,10 @@ export type MyOfferOut = {
      * Note
      */
     note: string | null;
+    /**
+     * Turnaround Days
+     */
+    turnaround_days: number | null;
 };
 
 /**
@@ -592,6 +596,10 @@ export type OfferIn = {
      * Note
      */
     note?: string | null;
+    /**
+     * Turnaround Days
+     */
+    turnaround_days?: number | null;
 };
 
 /**
@@ -632,6 +640,10 @@ export type OfferOut = {
      * Note
      */
     note: string | null;
+    /**
+     * Turnaround Days
+     */
+    turnaround_days: number | null;
 };
 
 /**

--- a/apps/web/src/lib/turnaround.tsx
+++ b/apps/web/src/lib/turnaround.tsx
@@ -1,0 +1,27 @@
+import { Trans } from '@lingui/react/macro';
+
+/**
+ * How long a written work takes, in the words a person would use.
+ *
+ * A closed set and not a number field: five taps cover what people actually
+ * offer, a keyboard on a phone is a keyboard on a phone, and "asap" typed into
+ * a text box sorts against nothing. Anything outside them is «договоримся»,
+ * which is what `null` means — an answer, not a gap.
+ *
+ * Shared by the screen that asks and the page that shows, for the reason
+ * `workFormat` gives: two copies of a rule about wording are two copies that
+ * drift, and these two already have to agree that seven days is "a week".
+ */
+export const TURNAROUNDS = [1, 3, 7, 14, 30] as const;
+
+export function TurnaroundLabel({ days }: { days: number }) {
+  if (days === 1) return <Trans>За день</Trans>;
+  if (days === 3) return <Trans>3 дня</Trans>;
+  if (days === 7) return <Trans>Неделя</Trans>;
+  if (days === 14) return <Trans>Две недели</Trans>;
+  if (days === 30) return <Trans>Месяц</Trans>;
+  // A number the form cannot produce — an older row, or an import. Shown as
+  // what it is rather than rounded to the nearest chip, which would misquote
+  // somebody's promise.
+  return <Trans>{days} дн.</Trans>;
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -111,6 +111,8 @@ export interface Offer {
   options: string[];
   /** The helper's own words, in whatever language they wrote them. */
   note: string | null;
+  /** Only a written work has one. `null` reads as "the two of them agree". */
+  turnaround_days: number | null;
 }
 
 /** One row in the results list. */
@@ -342,6 +344,7 @@ export interface OfferInput {
   service_type_id: number;
   option_ids?: number[];
   note?: string | null;
+  turnaround_days?: number | null;
   subject_id?: number | null;
   institution_id?: number | null;
   price_amount?: number | null;
@@ -371,6 +374,7 @@ export interface MyOffer {
   service_type_id: number;
   option_ids: number[];
   note: string | null;
+  turnaround_days: number | null;
   service_type: string;
   service_type_name: string;
   subject_id: number | null;

--- a/apps/web/src/locales/cs/messages.po
+++ b/apps/web/src/locales/cs/messages.po
@@ -177,9 +177,17 @@ msgstr "Vzhled: podle systému. Klepnutím změníš"
 #~ msgid "Хочу помогать"
 #~ msgstr "Chci pomáhat"
 
+#: src/lib/turnaround.tsx
+msgid "Две недели"
+msgstr "Dva týdny"
+
 #: src/components/AppHeader.tsx
 msgid "Язык"
 msgstr "Jazyk"
+
+#: src/lib/turnaround.tsx
+msgid "Месяц"
+msgstr "Měsíc"
 
 #. placeholder {0}: str(p.subject)
 #: src/components/Phrase.tsx
@@ -315,6 +323,10 @@ msgid "Убери что-нибудь из уточнений выше или н
 msgstr "Odeber něco z upřesnění výše, nebo to napiš jinak."
 
 #: src/pages/OfferPrices.tsx
+msgid "Срок"
+msgstr "Termín"
+
+#: src/pages/OfferPrices.tsx
 msgid "Анкета скрыта — услуги сохранятся, но в каталоге их не будет. Включить видимость можно в анкете."
 msgstr "Profil je skrytý — služby se uloží, ale v katalogu nebudou. Viditelnost zapneš v profilu."
 
@@ -409,6 +421,10 @@ msgstr "za kus"
 #: src/pages/MyHelper.tsx
 msgid "В каталоге"
 msgstr "V katalogu"
+
+#: src/lib/turnaround.tsx
+msgid "Неделя"
+msgstr "Týden"
 
 #: src/components/Phrase.tsx
 #: src/lib/workFormat.tsx
@@ -592,6 +608,10 @@ msgid "Кто поможет с учёбой в Чехии"
 msgstr "Kdo pomůže se studiem v Česku"
 
 #: src/pages/Helper.tsx
+msgid "Срок: <0/>"
+msgstr "Termín: <0/>"
+
+#: src/pages/Helper.tsx
 msgid "Свободные окна"
 msgstr "Volné termíny"
 
@@ -695,6 +715,10 @@ msgstr "Nostrifikace"
 msgid "до {0}"
 msgstr "do {0}"
 
+#: src/lib/turnaround.tsx
+msgid "{days} дн."
+msgstr "{days} dní"
+
 #: src/pages/Profile.tsx
 msgid "Жизнь в Чехии"
 msgstr "Život v Česku"
@@ -707,6 +731,10 @@ msgstr "Přidat předmět — matan, čeština, fyzika"
 msgid "Репетиторы, подготовка к přijímačky, помощь на экзамене и нострификация — от студентов, которые это уже прошли."
 msgstr "Doučování, příprava na přijímačky, pomoc u zkoušky a nostrifikace — od studentů, kteří si tím prošli."
 
+#: src/pages/OfferPrices.tsx
+msgid "Пара слов о себе — что берёшь и чего не берёшь"
+msgstr "Pár slov o tobě — co bereš a co ne"
+
 #: src/components/Incoming.tsx
 msgid "Пока никто ничего не просит"
 msgstr "Zatím nikdo o nic nežádá"
@@ -714,6 +742,10 @@ msgstr "Zatím nikdo o nic nežádá"
 #: src/components/TabBar.tsx
 msgid "Разместить"
 msgstr "Přidat"
+
+#: src/pages/OfferPrices.tsx
+msgid "Договоримся"
+msgstr "Domluvíme se"
 
 #: src/pages/OfferPrices.tsx
 msgid "Сколько берёшь?"
@@ -803,6 +835,10 @@ msgstr "Napsat · {0} Kč"
 #: src/pages/Profile.tsx
 msgid "скрыта — в каталоге её не видно"
 msgstr "skrytá — v katalogu není vidět"
+
+#: src/lib/turnaround.tsx
+msgid "За день"
+msgstr "Do dne"
 
 #: src/pages/Request.tsx
 msgid "выбран"
@@ -941,6 +977,10 @@ msgstr "Cena za hodinu, Kč — nepovinné"
 #: src/pages/Request.tsx
 msgid "Откликов пока нет"
 msgstr "Zatím žádné odpovědi"
+
+#: src/lib/turnaround.tsx
+msgid "3 дня"
+msgstr "3 dny"
 
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -177,9 +177,17 @@ msgstr "Appearance: follows the system. Tap to change"
 #~ msgid "Хочу помогать"
 #~ msgstr "I want to help"
 
+#: src/lib/turnaround.tsx
+msgid "Две недели"
+msgstr "Two weeks"
+
 #: src/components/AppHeader.tsx
 msgid "Язык"
 msgstr "Language"
+
+#: src/lib/turnaround.tsx
+msgid "Месяц"
+msgstr "A month"
 
 #. placeholder {0}: str(p.subject)
 #: src/components/Phrase.tsx
@@ -315,6 +323,10 @@ msgid "Убери что-нибудь из уточнений выше или н
 msgstr "Drop one of the details above, or put it differently."
 
 #: src/pages/OfferPrices.tsx
+msgid "Срок"
+msgstr "Turnaround"
+
+#: src/pages/OfferPrices.tsx
 msgid "Анкета скрыта — услуги сохранятся, но в каталоге их не будет. Включить видимость можно в анкете."
 msgstr "Your profile is hidden — the services are saved but will not be in the catalog. You can turn visibility on there."
 
@@ -409,6 +421,10 @@ msgstr "per item"
 #: src/pages/MyHelper.tsx
 msgid "В каталоге"
 msgstr "In the catalog"
+
+#: src/lib/turnaround.tsx
+msgid "Неделя"
+msgstr "A week"
 
 #: src/components/Phrase.tsx
 #: src/lib/workFormat.tsx
@@ -592,6 +608,10 @@ msgid "Кто поможет с учёбой в Чехии"
 msgstr "Who can help you study in Czechia"
 
 #: src/pages/Helper.tsx
+msgid "Срок: <0/>"
+msgstr "Turnaround: <0/>"
+
+#: src/pages/Helper.tsx
 msgid "Свободные окна"
 msgstr "Open time slots"
 
@@ -695,6 +715,10 @@ msgstr "Nostrification"
 msgid "до {0}"
 msgstr "by {0}"
 
+#: src/lib/turnaround.tsx
+msgid "{days} дн."
+msgstr "{days} days"
+
 #: src/pages/Profile.tsx
 msgid "Жизнь в Чехии"
 msgstr "Life in Czechia"
@@ -707,6 +731,10 @@ msgstr "Add a subject — matan, čeština, physics"
 msgid "Репетиторы, подготовка к přijímačky, помощь на экзамене и нострификация — от студентов, которые это уже прошли."
 msgstr "Tutors, přijímačky prep, help at the exam and nostrification — from students who have been through it."
 
+#: src/pages/OfferPrices.tsx
+msgid "Пара слов о себе — что берёшь и чего не берёшь"
+msgstr "A couple of words about you — what you take on and what you do not"
+
 #: src/components/Incoming.tsx
 msgid "Пока никто ничего не просит"
 msgstr "Nobody is asking for anything yet"
@@ -714,6 +742,10 @@ msgstr "Nobody is asking for anything yet"
 #: src/components/TabBar.tsx
 msgid "Разместить"
 msgstr "Post"
+
+#: src/pages/OfferPrices.tsx
+msgid "Договоримся"
+msgstr "We will agree"
 
 #: src/pages/OfferPrices.tsx
 msgid "Сколько берёшь?"
@@ -803,6 +835,10 @@ msgstr "Message · {0} Kč"
 #: src/pages/Profile.tsx
 msgid "скрыта — в каталоге её не видно"
 msgstr "hidden — not visible in the catalog"
+
+#: src/lib/turnaround.tsx
+msgid "За день"
+msgstr "In a day"
 
 #: src/pages/Request.tsx
 msgid "выбран"
@@ -941,6 +977,10 @@ msgstr "Price per hour, Kč — optional"
 #: src/pages/Request.tsx
 msgid "Откликов пока нет"
 msgstr "No responses yet"
+
+#: src/lib/turnaround.tsx
+msgid "3 дня"
+msgstr "3 days"
 
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"

--- a/apps/web/src/locales/ru/messages.po
+++ b/apps/web/src/locales/ru/messages.po
@@ -177,9 +177,17 @@ msgstr "Оформление: как в системе. Нажми, чтобы �
 #~ msgid "Хочу помогать"
 #~ msgstr "Хочу помогать"
 
+#: src/lib/turnaround.tsx
+msgid "Две недели"
+msgstr "Две недели"
+
 #: src/components/AppHeader.tsx
 msgid "Язык"
 msgstr "Язык"
+
+#: src/lib/turnaround.tsx
+msgid "Месяц"
+msgstr "Месяц"
 
 #. placeholder {0}: str(p.subject)
 #: src/components/Phrase.tsx
@@ -315,6 +323,10 @@ msgid "Убери что-нибудь из уточнений выше или н
 msgstr "Убери что-нибудь из уточнений выше или напиши иначе."
 
 #: src/pages/OfferPrices.tsx
+msgid "Срок"
+msgstr "Срок"
+
+#: src/pages/OfferPrices.tsx
 msgid "Анкета скрыта — услуги сохранятся, но в каталоге их не будет. Включить видимость можно в анкете."
 msgstr "Анкета скрыта — услуги сохранятся, но в каталоге их не будет. Включить видимость можно в анкете."
 
@@ -409,6 +421,10 @@ msgstr "за штуку"
 #: src/pages/MyHelper.tsx
 msgid "В каталоге"
 msgstr "В каталоге"
+
+#: src/lib/turnaround.tsx
+msgid "Неделя"
+msgstr "Неделя"
 
 #: src/components/Phrase.tsx
 #: src/lib/workFormat.tsx
@@ -592,6 +608,10 @@ msgid "Кто поможет с учёбой в Чехии"
 msgstr "Кто поможет с учёбой в Чехии"
 
 #: src/pages/Helper.tsx
+msgid "Срок: <0/>"
+msgstr "Срок: <0/>"
+
+#: src/pages/Helper.tsx
 msgid "Свободные окна"
 msgstr "Свободные окна"
 
@@ -695,6 +715,10 @@ msgstr "Нострификация"
 msgid "до {0}"
 msgstr "до {0}"
 
+#: src/lib/turnaround.tsx
+msgid "{days} дн."
+msgstr "{days} дн."
+
 #: src/pages/Profile.tsx
 msgid "Жизнь в Чехии"
 msgstr "Жизнь в Чехии"
@@ -707,6 +731,10 @@ msgstr "Добавить предмет — матан, čeština, физика"
 msgid "Репетиторы, подготовка к přijímačky, помощь на экзамене и нострификация — от студентов, которые это уже прошли."
 msgstr "Репетиторы, подготовка к přijímačky, помощь на экзамене и нострификация — от студентов, которые это уже прошли."
 
+#: src/pages/OfferPrices.tsx
+msgid "Пара слов о себе — что берёшь и чего не берёшь"
+msgstr "Пара слов о себе — что берёшь и чего не берёшь"
+
 #: src/components/Incoming.tsx
 msgid "Пока никто ничего не просит"
 msgstr "Пока никто ничего не просит"
@@ -714,6 +742,10 @@ msgstr "Пока никто ничего не просит"
 #: src/components/TabBar.tsx
 msgid "Разместить"
 msgstr "Разместить"
+
+#: src/pages/OfferPrices.tsx
+msgid "Договоримся"
+msgstr "Договоримся"
 
 #: src/pages/OfferPrices.tsx
 msgid "Сколько берёшь?"
@@ -803,6 +835,10 @@ msgstr "Написать · {0} Kč"
 #: src/pages/Profile.tsx
 msgid "скрыта — в каталоге её не видно"
 msgstr "скрыта — в каталоге её не видно"
+
+#: src/lib/turnaround.tsx
+msgid "За день"
+msgstr "За день"
 
 #: src/pages/Request.tsx
 msgid "выбран"
@@ -941,6 +977,10 @@ msgstr "Цена за час, Kč — необязательно"
 #: src/pages/Request.tsx
 msgid "Откликов пока нет"
 msgstr "Откликов пока нет"
+
+#: src/lib/turnaround.tsx
+msgid "3 дня"
+msgstr "3 дня"
 
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"

--- a/apps/web/src/locales/uk/messages.po
+++ b/apps/web/src/locales/uk/messages.po
@@ -177,9 +177,17 @@ msgstr "Оформлення: як у системі. Натисни, щоб з�
 #~ msgid "Хочу помогать"
 #~ msgstr "Хочу допомагати"
 
+#: src/lib/turnaround.tsx
+msgid "Две недели"
+msgstr "Два тижні"
+
 #: src/components/AppHeader.tsx
 msgid "Язык"
 msgstr "Мова"
+
+#: src/lib/turnaround.tsx
+msgid "Месяц"
+msgstr "Місяць"
 
 #. placeholder {0}: str(p.subject)
 #: src/components/Phrase.tsx
@@ -315,6 +323,10 @@ msgid "Убери что-нибудь из уточнений выше или н
 msgstr "Прибери щось з уточнень вище або напиши інакше."
 
 #: src/pages/OfferPrices.tsx
+msgid "Срок"
+msgstr "Термін"
+
+#: src/pages/OfferPrices.tsx
 msgid "Анкета скрыта — услуги сохранятся, но в каталоге их не будет. Включить видимость можно в анкете."
 msgstr "Анкета прихована — послуги збережуться, але в каталозі їх не буде. Увімкнути видимість можна в анкеті."
 
@@ -409,6 +421,10 @@ msgstr "за штуку"
 #: src/pages/MyHelper.tsx
 msgid "В каталоге"
 msgstr "У каталозі"
+
+#: src/lib/turnaround.tsx
+msgid "Неделя"
+msgstr "Тиждень"
 
 #: src/components/Phrase.tsx
 #: src/lib/workFormat.tsx
@@ -592,6 +608,10 @@ msgid "Кто поможет с учёбой в Чехии"
 msgstr "Хто допоможе з навчанням у Чехії"
 
 #: src/pages/Helper.tsx
+msgid "Срок: <0/>"
+msgstr "Термін: <0/>"
+
+#: src/pages/Helper.tsx
 msgid "Свободные окна"
 msgstr "Вільні вікна"
 
@@ -695,6 +715,10 @@ msgstr "Нострифікація"
 msgid "до {0}"
 msgstr "до {0}"
 
+#: src/lib/turnaround.tsx
+msgid "{days} дн."
+msgstr "{days} дн."
+
 #: src/pages/Profile.tsx
 msgid "Жизнь в Чехии"
 msgstr "Життя в Чехії"
@@ -707,6 +731,10 @@ msgstr "Додати предмет — матан, čeština, фізика"
 msgid "Репетиторы, подготовка к přijímačky, помощь на экзамене и нострификация — от студентов, которые это уже прошли."
 msgstr "Репетитори, підготовка до přijímačky, допомога на іспиті та нострифікація — від студентів, які це вже пройшли."
 
+#: src/pages/OfferPrices.tsx
+msgid "Пара слов о себе — что берёшь и чего не берёшь"
+msgstr "Пара слів про себе — що береш і чого не береш"
+
 #: src/components/Incoming.tsx
 msgid "Пока никто ничего не просит"
 msgstr "Поки ніхто нічого не просить"
@@ -714,6 +742,10 @@ msgstr "Поки ніхто нічого не просить"
 #: src/components/TabBar.tsx
 msgid "Разместить"
 msgstr "Розмістити"
+
+#: src/pages/OfferPrices.tsx
+msgid "Договоримся"
+msgstr "Домовимось"
 
 #: src/pages/OfferPrices.tsx
 msgid "Сколько берёшь?"
@@ -803,6 +835,10 @@ msgstr "Написати · {0} Kč"
 #: src/pages/Profile.tsx
 msgid "скрыта — в каталоге её не видно"
 msgstr "прихована — у каталозі її не видно"
+
+#: src/lib/turnaround.tsx
+msgid "За день"
+msgstr "За день"
 
 #: src/pages/Request.tsx
 msgid "выбран"
@@ -941,6 +977,10 @@ msgstr "Ціна за годину, Kč — необов'язково"
 #: src/pages/Request.tsx
 msgid "Откликов пока нет"
 msgstr "Відгуків поки немає"
+
+#: src/lib/turnaround.tsx
+msgid "3 дня"
+msgstr "3 дні"
 
 #: src/components/Phrase.tsx
 msgid "Помощь нужна до экзамена или на нём?"

--- a/apps/web/src/pages/Helper.tsx
+++ b/apps/web/src/pages/Helper.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/Ui';
 import { hapticSuccess, useMainButton } from '@/hooks/useTelegram';
 import { api } from '@/lib/api';
+import { TurnaroundLabel } from '@/lib/turnaround';
 import type { HelperDetail } from '@/lib/types';
 
 /**
@@ -160,7 +161,7 @@ export default function HelperPage() {
       {/* What an errand actually covers, in our words, and then in theirs. A
           chip saying "Insurance" is the same chip for everybody offering it;
           these lines are the difference between two people. */}
-      {coveredBy(data.offers).map(({ code, name, options, note }) => (
+      {coveredBy(data.offers).map(({ code, name, options, note, turnaround }) => (
         <div key={`covers-${code}`}>
           <Label>{name}</Label>
           {options.length > 0 ? (
@@ -170,8 +171,19 @@ export default function HelperPage() {
               ))}
             </ul>
           ) : null}
-          {note ? (
+          {/* Only a written work carries one, and it is the question asked
+              straight after the price, so it sits above their own words. */}
+          {turnaround != null ? (
             <div style={{ marginTop: options.length > 0 ? 8 : 0 }}>
+              <Sub>
+                <Trans>
+                  Срок: <TurnaroundLabel days={turnaround} />
+                </Trans>
+              </Sub>
+            </div>
+          ) : null}
+          {note ? (
+            <div style={{ marginTop: options.length > 0 || turnaround != null ? 8 : 0 }}>
               <Sub>{note}</Sub>
             </div>
           ) : null}
@@ -298,16 +310,23 @@ function withIntro(url: string, data: HelperDetail | undefined): string {
 function coveredBy(offers: HelperDetail['offers']) {
   const out = new Map<
     string,
-    { code: string; name: string; options: string[]; note: string | null }
+    {
+      code: string;
+      name: string;
+      options: string[];
+      note: string | null;
+      turnaround: number | null;
+    }
   >();
   for (const offer of offers) {
-    if (!offer.options.length && !offer.note) continue;
+    if (!offer.options.length && !offer.note && offer.turnaround_days == null) continue;
     if (out.has(offer.service_type)) continue;
     out.set(offer.service_type, {
       code: offer.service_type,
       name: offer.service_type_name,
       options: offer.options,
       note: offer.note,
+      turnaround: offer.turnaround_days,
     });
   }
   return [...out.values()];

--- a/apps/web/src/pages/MyHelper.tsx
+++ b/apps/web/src/pages/MyHelper.tsx
@@ -440,6 +440,7 @@ interface Draft {
   institution_name: string | null;
   option_ids: number[];
   note: string | null;
+  turnaround_days: number | null;
   price: string;
   unit: PriceUnit;
   langs: string[];
@@ -459,6 +460,7 @@ function toDraft(offer: MyOffer): Draft {
     institution_name: offer.institution_name,
     option_ids: offer.option_ids,
     note: offer.note,
+    turnaround_days: offer.turnaround_days,
     // Rounded, because the field holds digits: an older row saved as 550.5
     // would otherwise render a decimal point the input then refuses to accept.
     price: offer.price_amount == null ? '' : String(Math.round(offer.price_amount)),
@@ -477,10 +479,11 @@ function toOffer(row: Draft): OfferInput {
     price_amount: row.price ? Number(row.price) : null,
     price_unit: row.unit,
     langs: row.langs,
-    // Carried straight back: this screen does not edit a checklist, and the
-    // server would keep it anyway, but sending what we hold means one save
-    // never depends on the other end remembering.
+    // Carried straight back: this screen edits neither the checklist nor the
+    // turnaround, and the server would keep both anyway, but sending what we
+    // hold means one save never depends on the other end remembering.
     option_ids: row.option_ids,
     note: row.note,
+    turnaround_days: row.turnaround_days,
   };
 }

--- a/apps/web/src/pages/OfferPrices.tsx
+++ b/apps/web/src/pages/OfferPrices.tsx
@@ -25,6 +25,7 @@ import {
 import { hapticSelection, hapticSuccess, useMainButton } from '@/hooks/useTelegram';
 import { api } from '@/lib/api';
 import { groupRuns } from '@/lib/groups';
+import { TURNAROUNDS, TurnaroundLabel } from '@/lib/turnaround';
 import type {
   Institution,
   MyOffer,
@@ -206,6 +207,34 @@ export default function OfferPricesPage() {
       );
     });
   };
+
+  // Like the checklist, this belongs to the service and not to one of its
+  // rows, and tapping the chip that is already on clears it back to
+  // «договоримся» — a person who mis-taps has no other way back.
+  const setTurnaround = (type: ServiceType, days: number) => {
+    hapticSelection();
+    setRows((current) =>
+      current.map((row) =>
+        row.service_type_id === type.id
+          ? { ...row, turnaround_days: row.turnaround_days === days ? null : days }
+          : row,
+      ),
+    );
+  };
+
+  const clearTurnaround = (type: ServiceType) => {
+    hapticSelection();
+    setRows((current) =>
+      current.map((row) =>
+        row.service_type_id === type.id ? { ...row, turnaround_days: null } : row,
+      ),
+    );
+  };
+
+  const notePlaceholder = (type: ServiceType) =>
+    type.form_shape === 'work'
+      ? t`Пара слов о себе — что берёшь и чего не берёшь`
+      : t`Пара слов о себе — что делаешь и как быстро`;
 
   const setNote = (type: ServiceType, note: string) => {
     setRows((current) =>
@@ -428,15 +457,50 @@ export default function OfferPricesPage() {
                           }
                         />
                       ))}
+                      {/* Only a written work is asked when. A lesson happens
+                          when the two of them agree, and an errand takes as
+                          long as the office queue — asking either would be
+                          asking somebody to promise the queue. */}
+                      {type.form_shape === 'work' ? (
+                        <div style={{ marginTop: 4 }}>
+                          <Label>
+                            <Trans>Срок</Trans>
+                          </Label>
+                          <Chips>
+                            {TURNAROUNDS.map((days) => (
+                              <ChipView
+                                key={days}
+                                active={mineHere[0]?.turnaround_days === days}
+                                onClick={() => setTurnaround(type, days)}
+                              >
+                                <TurnaroundLabel days={days} />
+                              </ChipView>
+                            ))}
+                            {/* Nothing chosen is «договоримся», so the chip is
+                                the state rather than a sixth answer: it reads
+                                as chosen from the start because it is. */}
+                            <ChipView
+                              active={mineHere[0]?.turnaround_days == null}
+                              onClick={() => clearTurnaround(type)}
+                            >
+                              <Trans>Договоримся</Trans>
+                            </ChipView>
+                          </Chips>
+                        </div>
+                      ) : null}
+
                       {type.options.length > 0 ? (
                         <div className={`${ui.field} ${ui.fieldTall}`}>
                           <textarea
                             value={mineHere[0]?.note ?? ''}
                             onChange={(event) => setNote(type, event.target.value)}
-                            placeholder={t`Пара слов о себе — что делаешь и как быстро`}
+                            // A written work has just been asked how fast, so
+                            // inviting it again in prose asks for the same
+                            // answer twice and gets two that disagree.
+                            placeholder={notePlaceholder(type)}
                             // The same words as the placeholder, which stops
                             // being the name the moment anything is typed.
-                            aria-label={t`Пара слов о себе — что делаешь и как быстро`}
+                            aria-label={notePlaceholder(type)}
                             rows={3}
                             maxLength={600}
                             style={{
@@ -597,6 +661,8 @@ interface Draft {
   institution_name: string | null;
   option_ids: number[];
   note: string;
+  // `null` is «договоримся», which is an answer, so the field is never absent.
+  turnaround_days: number | null;
   price: string;
   unit: PriceUnit;
   langs: string[];
@@ -647,6 +713,7 @@ function blank(type: ServiceType): Draft {
     institution_name: null,
     option_ids: [],
     note: '',
+    turnaround_days: null,
     price: '',
     // From the server, not guessed here: a thesis priced by the hour reads as
     // ten times too little.
@@ -665,6 +732,7 @@ function fromOffer(type: ServiceType, offer: MyOffer): Draft {
     institution_name: offer.institution_name,
     option_ids: offer.option_ids,
     note: offer.note ?? '',
+    turnaround_days: offer.turnaround_days,
     // Rounded, because the field holds digits: an older row saved as 550.5
     // would render a decimal point the input then refuses to accept.
     price: offer.price_amount == null ? '' : String(Math.round(offer.price_amount)),
@@ -684,6 +752,7 @@ function keep(offer: MyOffer): OfferInput {
     langs: offer.langs,
     option_ids: offer.option_ids,
     note: offer.note,
+    turnaround_days: offer.turnaround_days,
   };
 }
 
@@ -699,5 +768,6 @@ function toOffer(row: Draft): OfferInput {
     langs: row.langs,
     option_ids: row.option_ids,
     note: row.note.trim() || null,
+    turnaround_days: row.turnaround_days,
   };
 }

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -99,7 +99,7 @@ because the two that differ are the ones that matter:
 | shape | which kinds | what the form asks |
 | --- | --- | --- |
 | `lesson` | tutoring, languages, exam preparation, entrance exams | a subject, a school where one is required, an hourly price, online or in person, where |
-| `work` | written work | a price per work, and nothing about meeting |
+| `work` | written work | a price per work, a turnaround, and nothing about meeting |
 | `errand` | nostrification, help during the exam, and all five of `life` | a price, remote or alongside you, where |
 
 Help *during* an exam is the clearest case: it sits on the `entrance` shelf
@@ -111,7 +111,7 @@ that per service type, so five errands are priced per case while nostrification
 and help during an exam are priced by the hour. The shape decides which
 questions exist, not what the answers are measured in.
 
-A `work` is always remote, so its form does not ask. For the other two the
+A `work` is always remote, so its form does not ask how you meet. For the other two the
 question is the same three answers under different words: `work_format` is
 `online` / `offline` / `both`, which reads as online-or-in-person for a lesson
 and remotely-or-alongside-you for an errand. One column, worded by what the
@@ -139,9 +139,24 @@ deleted, for the reason `languages` gives: the array holds plain integers and
 references nothing, so a deleted row would leave an offer pointing at an option
 with no name to show.
 
-The checklist belongs to the service type and not to the shape. Every errand has
-one today, and nothing stops a lesson growing one — "first lesson free" is the
-obvious candidate — which is why the column sits where it does.
+The checklist belongs to the service type and not to the shape, which is why the
+column sits where it does: every errand has one, and so does written work, whose
+lines are the kinds of work taken on rather than the errands run. Nothing stops
+a lesson growing one — "first lesson free" is the obvious candidate.
+
+**`offers.turnaround_days`** is how long the work takes, and `NULL` means the
+two of them will agree rather than that nobody knows: a written work is the one
+kind of help where "when" is the question asked straight after "how much", and
+a person who will not commit to a number is saying something, not omitting it.
+
+It is a column and not a key in `offers.attrs`, which is where a turnaround
+would naturally go — `attrs` is the bag for per-service-type extras that do not
+deserve columns. Two reasons it does not go there. No schema exposes `attrs`, so
+a client would be reading an untyped bag the generated types cannot check. And
+the question worth asking of a turnaround is a range — who can do it inside a
+week — which a small integer answers and a JSONB key does not. Days, not a free
+text, for the same reason: "asap" sorts against nothing. Nothing indexes the
+column yet, because nothing queries it until search does.
 
 ## Trees without recursion
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -149,6 +149,11 @@ two of them will agree rather than that nobody knows: a written work is the one
 kind of help where "when" is the question asked straight after "how much", and
 a person who will not commit to a number is saying something, not omitting it.
 
+Only a `work` is asked, and only a `work` may answer: a turnaround sent for any
+other kind of help is dropped on the way in, the same filter the checklist gets
+and for the same reason — a profile reading «Срок: неделя» under a lesson would
+be answering a question that form never asked.
+
 It is a column and not a key in `offers.attrs`, which is where a turnaround
 would naturally go — `attrs` is the bag for per-service-type extras that do not
 deserve columns. Two reasons it does not go there. No schema exposes `attrs`, so


### PR DESCRIPTION
Docs updated first: docs/data-model.md

`writing` is the only `work`-shaped service, and its form asked for a price and
nothing else — so two people who write theses were one row read twice. The
shape's own doc promised more than the form delivered: `work` was "a price per
work, and nothing about meeting", which says what it does *not* ask.

Two things fill it, and both already had a home in the schema.

**A checklist**, through the tables PR #36 added — the checklist belongs to the
service type and not to the shape, which is exactly why the column sits there.
Six lines in four languages: семестровка и реферат, бакалаврская, диплом и
магистерская, презентация к защите, правки после проверки, оформление по нормам
вуза. In the migration as well as the seed, because the deploy runs `alembic
upgrade head` and never `seed.py`.

**`offers.turnaround_days`** — a small integer, nullable, with a check
constraint. `NULL` is an answer and not a gap: it says the two of them will
agree, which is why zero is refused rather than accepted as a synonym.

It is a column and not a key in `offers.attrs`, which named "turnaround days"
as its own example. `attrs` is exposed by no schema, so a client would be
reading an untyped bag its generated types cannot check, and the question worth
asking of a turnaround is a range — who can do it inside a week — which a small
integer answers and a JSONB key does not. Nothing indexes it yet, because
nothing queries it until search does.

Only a `work` may answer: a turnaround sent for any other kind of help is
dropped on the way in, the same filter the checklist gets. A profile reading
«Срок: неделя» under a lesson would be answering a question that form never
asked.

On screen: five chips — за день, 3 дня, неделя, две недели, месяц — plus
«Договоримся», which is what `null` means and so reads as chosen from the start.
Five taps cover what people actually offer, and a keyboard on a phone is a
keyboard on a phone. The note beside them stops asking «как быстро» on a work
card, which would ask for the same answer twice and get two that disagree.

## Verification

`make check` green: 336 API tests, ruff, ty, biome, tsc, lingui `--strict`, and
`make contract` against a freshly dumped OpenAPI document. The migration was run
upgrade → downgrade → upgrade on a throwaway database built from migrations
only, `alembic check` reports no drift, and the seed runs twice over it without
duplicating a row — 31 active checklist lines, 124 translations, `writing` with
six.

`check-scroll.mjs` passes at all three phone sizes, and its `/offer/prices`
fixture now picks one service of each shape, so the turnaround block is on the
screen being measured rather than beside it.

Four rules are mutation-tested — each fails when its own rule is removed: the
check constraint, the `model_fields_set` guard, the shape filter, and the
seed's retirement rule.

Independent review: approved with no findings, after one round that found two
real problems (the turnaround was accepted on any service type; two comments
claimed a written work has a subject, which it does not).

## Out of scope

- Search does not filter by turnaround, and nothing indexes the column.
- The parser learns no words for «за неделю».
- Per-line pricing on a checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL
