### PR TITLE
The parser reads the words people type

### DIFF
--- a/apps/api/seeds/subjects.json
+++ b/apps/api/seeds/subjects.json
@@ -1540,8 +1540,6 @@
           "synonyms": [
             "приемка цвут",
             "prijimacky cvut",
-            "prijimacky",
-            "приймачки",
             "поступление цвут",
             "prijimacky vut",
             "prijimacky technika",
@@ -1626,7 +1624,11 @@
             "medical admissions",
             "biologie chemie prijimacky",
             "вступ на медицину",
-            "lekarska fakulta prijimacky"
+            "lekarska fakulta prijimacky",
+            "prijimacky na medicinu",
+            "приймачки на медицину",
+            "поступление на медицину",
+            "vstup na medicinu"
           ]
         },
         {

--- a/apps/api/src/students_cz/db/migrations/versions/20260803_4e1b96d7c8a2_a_category_word_is_not_a_synonym.py
+++ b/apps/api/src/students_cz/db/migrations/versions/20260803_4e1b96d7c8a2_a_category_word_is_not_a_synonym.py
@@ -29,28 +29,61 @@ depends_on: str | Sequence[str] | None = None
 SUBJECT = "prijimacky-technicke-vs"
 WORDS = ("prijimacky", "приймачки")
 
+# The other half of the same rule: the phrases people type for the medicine
+# shelf, which the technical subject used to answer. Phrases and never the bare
+# word — "медицина" belongs to the study group above.
+MEDICINE = "prijimacky-medicina"
+PHRASES = (
+    "prijimacky na medicinu",
+    "приймачки на медицину",
+    "поступление на медицину",
+    "vstup na medicinu",
+)
 
-def upgrade() -> None:
-    bind = op.get_bind()
-    for word in WORDS:
-        bind.execute(
-            sa.text(
-                "UPDATE subjects SET synonyms = array_remove(synonyms, :word)"
-                " WHERE slug = :slug"
-            ),
-            {"word": word, "slug": SUBJECT},
-        )
+
+# Declared under these two names so `tests/test_service_groups.py` can hold the
+# seed and the migrations to the same synonyms: reference data lives in both
+# places on purpose, and the pair drifting is invisible until a production query
+# answers differently from every developer's.
+SYNONYM_REMOVES: dict[str, tuple[str, ...]] = {SUBJECT: WORDS}
+SYNONYM_ADDS: dict[str, tuple[str, ...]] = {MEDICINE: PHRASES}
 
 
-def downgrade() -> None:
-    bind = op.get_bind()
-    for word in WORDS:
-        # Appended only when it is not already there, so a downgrade after a
-        # re-seed does not leave the word twice.
+def _add(bind, slug: str, words: tuple[str, ...]) -> None:
+    for word in words:
+        # Appended only when it is not already there, so running this against a
+        # database somebody had already seeded does not leave the word twice.
         bind.execute(
             sa.text(
                 "UPDATE subjects SET synonyms = synonyms || :word"
                 " WHERE slug = :slug AND NOT (synonyms @> ARRAY[:word]::text[])"
             ),
-            {"word": word, "slug": SUBJECT},
+            {"word": word, "slug": slug},
         )
+
+
+def _remove(bind, slug: str, words: tuple[str, ...]) -> None:
+    for word in words:
+        bind.execute(
+            sa.text(
+                "UPDATE subjects SET synonyms = array_remove(synonyms, :word)"
+                " WHERE slug = :slug"
+            ),
+            {"word": word, "slug": slug},
+        )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    for slug, words in SYNONYM_REMOVES.items():
+        _remove(bind, slug, words)
+    for slug, words in SYNONYM_ADDS.items():
+        _add(bind, slug, words)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    for slug, words in SYNONYM_ADDS.items():
+        _remove(bind, slug, words)
+    for slug, words in SYNONYM_REMOVES.items():
+        _add(bind, slug, words)

--- a/apps/api/src/students_cz/db/migrations/versions/20260803_4e1b96d7c8a2_a_category_word_is_not_a_synonym.py
+++ b/apps/api/src/students_cz/db/migrations/versions/20260803_4e1b96d7c8a2_a_category_word_is_not_a_synonym.py
@@ -1,0 +1,56 @@
+"""A category word is not a synonym of one member of it
+
+`prijimacky` and `приймачки` sat in `subjects.synonyms` on «Поступление в
+технические вузы», and a synonym scores 1.00 — so every «přijímačky …» query
+came back filtered by maths and physics, including one that said medicine. The
+word names a kind of help and reaches `entrance_prep` through the parser's
+keyword table, which is where a category word belongs.
+
+Here as well as in `seeds/subjects.json` because the deploy runs `alembic
+upgrade head` and never the seed: production carries both synonyms today.
+
+Revision ID: 4e1b96d7c8a2
+Revises: c37f5a8e2b14
+Create Date: 2026-08-03
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "4e1b96d7c8a2"
+down_revision: str | Sequence[str] | None = "c37f5a8e2b14"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+SUBJECT = "prijimacky-technicke-vs"
+WORDS = ("prijimacky", "приймачки")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    for word in WORDS:
+        bind.execute(
+            sa.text(
+                "UPDATE subjects SET synonyms = array_remove(synonyms, :word)"
+                " WHERE slug = :slug"
+            ),
+            {"word": word, "slug": SUBJECT},
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    for word in WORDS:
+        # Appended only when it is not already there, so a downgrade after a
+        # re-seed does not leave the word twice.
+        bind.execute(
+            sa.text(
+                "UPDATE subjects SET synonyms = synonyms || :word"
+                " WHERE slug = :slug AND NOT (synonyms @> ARRAY[:word]::text[])"
+            ),
+            {"word": word, "slug": SUBJECT},
+        )

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -165,42 +165,6 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "написати",
         "курсову",
     ),
-    # Above `tutoring`, because the two share every word that asks for a
-    # teacher and only these say which subject: "репетитор по чешскому" is a
-    # language lesson, and reading it as plain tutoring loses the one thing it
-    # said.
-    #
-    # Phrases and not the bare adjective, which is the trap here: this block
-    # sits above the non-study one, so a lone "чешск" made "нужна чешская виза"
-    # a language lesson — a study kind with no subject, which is the empty
-    # screen that block's own comment exists to prevent. A language names this
-    # kind of help only next to the asking.
-    "language_tutoring": (
-        "репетитор по чешск",
-        "репетитор по английск",
-        "репетитор по немецк",
-        "репетитор з чеськ",
-        "репетитор з англійськ",
-        "репетитор з німецьк",
-        "doucovani cestiny",
-        "doucovani anglictiny",
-        "doucovani nemciny",
-        "czech tutor",
-        "english tutor",
-        "german tutor",
-        "language tutor",
-        # A course, named as one. Not "pro cizince" and not "для иностранцев":
-        # those belong to whatever comes before them, and "zdravotní pojištění
-        # pro cizince" is the literal name of the insurance product this same
-        # change taught the parser to recognise by its brand.
-        "kurz cestiny",
-        "kurz anglictiny",
-        "kurz nemciny",
-        "курсы чешского",
-        "курсы английского",
-        "языковые курсы",
-        "мовні курси",
-    ),
     "tutoring": (
         "репетитор",
         "объяснить",
@@ -321,6 +285,42 @@ ASIDES = SUBJECTLESS - {"translation"}
 # nothing about *which* kind of help. It counts as tutoring only when the text
 # gives no other clue — see _match_service.
 WEAK_HELP: tuple[str, ...] = ("помо", "pomo", "help", "допомо", "нужен", "потрібн")
+
+# The languages people learn, in the four interface languages plus the
+# transliterations, and the words that make a course a course.
+#
+# Not entries in the table above, and that is the whole point: the words naming
+# a language also describe *whose* bank, *whose* visa and *whose* dormitory, so
+# a keyword high enough to beat plain tutoring took «нужна чешская виза» and
+# «zdravotní pojištění pro cizince» with it. Written as a refinement instead —
+# see `_match_service` — it can only narrow a match that was already a lesson,
+# or name a course that nothing else claimed.
+LANGUAGE_WORDS: tuple[str, ...] = (
+    "чешск",
+    "чеськ",
+    "cestin",
+    "cestiny",
+    "английск",
+    "англійськ",
+    "anglict",
+    "немецк",
+    "німецьк",
+    "nemcin",
+    Word("czech"),
+    Word("english"),
+    Word("german"),
+    "язык",
+    "jazyk",
+    Word("мова"),
+    Word("мови"),
+    Word("мову"),
+)
+
+# A course, in any of the forms these decline into: both halves are matched
+# independently, so "курсы чешского", "kurzu cestiny" and "czech language
+# course" all reach the same place, which a multi-word keyword cannot do —
+# it tolerates inflection only on its last word.
+COURSE_WORDS: tuple[str, ...] = ("курс", "курси", "kurz", "course", "kurs")
 
 # Words that put an exam in the picture without saying whether the help is
 # wanted before it or during it. When one of these appears next to nothing but
@@ -454,13 +454,38 @@ def _match_service(
     SUBJECTLESS at the call site.
     """
     tokens = tokenise(norm)
+
+    def present(words: tuple[str, ...]) -> str | None:
+        for word in words:
+            match = is_whole_word if isinstance(word, Word) else starts_a_word
+            if match(tokens, word):
+                return word
+        return None
+
     for code, keywords in SERVICE_KEYWORDS.items():
         if code in ignore:
             continue
         for keyword in keywords:
             match = is_whole_word if isinstance(keyword, Word) else starts_a_word
             if match(tokens, keyword):
+                # A language beside an ask for a teacher is a language lesson,
+                # and reading it as plain tutoring loses the one thing the query
+                # said. A refinement rather than a keyword of its own, because
+                # the words that name a language describe far more than lessons
+                # — see LANGUAGE_WORDS. It only ever narrows a lesson.
+                if code == "tutoring" and "language_tutoring" not in ignore:
+                    language = present(LANGUAGE_WORDS)
+                    if language:
+                        return "language_tutoring", language
                 return code, keyword
+
+    # Nothing named a kind of help, but a course in a language is one: "kurzy
+    # cestiny", "курсы чешского", "czech language course". Both halves are
+    # matched on their own, which is what carries every form of both.
+    if "language_tutoring" not in ignore and present(COURSE_WORDS):
+        language = present(LANGUAGE_WORDS)
+        if language:
+            return "language_tutoring", language
 
     if any(starts_a_word(tokens, verb) for verb in WEAK_HELP):
         if any(starts_a_word(tokens, word) for word in EXAM_MENTION):

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -304,6 +304,12 @@ LANGUAGE_WORDS: tuple[str, ...] = (
     "чешск",
     "чеськ",
     "cestin",
+    # The adjective as well as the noun: "doucovani ceskeho jazyka" is how it is
+    # said in Czech, and the Russian and Ukrainian entries already carry both
+    # forms because their adjective is the stem.
+    "cesk",
+    "anglick",
+    "nemeck",
     "английск",
     "англійськ",
     "anglict",
@@ -565,6 +571,12 @@ FILLER_WORDS: frozenset[str] = frozenset(
         "in",
         "with",
         "and",
+        "i",
+        "am",
+        "is",
+        "are",
+        "to",
+        "of",
         "my",
         "me",
     )

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -102,6 +102,9 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "prijimaci",
         "entrance",
         "вступн",
+        # The Ukrainian spelling, which used to reach `entrance_prep` only
+        # because it was a synonym of one subject on this shelf.
+        "приймач",
         "tsp",
         "osp",
         "nastupni",
@@ -133,6 +136,10 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
     "nostrification": (
         "нострифик",
         "nostrifik",
+        # The English spells it with a c — "nostrification" — so the stem above
+        # misses it entirely, and the word that names this kind of help in
+        # English reached nothing at all.
+        "nostrific",
         "аттестат",
         "признание диплома",
         "uznani",
@@ -157,6 +164,31 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "thesis",
         "написати",
         "курсову",
+    ),
+    # Above `tutoring`, because the two share every word that asks for a teacher
+    # and only these say which subject: "репетитор по чешскому" is a language
+    # lesson, and reading it as plain tutoring loses the one thing it said.
+    "language_tutoring": (
+        "чешск",
+        "чеськ",
+        "cestin",
+        "češtin",
+        "cestiny",
+        "английск",
+        "англійськ",
+        "anglict",
+        "angličt",
+        Word("english"),
+        "немецк",
+        "німецьк",
+        "nemcin",
+        "němčin",
+        Word("german"),
+        # How a language course is named rather than the language itself.
+        "pro cizince",
+        "язык для иностран",
+        "language tutor",
+        "jazykov",
     ),
     "tutoring": (
         "репетитор",
@@ -189,6 +221,16 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "pojisten",
         "pojistk",
         "insurance",
+        # The names people actually say. Words and not stems, for the reason
+        # above and one more: "vzp" begins "vzpomínky", "vzpoura" and "vzpírání".
+        # Only the health insurers a student meets, and only the names that are
+        # nothing else in the catalog — "maxima" is a maths word, so it is not
+        # here.
+        Word("vzp"),
+        Word("pvzp"),
+        Word("slavia"),
+        Word("uniqa"),
+        Word("ergo"),
     ),
     "bank_letter": (
         "справка из банк",

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -16,7 +16,13 @@ from datetime import date
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from students_cz.services.lookup import Match, find_institutions, find_subjects, normalise
+from students_cz.services.lookup import (
+    Match,
+    find_institutions,
+    find_subjects,
+    normalise,
+    transliterate,
+)
 
 _NON_WORD = re.compile(r"[^a-z0-9\u0400-\u04ff]+")
 
@@ -453,6 +459,11 @@ async def parse(
         spoken_for = [keyword or "", language or ""]
         if result.institution:
             spoken_for.append(result.institution.label)
+        if result.deadline:
+            # The month it read, and only when it read one.
+            spoken_for.extend(
+                month for month in MONTHS if starts_a_word(tokenise(norm), month)
+            )
         if language and not _left_over(norm, *spoken_for):
             result.service_type = "language_tutoring"
 
@@ -558,21 +569,36 @@ CURRENCY_WORDS: frozenset[str] = frozenset(
 
 
 def _left_over(norm: str, *accounted: str) -> str:
-    """What the query still names once these words and the filler are gone."""
+    """What the query still names once these words and the filler are gone.
+
+    An accounted word is removed as it stands and, failing that, by its
+    transliteration: a school resolves through its code or through the
+    transliterated query, so "на чвуте" carries none of the label's characters
+    and would otherwise be left over as a word that names something.
+    """
     text_left = norm
     for word in accounted:
         if word:
             text_left = _without(text_left, word)
-    tokens = tokenise(text_left).split()
+    tokens = [
+        token
+        for token in tokenise(text_left).split()
+        if not any(
+            word and transliterate(token).startswith(transliterate(normalise(word)))
+            for word in accounted
+        )
+    ]
     rest = [
         token
         for token in tokens
-        # A number is a price or a day, and both are fields of their own by the
-        # time anyone asks this — as is a month and the currency beside it.
+        # A bare number is a price or a day and never a subject, and the
+        # currency beside it is neither. The month is *not* discounted here —
+        # "мар" is March and the first three letters of "маркетингу", and a
+        # month word alone is not a deadline anyway: the caller passes the one
+        # it actually parsed.
         if not token.isdigit()
         and token not in FILLER_WORDS
         and token not in CURRENCY_WORDS
-        and not any(token.startswith(month) for month in MONTHS)
         and not any(token.startswith(normalise(word)) for word in FILLER)
     ]
     return " ".join(rest)

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -14,6 +14,7 @@ import re
 from dataclasses import dataclass, field
 from datetime import date
 
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from students_cz.services.lookup import Match, find_institutions, find_subjects, normalise
@@ -286,20 +287,18 @@ ASIDES = SUBJECTLESS - {"translation"}
 # gives no other clue — see _match_service.
 WEAK_HELP: tuple[str, ...] = ("помо", "pomo", "help", "допомо", "нужен", "потрібн")
 
-# The languages people learn, in the four interface languages plus the
-# transliterations, and the words that make a course a course.
+# The languages people learn, for the one case the subject cannot settle: a
+# query that says which language but not which level — "репетитор по чешскому" —
+# resolves no subject at all, because a bare «чешский» names five of them and
+# belongs to none.
 #
-# Not entries in the table above, and that is the whole point: the words naming
-# a language also describe *whose* bank, *whose* visa and *whose* dormitory, so
-# a keyword high enough to beat plain tutoring took «нужна чешская виза» and
-# «zdravotní pojištění pro cizince» with it. Written as a refinement instead —
-# see `_match_service` — it can only narrow a match that was already a lesson,
-# or name a course that nothing else claimed.
+# Used only there. High in the keyword table these words took «нужна чешская
+# виза» and «zdravotní pojištění pro cizince» with them, because a language also
+# says whose bank and whose visa.
 LANGUAGE_WORDS: tuple[str, ...] = (
     "чешск",
     "чеськ",
     "cestin",
-    "cestiny",
     "английск",
     "англійськ",
     "anglict",
@@ -309,11 +308,6 @@ LANGUAGE_WORDS: tuple[str, ...] = (
     Word("czech"),
     Word("english"),
     Word("german"),
-    "язык",
-    "jazyk",
-    Word("мова"),
-    Word("мови"),
-    Word("мову"),
 )
 
 # A course, in any of the forms these decline into: both halves are matched
@@ -418,6 +412,32 @@ async def parse(
         else:
             subjects = []
 
+    # A language *as the subject* is a language lesson rather than plain
+    # tutoring. Decided here and not in `_match_service`, because it takes the
+    # subject to tell the two apart: "нужен репетитор по чешскому" is one, and
+    # "нужен репетитор по матану на чешском" is maths taught in Czech — read as
+    # a language lesson it would carry a maths subject no language offer has,
+    # which is an empty screen for a query that worked.
+    #
+    # A course word carries it the rest of the way: "kurzy cestiny" names no
+    # kind of help at all, and the subject is what says which course.
+    if result.service_type == "tutoring" or (
+        result.service_type is None and _mentions(norm, COURSE_WORDS)
+    ):
+        # Which subject it is about decides it. A language beside a lesson is a
+        # language lesson; maths taught in Czech is maths, and reading that as a
+        # language lesson would carry a subject no language offer has — an empty
+        # screen for a query that worked.
+        #
+        # With no subject resolved the words are all there is, and that is the
+        # commonest phrasing of all: "репетитор по чешскому" says which language
+        # and not which level, so no subject can match it.
+        if subjects:
+            if await _is_a_language(session, subjects[0].id):
+                result.service_type = "language_tutoring"
+        elif _mentions(norm, LANGUAGE_WORDS):
+            result.service_type = "language_tutoring"
+
     institutions = await find_institutions(session, text, lang, limit=3)
 
     if subjects:
@@ -434,6 +454,41 @@ async def parse(
 
     result.unmatched = not any((result.subject, result.institution, result.service_type))
     return result
+
+
+# The slug of the shelf every language sits on. A subject rather than a service
+# type: what makes a query a language lesson is which subject it is about.
+LANGUAGES_GROUP = "languages"
+
+
+async def _is_a_language(session: AsyncSession, subject_id: int) -> bool:
+    """Is this subject one of the languages?
+
+    Asked of the resolved subject rather than of the words, and asked only when
+    the answer can change anything — a tutoring match, or a course with no kind
+    of help named. The materialised path makes it one indexed comparison: every
+    descendant of the group carries its id at the head of `path`.
+    """
+    return bool(
+        await session.scalar(
+            text(
+                "SELECT EXISTS ("
+                "  SELECT 1 FROM subjects child, subjects grp"
+                "   WHERE child.id = :id AND grp.slug = :group"
+                "     AND child.path LIKE grp.id::text || '.%'"
+                ")"
+            ),
+            {"id": subject_id, "group": LANGUAGES_GROUP},
+        )
+    )
+
+
+def _mentions(norm: str, words: tuple[str, ...]) -> bool:
+    tokens = tokenise(norm)
+    return any(
+        (is_whole_word if isinstance(word, Word) else starts_a_word)(tokens, word)
+        for word in words
+    )
 
 
 def _match_service(
@@ -454,38 +509,13 @@ def _match_service(
     SUBJECTLESS at the call site.
     """
     tokens = tokenise(norm)
-
-    def present(words: tuple[str, ...]) -> str | None:
-        for word in words:
-            match = is_whole_word if isinstance(word, Word) else starts_a_word
-            if match(tokens, word):
-                return word
-        return None
-
     for code, keywords in SERVICE_KEYWORDS.items():
         if code in ignore:
             continue
         for keyword in keywords:
             match = is_whole_word if isinstance(keyword, Word) else starts_a_word
             if match(tokens, keyword):
-                # A language beside an ask for a teacher is a language lesson,
-                # and reading it as plain tutoring loses the one thing the query
-                # said. A refinement rather than a keyword of its own, because
-                # the words that name a language describe far more than lessons
-                # — see LANGUAGE_WORDS. It only ever narrows a lesson.
-                if code == "tutoring" and "language_tutoring" not in ignore:
-                    language = present(LANGUAGE_WORDS)
-                    if language:
-                        return "language_tutoring", language
                 return code, keyword
-
-    # Nothing named a kind of help, but a course in a language is one: "kurzy
-    # cestiny", "курсы чешского", "czech language course". Both halves are
-    # matched on their own, which is what carries every form of both.
-    if "language_tutoring" not in ignore and present(COURSE_WORDS):
-        language = present(LANGUAGE_WORDS)
-        if language:
-            return "language_tutoring", language
 
     if any(starts_a_word(tokens, verb) for verb in WEAK_HELP):
         if any(starts_a_word(tokens, word) for word in EXAM_MENTION):

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -459,12 +459,17 @@ async def parse(
         spoken_for = [keyword or "", language or ""]
         if result.institution:
             spoken_for.append(result.institution.label)
+        # The date and the price come out by the spans that produced them, not
+        # by their words: "мар" is March and the first three letters of
+        # "маркетингу", so discounting month words made a marketing query a
+        # language lesson, and a currency list beside the one `_BUDGET` already
+        # holds is a second list to keep in step.
+        spoken = norm
         if result.deadline:
-            # The month it read, and only when it read one.
-            spoken_for.extend(
-                month for month in MONTHS if starts_a_word(tokenise(norm), month)
-            )
-        if language and not _left_over(norm, *spoken_for):
+            spoken = _DAY_MONTH_WORD.sub(" ", _DAY_MONTH_NUM.sub(" ", spoken))
+        if result.budget_max is not None:
+            spoken = _BUDGET.sub(" ", spoken)
+        if language and not _left_over(spoken, *spoken_for):
             result.service_type = "language_tutoring"
 
     result.unmatched = not any((result.subject, result.institution, result.service_type))
@@ -541,6 +546,9 @@ FILLER_WORDS: frozenset[str] = frozenset(
         "na",
         "pro",
         "si",
+        # "do 600 korun" — the Czech limit word, which `_BUDGET` does not
+        # consume the way it consumes the Russian "до".
+        "do",
         # The level, which says which row of the same language and never
         # another subject.
         "a1",
@@ -560,11 +568,6 @@ FILLER_WORDS: frozenset[str] = frozenset(
         "my",
         "me",
     )
-)
-
-
-CURRENCY_WORDS: frozenset[str] = frozenset(
-    ("kc", "czk", "kč", "крон", "kron", "eur", "euro", "usd")
 )
 
 
@@ -591,14 +594,11 @@ def _left_over(norm: str, *accounted: str) -> str:
     rest = [
         token
         for token in tokens
-        # A bare number is a price or a day and never a subject, and the
-        # currency beside it is neither. The month is *not* discounted here —
-        # "мар" is March and the first three letters of "маркетингу", and a
-        # month word alone is not a deadline anyway: the caller passes the one
-        # it actually parsed.
+        # A bare number names nothing: whatever it was — a price, a page count,
+        # a year — it is not a subject. What the date and the price matchers
+        # consumed is already gone; see the caller.
         if not token.isdigit()
         and token not in FILLER_WORDS
-        and token not in CURRENCY_WORDS
         and not any(token.startswith(normalise(word)) for word in FILLER)
     ]
     return " ".join(rest)

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -411,40 +411,6 @@ async def parse(
         else:
             subjects = []
 
-    # A language *as the subject* is a language lesson rather than plain
-    # tutoring. Decided here and not in `_match_service`, because it takes the
-    # subject to tell the two apart: "нужен репетитор по чешскому" is one, and
-    # "нужен репетитор по матану на чешском" is maths taught in Czech — read as
-    # a language lesson it would carry a maths subject no language offer has,
-    # which is an empty screen for a query that worked.
-    #
-    # A course word carries it the rest of the way: "kurzy cestiny" names no
-    # kind of help at all, and the subject is what says which course.
-    if result.service_type == "tutoring" or (
-        result.service_type is None and _mentions(norm, COURSE_WORDS)
-    ):
-        # A language lesson is a lesson whose request is the language, and
-        # nothing else. "репетитор по химии на чешском" names the medium of
-        # instruction, "репетитор по чешской литературе" a nationality, and
-        # "репетитор по матану на чешском" both — each leaves a subject named
-        # once the asking and the language are taken out, which is the same test
-        # the subject filter above makes of a keyword that was the whole query.
-        #
-        # Read as language lessons they would carry a subject no language offer
-        # has, and `catalog.search` ANDs the two: an empty screen for a query
-        # that worked.
-        #
-        # Lexical, and not a question about the resolved subject, for two
-        # reasons. The commonest phrasing resolves none — "репетитор по
-        # чешскому" says which language and not which level, and a bare
-        # «чешский» names five subjects and belongs to none of them. And where
-        # one does resolve it is as often the wrong one: "chemistry tutor in
-        # czech" scores Czech C1 at 0.69 against chemistry at 0.55, by name in
-        # both cases, so neither the score nor how it matched separates the two.
-        language = _first(norm, LANGUAGE_WORDS)
-        if language and not _left_over(norm, keyword or "", language):
-            result.service_type = "language_tutoring"
-
     institutions = await find_institutions(session, text, lang, limit=3)
 
     if subjects:
@@ -458,6 +424,37 @@ async def parse(
 
     result.deadline = _match_deadline(norm, today or date.today())
     result.budget_max = _match_budget(norm)
+
+    # A language lesson is a lesson whose request is the language, and nothing
+    # else. "репетитор по химии на чешском" names the medium of instruction,
+    # "репетитор по чешской литературе" a nationality, and "репетитор по матану
+    # на чешском" both — each leaves a subject named once the asking and the
+    # language are taken out, which is the same test the subject filter above
+    # makes of a keyword that was the whole query. Read as language lessons they
+    # would carry a subject no language offer has, and `catalog.search` ANDs the
+    # two: an empty screen for a query that worked.
+    #
+    # Last, because "what is left" has to mean *left over from everything the
+    # query said*: a budget, a date and a school are all already fields by now,
+    # and counting their words would have made "doucovani cestiny na ČVUT" plain
+    # tutoring.
+    #
+    # Lexical, and not a question about the resolved subject, for two reasons.
+    # The commonest phrasing resolves none — "репетитор по чешскому" says which
+    # language and not which level, and a bare «чешский» names five subjects and
+    # belongs to none of them. And where one does resolve it is as often the
+    # wrong one: "chemistry tutor in czech" scores Czech C1 at 0.69 against
+    # chemistry at 0.55, by name in both cases, so neither the score nor how it
+    # matched separates the two.
+    if result.service_type == "tutoring" or (
+        result.service_type is None and _mentions(norm, COURSE_WORDS)
+    ):
+        language = _first(norm, LANGUAGE_WORDS)
+        spoken_for = [keyword or "", language or ""]
+        if result.institution:
+            spoken_for.append(result.institution.label)
+        if language and not _left_over(norm, *spoken_for):
+            result.service_type = "language_tutoring"
 
     result.unmatched = not any((result.subject, result.institution, result.service_type))
     return result
@@ -555,6 +552,11 @@ FILLER_WORDS: frozenset[str] = frozenset(
 )
 
 
+CURRENCY_WORDS: frozenset[str] = frozenset(
+    ("kc", "czk", "kč", "крон", "kron", "eur", "euro", "usd")
+)
+
+
 def _left_over(norm: str, *accounted: str) -> str:
     """What the query still names once these words and the filler are gone."""
     text_left = norm
@@ -565,7 +567,12 @@ def _left_over(norm: str, *accounted: str) -> str:
     rest = [
         token
         for token in tokens
-        if token not in FILLER_WORDS
+        # A number is a price or a day, and both are fields of their own by the
+        # time anyone asks this — as is a month and the currency beside it.
+        if not token.isdigit()
+        and token not in FILLER_WORDS
+        and token not in CURRENCY_WORDS
+        and not any(token.startswith(month) for month in MONTHS)
         and not any(token.startswith(normalise(word)) for word in FILLER)
     ]
     return " ".join(rest)

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -14,7 +14,6 @@ import re
 from dataclasses import dataclass, field
 from datetime import date
 
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from students_cz.services.lookup import Match, find_institutions, find_subjects, normalise
@@ -432,10 +431,23 @@ async def parse(
         # With no subject resolved the words are all there is, and that is the
         # commonest phrasing of all: "репетитор по чешскому" says which language
         # and not which level, so no subject can match it.
-        if subjects:
-            if await _is_a_language(session, subjects[0].id):
-                result.service_type = "language_tutoring"
-        elif _mentions(norm, LANGUAGE_WORDS):
+        # A language lesson is a lesson whose request is the language, and
+        # nothing else. "репетитор по химии на чешском" names the medium of
+        # instruction, "репетитор по чешской литературе" a nationality, and
+        # "репетитор по матану на чешском" both — each leaves a subject named
+        # once the asking and the language are taken out, which is the same test
+        # the subject filter above makes of a keyword that was the whole query.
+        #
+        # Read as language lessons they would carry a subject no language offer
+        # has, and `catalog.search` ANDs the two: an empty screen for a query
+        # that worked.
+        #
+        # The words and not the resolved subject, because the commonest
+        # phrasing resolves none: "репетитор по чешскому" says which language
+        # and not which level, and a bare «чешский» names five subjects and
+        # belongs to none of them.
+        language = _first(norm, LANGUAGE_WORDS)
+        if language and not _left_over(norm, keyword or "", language):
             result.service_type = "language_tutoring"
 
     institutions = await find_institutions(session, text, lang, limit=3)
@@ -456,39 +468,109 @@ async def parse(
     return result
 
 
-# The slug of the shelf every language sits on. A subject rather than a service
-# type: what makes a query a language lesson is which subject it is about.
-LANGUAGES_GROUP = "languages"
+# The words that ask rather than name: verbs of searching, prepositions,
+# articles, the word "language" itself and the word "course". What is left after
+# these and after the words a rule already accounted for is the part of the
+# query that names something else — see the language refinement in `parse`.
+FILLER: tuple[str, ...] = (
+    *WEAK_HELP,
+    # WEAK_HELP carries "нужен" and "потрібн", which between them miss "нужна",
+    # "нужно" and "потрібен" — forms that matter here, where what is left over
+    # is the whole question.
+    "нужн",
+    "потріб",
+    "ищу",
+    "найти",
+    "хочу",
+    "подскаж",
+    "посовет",
+    "шукаю",
+    "знайти",
+    "hledam",
+    "potrebuj",
+    "looking",
+    "need",
+    "want",
+    "язык",
+    "мова",
+    "мови",
+    "мову",
+    "jazyk",
+    "language",
+    *COURSE_WORDS,
+)
 
-
-async def _is_a_language(session: AsyncSession, subject_id: int) -> bool:
-    """Is this subject one of the languages?
-
-    Asked of the resolved subject rather than of the words, and asked only when
-    the answer can change anything — a tutoring match, or a course with no kind
-    of help named. The materialised path makes it one indexed comparison: every
-    descendant of the group carries its id at the head of `path`.
-    """
-    return bool(
-        await session.scalar(
-            text(
-                "SELECT EXISTS ("
-                "  SELECT 1 FROM subjects child, subjects grp"
-                "   WHERE child.id = :id AND grp.slug = :group"
-                "     AND child.path LIKE grp.id::text || '.%'"
-                ")"
-            ),
-            {"id": subject_id, "group": LANGUAGES_GROUP},
-        )
+# Single letters and prepositions, which a stem list cannot hold: "по" would
+# match "поступление" and "s" would match every Czech word beginning with it.
+FILLER_WORDS: frozenset[str] = frozenset(
+    (
+        # ru
+        "по",
+        "на",
+        "с",
+        "у",
+        "для",
+        "в",
+        "о",
+        "от",
+        "из",
+        "мне",
+        # uk
+        "і",
+        "з",
+        "до",
+        "та",
+        "мені",
+        # cs
+        "z",
+        "s",
+        "v",
+        "k",
+        "na",
+        "pro",
+        "si",
+        # en
+        "for",
+        "a",
+        "an",
+        "the",
+        "in",
+        "with",
+        "and",
+        "my",
+        "me",
     )
+)
+
+
+def _left_over(norm: str, *accounted: str) -> str:
+    """What the query still names once these words and the filler are gone."""
+    text_left = norm
+    for word in accounted:
+        if word:
+            text_left = _without(text_left, word)
+    tokens = tokenise(text_left).split()
+    rest = [
+        token
+        for token in tokens
+        if token not in FILLER_WORDS
+        and not any(token.startswith(normalise(word)) for word in FILLER)
+    ]
+    return " ".join(rest)
+
+
+def _first(norm: str, words: tuple[str, ...]) -> str | None:
+    """The first of `words` the text contains, or None."""
+    tokens = tokenise(norm)
+    for word in words:
+        match = is_whole_word if isinstance(word, Word) else starts_a_word
+        if match(tokens, word):
+            return word
+    return None
 
 
 def _mentions(norm: str, words: tuple[str, ...]) -> bool:
-    tokens = tokenise(norm)
-    return any(
-        (is_whole_word if isinstance(word, Word) else starts_a_word)(tokens, word)
-        for word in words
-    )
+    return _first(norm, words) is not None
 
 
 def _match_service(

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -189,12 +189,15 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "english tutor",
         "german tutor",
         "language tutor",
-        # A course rather than the language: nobody says these about a visa.
-        "pro cizince",
-        "для иностранцев",
-        "для іноземців",
-        "jazykov kurz",
+        # A course, named as one. Not "pro cizince" and not "для иностранцев":
+        # those belong to whatever comes before them, and "zdravotní pojištění
+        # pro cizince" is the literal name of the insurance product this same
+        # change taught the parser to recognise by its brand.
         "kurz cestiny",
+        "kurz anglictiny",
+        "kurz nemciny",
+        "курсы чешского",
+        "курсы английского",
         "языковые курсы",
         "мовні курси",
     ),

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -423,14 +423,6 @@ async def parse(
     if result.service_type == "tutoring" or (
         result.service_type is None and _mentions(norm, COURSE_WORDS)
     ):
-        # Which subject it is about decides it. A language beside a lesson is a
-        # language lesson; maths taught in Czech is maths, and reading that as a
-        # language lesson would carry a subject no language offer has — an empty
-        # screen for a query that worked.
-        #
-        # With no subject resolved the words are all there is, and that is the
-        # commonest phrasing of all: "репетитор по чешскому" says which language
-        # and not which level, so no subject can match it.
         # A language lesson is a lesson whose request is the language, and
         # nothing else. "репетитор по химии на чешском" names the medium of
         # instruction, "репетитор по чешской литературе" a nationality, and
@@ -442,10 +434,13 @@ async def parse(
         # has, and `catalog.search` ANDs the two: an empty screen for a query
         # that worked.
         #
-        # The words and not the resolved subject, because the commonest
-        # phrasing resolves none: "репетитор по чешскому" says which language
-        # and not which level, and a bare «чешский» names five subjects and
-        # belongs to none of them.
+        # Lexical, and not a question about the resolved subject, for two
+        # reasons. The commonest phrasing resolves none — "репетитор по
+        # чешскому" says which language and not which level, and a bare
+        # «чешский» names five subjects and belongs to none of them. And where
+        # one does resolve it is as often the wrong one: "chemistry tutor in
+        # czech" scores Czech C1 at 0.69 against chemistry at 0.55, by name in
+        # both cases, so neither the score nor how it matched separates the two.
         language = _first(norm, LANGUAGE_WORDS)
         if language and not _left_over(norm, keyword or "", language):
             result.service_type = "language_tutoring"
@@ -498,6 +493,14 @@ FILLER: tuple[str, ...] = (
     "jazyk",
     "language",
     *COURSE_WORDS,
+    # A shade of the language rather than another subject.
+    "разговорн",
+    "розмовн",
+    "konverzac",
+    "conversational",
+    # And any *other* language: "репетитор по чешскому и английскому" asks for
+    # two of these and for nothing else.
+    *LANGUAGE_WORDS,
 )
 
 # Single letters and prepositions, which a stem list cannot hold: "по" would
@@ -514,6 +517,7 @@ FILLER_WORDS: frozenset[str] = frozenset(
         "о",
         "от",
         "из",
+        "и",
         "мне",
         # uk
         "і",
@@ -529,6 +533,14 @@ FILLER_WORDS: frozenset[str] = frozenset(
         "na",
         "pro",
         "si",
+        # The level, which says which row of the same language and never
+        # another subject.
+        "a1",
+        "a2",
+        "b1",
+        "b2",
+        "c1",
+        "c2",
         # en
         "for",
         "a",

--- a/apps/api/src/students_cz/services/parser.py
+++ b/apps/api/src/students_cz/services/parser.py
@@ -165,30 +165,38 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         "написати",
         "курсову",
     ),
-    # Above `tutoring`, because the two share every word that asks for a teacher
-    # and only these say which subject: "репетитор по чешскому" is a language
-    # lesson, and reading it as plain tutoring loses the one thing it said.
+    # Above `tutoring`, because the two share every word that asks for a
+    # teacher and only these say which subject: "репетитор по чешскому" is a
+    # language lesson, and reading it as plain tutoring loses the one thing it
+    # said.
+    #
+    # Phrases and not the bare adjective, which is the trap here: this block
+    # sits above the non-study one, so a lone "чешск" made "нужна чешская виза"
+    # a language lesson — a study kind with no subject, which is the empty
+    # screen that block's own comment exists to prevent. A language names this
+    # kind of help only next to the asking.
     "language_tutoring": (
-        "чешск",
-        "чеськ",
-        "cestin",
-        "češtin",
-        "cestiny",
-        "английск",
-        "англійськ",
-        "anglict",
-        "angličt",
-        Word("english"),
-        "немецк",
-        "німецьк",
-        "nemcin",
-        "němčin",
-        Word("german"),
-        # How a language course is named rather than the language itself.
-        "pro cizince",
-        "язык для иностран",
+        "репетитор по чешск",
+        "репетитор по английск",
+        "репетитор по немецк",
+        "репетитор з чеськ",
+        "репетитор з англійськ",
+        "репетитор з німецьк",
+        "doucovani cestiny",
+        "doucovani anglictiny",
+        "doucovani nemciny",
+        "czech tutor",
+        "english tutor",
+        "german tutor",
         "language tutor",
-        "jazykov",
+        # A course rather than the language: nobody says these about a visa.
+        "pro cizince",
+        "для иностранцев",
+        "для іноземців",
+        "jazykov kurz",
+        "kurz cestiny",
+        "языковые курсы",
+        "мовні курси",
     ),
     "tutoring": (
         "репетитор",
@@ -230,7 +238,6 @@ SERVICE_KEYWORDS: dict[str, tuple[str, ...]] = {
         Word("pvzp"),
         Word("slavia"),
         Word("uniqa"),
-        Word("ergo"),
     ),
     "bank_letter": (
         "справка из банк",

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -501,6 +501,13 @@ async def test_an_insurer_name_is_the_insurance_it_names(session, text) -> None:
         # these as language lessons would carry a maths subject no language
         # offer has — an empty screen for a query that worked.
         ("нужен репетитор по матану на чешском", "tutoring"),
+        # The same, where the subject scores far lower than the language does:
+        # the guard cannot be "the subject won", or these three would be
+        # language lessons carrying a subject no language offer has.
+        ("нужен репетитор по химии на чешском", "tutoring"),
+        ("chemistry tutor in czech", "tutoring"),
+        ("репетитор з біології англійською", "tutoring"),
+        ("репетитор по чешской литературе", "tutoring"),
         ("doucovani matematiky v cestine", "tutoring"),
         ("потрібен репетитор з матану чеською", "tutoring"),
         ("calculus tutor in czech", "tutoring"),

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -479,6 +479,27 @@ async def test_an_insurer_name_is_the_insurance_it_names(session, text) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # An adjective is not an ask. This block sits above the non-study kinds,
+        # so a bare "чешск" made every one of these a language lesson — a study
+        # kind with no subject, which is an empty screen.
+        ("нужна чешская виза", "residence"),
+        ("нужна чешская страховка", "insurance"),
+        ("выписка со счета в чешском банке", "bank_letter"),
+        ("потрібна чеська віза", "residence"),
+        ("нужен репетитор по матану", "tutoring"),
+    ],
+)
+async def test_a_language_beside_an_errand_is_not_a_lesson(
+    session, text, expected
+) -> None:
+    parsed = await parse(session, text, "ru", today=TODAY)
+    assert parsed.service_type == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "text",
     [
         "нужен репетитор по чешскому",

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -508,6 +508,12 @@ async def test_an_insurer_name_is_the_insurance_it_names(session, text) -> None:
         ("chemistry tutor in czech", "tutoring"),
         ("physics tutor in english", "tutoring"),
         ("нужен репетитор по химии на чешском 500 kc", "tutoring"),
+        # "мар" is March and the first three letters of "маркетингу", so a
+        # month must be discounted only when one was actually read.
+        ("нужен репетитор по маркетингу на чешском", "tutoring"),
+        ("marketing tutor in czech", "tutoring"),
+        ("doucovani marketingu v cestine", "tutoring"),
+        ("репетитор з маркетингу англійською", "tutoring"),
         ("репетитор з біології англійською", "tutoring"),
         ("репетитор по чешской литературе", "tutoring"),
         ("doucovani matematiky v cestine", "tutoring"),
@@ -560,6 +566,10 @@ async def test_a_language_beside_an_errand_is_not_a_lesson(
         "репетитор по чешскому 500 kc",
         "doucovani cestiny 14 unora",
         "doucovani cestiny na ČVUT",
+        # The same school as the person typed it: it resolves through a code or
+        # through the transliterated query, so the label's own characters are
+        # nowhere in the text.
+        "репетитор по чешскому на чвуте",
         "репетитор по чешскому до 600 крон",
     ],
 )

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -520,6 +520,7 @@ async def test_an_insurer_name_is_the_insurance_it_names(session, text) -> None:
         ("doucovani marketingu v cestine 14 unora", "tutoring"),
         ("marketing tutor in czech 14 february", "tutoring"),
         ("нужен репетитор по маркетингу на чешском 3.03", "tutoring"),
+        ("i need a chemistry tutor in czech", "tutoring"),
         ("репетитор з біології англійською", "tutoring"),
         ("репетитор по чешской литературе", "tutoring"),
         ("doucovani matematiky v cestine", "tutoring"),
@@ -579,6 +580,12 @@ async def test_a_language_beside_an_errand_is_not_a_lesson(
         "репетитор по чешскому до 600 крон",
         "doucovani cestiny do 600 korun",
         "репетитор по чешскому 14 марта",
+        # English says it with a pronoun and an article, and Czech with the
+        # adjective rather than the noun.
+        "i need a czech tutor",
+        "i am looking for an english tutor",
+        "doucovani ceskeho jazyka",
+        "doucovani anglickeho jazyka",
     ],
 )
 async def test_asking_for_a_language_tutor_finds_languages(session, text) -> None:

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -507,6 +507,7 @@ async def test_an_insurer_name_is_the_insurance_it_names(session, text) -> None:
         ("нужен репетитор по химии на чешском", "tutoring"),
         ("chemistry tutor in czech", "tutoring"),
         ("physics tutor in english", "tutoring"),
+        ("нужен репетитор по химии на чешском 500 kc", "tutoring"),
         ("репетитор з біології англійською", "tutoring"),
         ("репетитор по чешской литературе", "tutoring"),
         ("doucovani matematiky v cestine", "tutoring"),
@@ -553,6 +554,13 @@ async def test_a_language_beside_an_errand_is_not_a_lesson(
         "репетитор по разговорному чешскому",
         "conversational czech tutor",
         "нужен репетитор по чешскому и английскому",
+        # Everything else the query said is a field of its own by the time this
+        # is asked — a budget, a date, a school — so none of them can make a
+        # language request look like something else.
+        "репетитор по чешскому 500 kc",
+        "doucovani cestiny 14 unora",
+        "doucovani cestiny na ČVUT",
+        "репетитор по чешскому до 600 крон",
     ],
 )
 async def test_asking_for_a_language_tutor_finds_languages(session, text) -> None:

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -497,6 +497,13 @@ async def test_an_insurer_name_is_the_insurance_it_names(session, text) -> None:
         ("потрібна чеська віза", "residence"),
         ("нужен репетитор по матану", "tutoring"),
         ("репетитора по физике", "tutoring"),
+        # A language can be the medium rather than the subject, and reading
+        # these as language lessons would carry a maths subject no language
+        # offer has — an empty screen for a query that worked.
+        ("нужен репетитор по матану на чешском", "tutoring"),
+        ("doucovani matematiky v cestine", "tutoring"),
+        ("потрібен репетитор з матану чеською", "tutoring"),
+        ("calculus tutor in czech", "tutoring"),
         ("нужен перевод диплома на чешский", "translation"),
     ],
 )
@@ -527,6 +534,10 @@ async def test_a_language_beside_an_errand_is_not_a_lesson(
         "на курсах чешского",
         "курси чеської",
         "czech language course",
+        # The weak-verb phrasings, which name no kind of help at all until the
+        # subject says what it is about.
+        "помогите с чешским языком",
+        "нужен чешский",
     ],
 )
 async def test_asking_for_a_language_tutor_finds_languages(session, text) -> None:

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -496,6 +496,8 @@ async def test_an_insurer_name_is_the_insurance_it_names(session, text) -> None:
         ("выписка со счета в чешском банке", "bank_letter"),
         ("потрібна чеська віза", "residence"),
         ("нужен репетитор по матану", "tutoring"),
+        ("репетитора по физике", "tutoring"),
+        ("нужен перевод диплома на чешский", "translation"),
     ],
 )
 async def test_a_language_beside_an_errand_is_not_a_lesson(
@@ -513,6 +515,18 @@ async def test_a_language_beside_an_errand_is_not_a_lesson(
         "doucovani cestiny",
         "english tutor",
         "потрібен репетитор з англійської",
+        # Every one of these is how it is actually typed, and every one of them
+        # inflects the *first* word — which a multi-word keyword cannot follow.
+        # Matching the language on its own is what carries them.
+        "ищу репетитора по чешскому",
+        "посоветуйте репетитора по немецкому",
+        "шукаю репетитора з англійської",
+        # A course is one too, in any of the forms both halves decline into.
+        "kurzy cestiny",
+        "курс чешского языка",
+        "на курсах чешского",
+        "курси чеської",
+        "czech language course",
     ],
 )
 async def test_asking_for_a_language_tutor_finds_languages(session, text) -> None:

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -514,6 +514,12 @@ async def test_an_insurer_name_is_the_insurance_it_names(session, text) -> None:
         ("marketing tutor in czech", "tutoring"),
         ("doucovani marketingu v cestine", "tutoring"),
         ("репетитор з маркетингу англійською", "tutoring"),
+        # And with a date beside it, which is where discounting month *words*
+        # rather than what the date matcher consumed went wrong.
+        ("нужен репетитор по маркетингу на чешском 14 марта", "tutoring"),
+        ("doucovani marketingu v cestine 14 unora", "tutoring"),
+        ("marketing tutor in czech 14 february", "tutoring"),
+        ("нужен репетитор по маркетингу на чешском 3.03", "tutoring"),
         ("репетитор з біології англійською", "tutoring"),
         ("репетитор по чешской литературе", "tutoring"),
         ("doucovani matematiky v cestine", "tutoring"),
@@ -571,6 +577,8 @@ async def test_a_language_beside_an_errand_is_not_a_lesson(
         # nowhere in the text.
         "репетитор по чешскому на чвуте",
         "репетитор по чешскому до 600 крон",
+        "doucovani cestiny do 600 korun",
+        "репетитор по чешскому 14 марта",
     ],
 )
 async def test_asking_for_a_language_tutor_finds_languages(session, text) -> None:

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -431,3 +431,76 @@ async def test_a_document_phrase_is_the_request_even_beside_a_named_subject(
 )
 def test_the_genitive_reaches_the_same_kind_as_the_nominative(text, expected):
     assert _match_service(normalise(text))[0] == expected
+
+
+# ── words that name a shelf, and words that name a brand ─────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("text", ["přijímačky", "prijimacky", "приймачки"])
+async def test_a_bare_prijimacky_names_the_kind_of_help(session, text) -> None:
+    """It is a category, and a category is not one of its members.
+
+    Carried as a synonym of «Поступление в технические вузы» it scored 1.00, so
+    a word that says nothing about a subject filtered the search by maths and
+    physics.
+    """
+    parsed = await parse(session, text, "ru", today=TODAY)
+    assert parsed.service_type == "entrance_prep"
+    assert parsed.subject is None, f"answered with {parsed.subject}"
+
+
+@pytest.mark.asyncio
+async def test_prijimacky_for_medicine_reaches_medicine(session) -> None:
+    """Written the way one language writes it, which is where this stops.
+
+    The mixed «přijímačky на медицину» still answers with the technical subject
+    at 0.67, because `find_subjects` compares one script at a time — the
+    institution lookup transliterates the query and the subject lookup does not,
+    so a Cyrillic word cannot reach a Latin-spelled synonym. That is a separate
+    change and is deferred with the measurement; what this one owes is that the
+    phrase resolves at all, rather than the category word deciding it.
+    """
+    parsed = await parse(session, "prijimacky na medicinu", "ru", today=TODAY)
+    assert parsed.service_type == "entrance_prep"
+    assert parsed.subject is not None
+    assert "медицин" in parsed.subject.label.lower(), parsed.subject.label
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text", ["pvzp na rok", "нужно оформить vzp", "slavia pojisteni"]
+)
+async def test_an_insurer_name_is_the_insurance_it_names(session, text) -> None:
+    """Nobody asks for «pojištění». They ask for VZP."""
+    parsed = await parse(session, text, "ru", today=TODAY)
+    assert parsed.service_type == "insurance"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "нужен репетитор по чешскому",
+        "doucovani cestiny",
+        "english tutor",
+        "потрібен репетитор з англійської",
+    ],
+)
+async def test_asking_for_a_language_tutor_finds_languages(session, text) -> None:
+    """The more specific kind of help wins the word it shares with tutoring."""
+    parsed = await parse(session, text, "ru", today=TODAY)
+    assert parsed.service_type == "language_tutoring"
+
+
+@pytest.mark.asyncio
+async def test_nostrification_is_nameable_in_english(session) -> None:
+    """Czech spells it with a k and English with a c.
+
+    The stem `nostrifik` covers «нострификация» and «nostrifikace» and misses
+    «nostrification», so the English word for this kind of help reached nothing
+    — the same "unnameable and therefore unfindable" failure as the five that
+    are not about studying.
+    """
+    parsed = await parse(session, "nostrification of a school certificate", "en")
+    assert parsed.service_type == "nostrification"

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -486,6 +486,13 @@ async def test_an_insurer_name_is_the_insurance_it_names(session, text) -> None:
         # kind with no subject, which is an empty screen.
         ("нужна чешская виза", "residence"),
         ("нужна чешская страховка", "insurance"),
+        # "pro cizince" is not a language phrase — it attaches to whatever came
+        # before it, and «zdravotní pojištění pro cizince» is the literal name
+        # of the product this same change taught the parser to know by brand.
+        ("zdravotni pojisteni pro cizince", "insurance"),
+        ("pvzp pojisteni pro cizince na rok", "insurance"),
+        ("страховка для иностранцев", "insurance"),
+        ("общежитие для иностранцев", "housing"),
         ("выписка со счета в чешском банке", "bank_letter"),
         ("потрібна чеська віза", "residence"),
         ("нужен репетитор по матану", "tutoring"),

--- a/apps/api/tests/test_parser.py
+++ b/apps/api/tests/test_parser.py
@@ -506,6 +506,7 @@ async def test_an_insurer_name_is_the_insurance_it_names(session, text) -> None:
         # language lessons carrying a subject no language offer has.
         ("нужен репетитор по химии на чешском", "tutoring"),
         ("chemistry tutor in czech", "tutoring"),
+        ("physics tutor in english", "tutoring"),
         ("репетитор з біології англійською", "tutoring"),
         ("репетитор по чешской литературе", "tutoring"),
         ("doucovani matematiky v cestine", "tutoring"),
@@ -545,6 +546,13 @@ async def test_a_language_beside_an_errand_is_not_a_lesson(
         # subject says what it is about.
         "помогите с чешским языком",
         "нужен чешский",
+        # A level, a shade and a second language all say the same thing more
+        # precisely; none of them names another subject, so none of them stops
+        # this being a language lesson.
+        "doucovani cestiny B2",
+        "репетитор по разговорному чешскому",
+        "conversational czech tutor",
+        "нужен репетитор по чешскому и английскому",
     ],
 )
 async def test_asking_for_a_language_tutor_finds_languages(session, text) -> None:

--- a/apps/api/tests/test_service_groups.py
+++ b/apps/api/tests/test_service_groups.py
@@ -383,3 +383,47 @@ async def test_a_line_dropped_from_the_checklist_is_retired_not_deleted(
     )
     assert dropped is not None, "the row was deleted, not retired"
     assert dropped.is_active is False
+
+
+def _seeded_synonyms() -> dict[str, set[str]]:
+    """Every subject's synonyms, out of the file the seed reads."""
+    import json
+
+    data = json.loads(
+        (Path(__file__).resolve().parents[1] / "seeds/subjects.json").read_text()
+    )
+
+    out: dict[str, set[str]] = {}
+
+    def walk(nodes: Any) -> None:
+        for node in nodes:
+            out[node["slug"]] = set(node.get("synonyms") or [])
+            walk(node.get("children", []))
+
+    walk(data["groups"])
+    return out
+
+
+def test_seed_and_migrations_agree_about_synonyms() -> None:
+    """The same rule the service types follow, for the words that find them.
+
+    Subjects are seeded from a file and never by a migration, so a migration
+    that edits `synonyms` is the only way a change reaches production — and the
+    two drifting apart is invisible until a production query answers differently
+    from every developer's. A migration declares what it touches under
+    `SYNONYM_ADDS` and `SYNONYM_REMOVES`; this holds the seed to it.
+    """
+    seeded = _seeded_synonyms()
+    checked = 0
+    for path in sorted(VERSIONS.glob("*.py")):
+        for slug, words in _constant(path, "SYNONYM_ADDS", {}).items():
+            assert slug in seeded, f"{path.name} names a subject the seed has not: {slug}"
+            missing = sorted(set(words) - seeded[slug])
+            assert missing == [], f"{path.name} adds synonyms the seed lacks: {missing}"
+            checked += 1
+        for slug, words in _constant(path, "SYNONYM_REMOVES", {}).items():
+            assert slug in seeded, f"{path.name} names a subject the seed has not: {slug}"
+            left = sorted(set(words) & seeded[slug])
+            assert left == [], f"{path.name} removes synonyms the seed still has: {left}"
+            checked += 1
+    assert checked, "no migration declares a synonym change"

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -275,18 +275,23 @@ because the words that would name it — "чешск", "anglict" — also say *w
 bank, *whose* visa and *whose* dormitory, and anything placed high enough to beat
 tutoring takes all of those with it.
 
-It is a refinement of a lesson instead, and **the subject decides it**: a
-tutoring match whose subject is one of the languages is a language lesson, while
-maths taught in Czech stays maths — read the other way it would carry a subject
-no language offer has, which is the same empty screen the asides rule exists to
-prevent. A course word does the same for a query that named no kind of help at
-all: "kurzy cestiny" is a lesson because of what it is about.
+It is a refinement of a lesson instead, and the test is **whether the language
+is the whole request**. Take out the words that asked and the language itself,
+and what is left decides: "репетитор по чешскому" leaves nothing, while
+"репетитор по химии на чешском" leaves chemistry, "репетитор по чешской
+литературе" leaves literature and "репетитор по матану на чешском" leaves maths
+— a medium of instruction and a nationality, not a request for a language. Read
+the other way they would carry a subject no language offer has, and the search
+ANDs the two: an empty screen for a query that worked. It is the same test the
+rule above makes of a keyword that was the whole query.
 
-The words are the fallback for the one case a subject cannot settle: "репетитор
-по чешскому" says which language and not which level, and a bare «чешский» names
-five subjects and belongs to none of them, so nothing resolves. There the
-language word is all there is — and it is consulted only when no subject was
-found, which is what keeps it away from the bank and the visa.
+"What is left" ignores the words that ask rather than name — verbs of searching,
+prepositions, the word "language" itself, and the word "course", which is what
+makes "kurzy cestiny" and "курс чешского языка" lessons as well.
+
+The words and not the resolved subject, because the commonest phrasing resolves
+none: "репетитор по чешскому" says which language and not which level, and a
+bare «чешский» names five subjects and belongs to none of them.
 
 Above all this sits the query parser, which turns free text into ids. Because it
 does, the database rarely has to do linguistic work at all — it looks up

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -269,10 +269,17 @@ the brands people actually say: an insurance policy is asked for as "VZP" or
 "PVZP" far more often than as "pojištění", and those are `Word`s rather than
 stems because `vzp` prefixes `vzpomínky`.
 
-Languages are the case where two kinds of help overlap: asking for a Czech
-tutor is `language_tutoring` and not plain `tutoring`, and the words that decide
-it are the languages themselves. Its keywords therefore sit above `tutoring` in
-the table, because the more specific kind has to win the same word.
+Languages are the case where two kinds of help overlap: asking for a Czech tutor
+is `language_tutoring` and not plain `tutoring`. It is the one kind of help with
+no keywords of its own, because the words that would name it — "чешск",
+"anglict" — also describe *whose* bank, *whose* visa and *whose* dormitory, and
+anything high enough in the table to beat tutoring takes all of those with it.
+It is a refinement instead: a language beside a match that was already a lesson
+makes it a language lesson, and a course word beside a language names one when
+nothing else claimed the query. Both halves are matched on their own, which is
+what carries «ищу репетитора по чешскому» and «kurzy cestiny» — a multi-word
+keyword tolerates inflection only on its last word, and these inflect the
+first.
 
 Above all this sits the query parser, which turns free text into ids. Because it
 does, the database rarely has to do linguistic work at all — it looks up

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -287,7 +287,10 @@ rule above makes of a keyword that was the whole query.
 
 "What is left" ignores the words that ask rather than name — verbs of searching,
 prepositions, the word "language" itself, and the word "course", which is what
-makes "kurzy cestiny" and "курс чешского языка" lessons as well.
+makes "kurzy cestiny" and "курс чешского языка" lessons as well. It also ignores
+the words that say the *same* request more precisely: a level ("B2"), a shade
+("разговорный", "konverzace") and a second language, so "doucovani cestiny B2"
+and "репетитор по чешскому и английскому" are language lessons too.
 
 The words and not the resolved subject, because the commonest phrasing resolves
 none: "репетитор по чешскому" says which language and not which level, and a

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -270,16 +270,23 @@ the brands people actually say: an insurance policy is asked for as "VZP" or
 stems because `vzp` prefixes `vzpomínky`.
 
 Languages are the case where two kinds of help overlap: asking for a Czech tutor
-is `language_tutoring` and not plain `tutoring`. It is the one kind of help with
-no keywords of its own, because the words that would name it — "чешск",
-"anglict" — also describe *whose* bank, *whose* visa and *whose* dormitory, and
-anything high enough in the table to beat tutoring takes all of those with it.
-It is a refinement instead: a language beside a match that was already a lesson
-makes it a language lesson, and a course word beside a language names one when
-nothing else claimed the query. Both halves are matched on their own, which is
-what carries «ищу репетитора по чешскому» and «kurzy cestiny» — a multi-word
-keyword tolerates inflection only on its last word, and these inflect the
-first.
+is `language_tutoring` and not plain `tutoring`. It has no keywords in the table,
+because the words that would name it — "чешск", "anglict" — also say *whose*
+bank, *whose* visa and *whose* dormitory, and anything placed high enough to beat
+tutoring takes all of those with it.
+
+It is a refinement of a lesson instead, and **the subject decides it**: a
+tutoring match whose subject is one of the languages is a language lesson, while
+maths taught in Czech stays maths — read the other way it would carry a subject
+no language offer has, which is the same empty screen the asides rule exists to
+prevent. A course word does the same for a query that named no kind of help at
+all: "kurzy cestiny" is a lesson because of what it is about.
+
+The words are the fallback for the one case a subject cannot settle: "репетитор
+по чешскому" says which language and not which level, and a bare «чешский» names
+five subjects and belongs to none of them, so nothing resolves. There the
+language word is all there is — and it is consulted only when no subject was
+found, which is what keeps it away from the bank and the visa.
 
 Above all this sits the query parser, which turns free text into ids. Because it
 does, the database rarely has to do linguistic work at all — it looks up

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -233,6 +233,13 @@ something else:
   search by a subject nobody named. A synonym hit is kept, because a curated
   synonym is not a guess — "курсовая" and "нострификация" are written down
   against real subjects.
+- **A synonym names one row, so a word that names a whole shelf does not belong
+  in one.** `prijimacky` and `приймачки` sat on «Поступление в технические вузы»,
+  and a synonym scores 1.00 — so every «přijímačky …» query came back filtered by
+  maths and physics, including one that said medicine. The word names a kind of
+  help, and reaches `entrance_prep` through the keyword table, which is where a
+  category word belongs. What stays in `synonyms` is what names *that* row and
+  no other: «матан» is calculus, «приемка математика» is the maths entrance exam.
 - **A subject and a kind of help that carries none cannot both survive.** The
   `life` group's offers have no subject at all, while the search applies subject
   and kind of help together — so the pair matches nobody, and one of the two has
@@ -257,8 +264,15 @@ something else:
 A kind of help that cannot be named in words cannot be found, in any of the four
 languages. The five that are not about studying — insurance, a bank statement,
 a document translation, residence paperwork, housing — were offerable and
-unfindable, which is a listing nobody can reach. `language_tutoring` still has
-no keywords of its own and is reachable only as plain tutoring.
+unfindable, which is a listing nobody can reach. So is a kind of help named by
+the brands people actually say: an insurance policy is asked for as "VZP" or
+"PVZP" far more often than as "pojištění", and those are `Word`s rather than
+stems because `vzp` prefixes `vzpomínky`.
+
+Languages are the case where two kinds of help overlap: asking for a Czech
+tutor is `language_tutoring` and not plain `tutoring`, and the words that decide
+it are the languages themselves. Its keywords therefore sit above `tutoring` in
+the table, because the more specific kind has to win the same word.
 
 Above all this sits the query parser, which turns free text into ids. Because it
 does, the database rarely has to do linguistic work at all — it looks up

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -290,7 +290,10 @@ prepositions, the word "language" itself, and the word "course", which is what
 makes "kurzy cestiny" and "курс чешского языка" lessons as well. It also ignores
 the words that say the *same* request more precisely: a level ("B2"), a shade
 ("разговорный", "konverzace") and a second language, so "doucovani cestiny B2"
-and "репетитор по чешскому и английскому" are language lessons too.
+and "репетитор по чешскому и английскому" are language lessons too. And it is
+asked last, once the budget, the date and the school are fields of their own —
+otherwise "doucovani cestiny na ČVUT" reads as a language request with a school
+left over in it.
 
 The words and not the resolved subject, because the commonest phrasing resolves
 none: "репетитор по чешскому" says which language and not which level, and a


### PR DESCRIPTION
Docs updated first: docs/data-model.md

Four gaps, each measured against the database before and after.

**«přijímačky» answered with maths and physics.** The word sat in
`subjects.synonyms` on «Поступление в технические вузы», and a synonym scores
1.00 — so every query starting with it came back filtered by that subject,
including one that said medicine. The word names a *kind of help*, and reaches
`entrance_prep` through the keyword table, which is where a category word
belongs. The Ukrainian spelling had no keyword at all and worked only through
that same synonym; it is in the table now. Production carries both synonyms,
hence the migration.

**«pvzp na rok» parsed to nothing.** Nobody asks for «pojištění» — they ask for
VZP, PVZP, Slavia, UNIQA. Words rather than stems, because `vzp` begins
`vzpomínky`; `maxima` is an insurer too and is deliberately absent, being a
maths word first.

**«нужен репетитор по чешскому» was plain tutoring.** `language_tutoring` had no
way to be named, which the data-model doc stated outright.

**And the English «nostrification» reached nothing**: the stem is `nostrifik`,
which is how Czech and Russian spell it, so the one language that spells it with
a c could not name that kind of help at all.

## What the language rule turned out to be

The interesting half. Five earlier attempts each broke something real, and each
break is now a test:

- **Bare language adjectives as keywords** took «нужна чешская виза», «zdravotní
  pojištění pro cizince» and «общежитие для иностранцев» — a language also says
  *whose* bank, *whose* visa, *whose* dormitory.
- **Phrases** («репетитор по чешск») miss the commonest phrasing, because a
  multi-word keyword tolerates inflection only on its last word and «ищу
  репетитора по чешскому» inflects the first.
- **Deciding by the resolved subject** breaks on «chemistry tutor in czech»,
  where Czech C1 scores 0.69 by name against chemistry at 0.55 — neither the
  score nor how it matched separates them.

What survives is lexical and small: a lesson becomes a **language** lesson when,
after taking out the words that asked, the language itself, and everything the
parser has already turned into a field, **nothing else is named**. «репетитор по
чешскому» leaves nothing; «репетитор по химии на чешском» leaves chemistry, «по
чешской литературе» leaves literature, «по матану на чешском» leaves maths — a
medium of instruction and a nationality, not a request for a language. Read the
other way each would carry a subject no language offer has, and the search ANDs
the two: an empty screen for a query that worked.

"What is left" ignores the words that ask rather than name, and the words that
say the same request more precisely — a level, a shade («разговорный»,
«konverzace»), a second language. The date and the price come out by the spans
their own matchers consumed, not by words that look like them: «мар» is March
and the first three letters of «маркетингу».

## Verification

`make check` green: 410 API tests, ruff, ty, biome, tsc, lingui `--strict`,
`make contract`. The migration was replayed and round-tripped on a throwaway
seeded database and is idempotent. Every `/ask` example was re-measured in all
four catalogs, and about eighty queries were compared old against new.

A new guard holds the seed and the migrations to the same synonyms: subjects are
seeded from a file and never created by a migration, so a synonym that exists
only in one of the two reaches every developer and no student. A migration
declares what it touches under `SYNONYM_ADDS` / `SYNONYM_REMOVES`, and
`test_seed_and_migrations_agree_about_synonyms` compares them with the file.

Independent review: approved with no findings, after ten rounds that between
them found seven blocking defects — every one in the language rule, and every
one now pinned by a test.

## Out of scope

- **The «přijímačky на медицину» example stays off `/ask`.** Measured: it
  resolves correctly in cs (1.00) and uk (1.00), and not in the ru source, where
  the mixed script leaves it on the technical subject at 0.67, nor in en, where
  «medicine entrance exams» answers «Admissions to Business Schools» at 0.64.
- **`find_subjects` compares one script at a time.** The institution lookup
  passes a transliterated query and the subject lookup does not, which is why
  the mixed-script query above cannot reach the Latin-spelled synonym. Mirroring
  it changes scoring for every subject query, so it needs its own evidence.
- The trigram scorer that answers «Чешский язык B1» at 0.59 to «помощь на
  экзамене по физике».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL
