### PR TITLE
A removed chip takes back the chip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           cache-dependency-path: apps/web/pnpm-lock.yaml
 
@@ -173,7 +173,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # 24, because `pnpm test` runs TypeScript through node's own test
+          # runner and its type stripping is only unflagged from 22.18.
+          node-version: 24
           cache: pnpm
           cache-dependency-path: apps/web/pnpm-lock.yaml
 
@@ -184,6 +186,9 @@ jobs:
 
       - name: Type-check
         run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
 
       - name: Check every message is translated
         # An untranslated string falls back to the Russian source *and* to

--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,9 @@ tunnel: tunnel-tool  ## Expose the mini app over HTTPS so Telegram can reach it
 # ── checks ──────────────────────────────────────────────────────────────
 
 .PHONY: test
-test:  ## Run the API test suite (needs the database up)
+test:  ## Run both test suites (the API's needs the database up)
 	cd $(API) && uv run pytest -q
+	cd $(WEB) && pnpm test
 
 .PHONY: lint
 lint:  ## Lint and type-check both apps

--- a/README.md
+++ b/README.md
@@ -100,12 +100,16 @@ two ways to break production are in [docs/deploy.md](docs/deploy.md).
 
 ```sh
 make check                # everything CI runs
-make test                 # just the API suite
+make test                 # both test suites
 ```
 
-Tests run against a real Postgres, each inside a transaction that is rolled
-back. The interesting logic here is SQL — trigram matching, word-boundary
-synonym matching, exclusion constraints — and none of it survives being mocked.
+The API's tests run against a real Postgres, each inside a transaction that is
+rolled back. The interesting logic there is SQL — trigram matching,
+word-boundary matching of synonyms, exclusion constraints — and none of it
+survives being mocked.
+
+The mini app's tests run on node's own runner, on the modules that hold a rule
+rather than a layout: `pnpm test` in `apps/web`, no test framework installed.
 
 The tooling is [uv](https://docs.astral.sh/uv/) and
 [ruff](https://docs.astral.sh/ruff/) plus [ty](https://docs.astral.sh/ty/) on

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -119,7 +119,8 @@ close the app from the client's menu rather than just backing out of it.
 | `pnpm lint`           | Biome — lint, format check and import order           |
 | `pnpm lint:fix`       | The same, with the safe fixes applied                 |
 | `pnpm format`         | Format only                                           |
-| `pnpm typecheck`      | `tsc -b`, no emit                                     |
+| `pnpm typecheck`      | `tsc -b`, then the tests' own project, no emit         |
+| `pnpm test`           | `tests/` on node's own runner; fails if it finds none  |
 | `pnpm i18n:extract`   | Scan source for new messages, update the `.po` files  |
 | `pnpm i18n:compile`   | Compile catalogs by hand (the build does not need it) |
 | `pnpm api:generate`   | Regenerate API types — via `make contract`, see below  |

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "typecheck": "tsc -b && tsc -p tsconfig.test.json",
-    "test": "node --test \"tests/**/*.test.ts\"",
+    "test": "node scripts/test.mjs",
     "check:scroll": "node scripts/check-scroll.mjs",
     "i18n:extract": "lingui extract",
     "i18n:compile": "lingui compile",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@11.17.0",
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.18"
   },
   "scripts": {
     "dev": "vite",
@@ -14,7 +14,8 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
-    "typecheck": "tsc -b",
+    "typecheck": "tsc -b && tsc -p tsconfig.test.json",
+    "test": "node --test \"tests/**/*.test.ts\"",
     "check:scroll": "node scripts/check-scroll.mjs",
     "i18n:extract": "lingui extract",
     "i18n:compile": "lingui compile",

--- a/apps/web/scripts/test.mjs
+++ b/apps/web/scripts/test.mjs
@@ -1,0 +1,23 @@
+/*
+ * The tests, and a check that there were any.
+ *
+ * `node --test "tests/**\/*.test.ts"` exits 0 reporting "tests 0" when the
+ * pattern matches nothing, so a renamed directory would leave `pnpm test`,
+ * `make check` and CI green with nothing executed — the same failure the
+ * contract check guards against, and the same fix: look at the input before
+ * trusting the exit code.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { globSync } from 'node:fs';
+
+const files = globSync('tests/**/*.test.ts').sort();
+if (files.length === 0) {
+  console.error('No test files under apps/web/tests. Nothing ran.');
+  process.exit(1);
+}
+
+const { status } = spawnSync(process.execPath, ['--test', ...files], {
+  stdio: 'inherit',
+});
+process.exit(status ?? 1);

--- a/apps/web/src/lib/offerRows.ts
+++ b/apps/web/src/lib/offerRows.ts
@@ -79,12 +79,23 @@ export function dropRow(rows: Draft[], row: Draft, axis: Axis): Draft[] {
   if (bare && others.some((other) => other.service_type_id === row.service_type_id)) {
     return others;
   }
-  // In place, so the row keeps its position among its neighbours. The key it
-  // takes when nothing is left to name it is the one a fresh row of this
-  // service would have, and nothing of this service is left to collide with it.
+  // In place, so the row keeps its position among its neighbours, and re-keyed
+  // from what it now holds. Keeping the old key would leave a row named after
+  // an axis it no longer has, which `addAxis` could then mint a second time.
   return rows.map((other) =>
-    other.key === row.key
-      ? { ...left, key: bare ? `${row.service_type_id}:new` : other.key }
-      : other,
+    other.key === row.key ? { ...left, key: keyOf(left) } : other,
   );
+}
+
+/**
+ * A row's key, from its axes.
+ *
+ * Unique by construction: `offers` is unique on the same four columns, so two
+ * rows of one service cannot hold the same pair. The other places that mint a
+ * key — a row read from the server, a row a picker just added — name the same
+ * pair, and a row with no axis left is the one blank row its service is
+ * allowed.
+ */
+function keyOf(row: Draft): string {
+  return `${row.service_type_id}:${row.subject_id}:${row.institution_id}`;
 }

--- a/apps/web/src/lib/offerRows.ts
+++ b/apps/web/src/lib/offerRows.ts
@@ -45,36 +45,46 @@ export function serviceAnswers(rows: Draft[], serviceTypeId: number): Partial<Dr
   return { price, option_ids, note, turnaround_days };
 }
 
+/** The two axes a row can carry. `offers` is unique on both of them. */
+export type Axis = 'subject' | 'institution';
+
+const without = (row: Draft, axis: Axis): Draft =>
+  axis === 'subject'
+    ? { ...row, subject_id: null, subject_name: null }
+    : { ...row, institution_id: null, institution_name: null };
+
 /**
  * The rows left after one axis chip is removed.
  *
- * Removing the last subject — or the last school — must not remove the
- * service: the person ticked it, and a service with no axis is one search
- * cannot reach yet, not one they withdrew. So the last row of a service stays,
- * and only its axes are cleared.
+ * The tapped chip is the whole of what is being taken back, and two things
+ * follow from that.
  *
- * It keeps everything else it held. The checklist, the note and the turnaround
- * belong to the service type and not to one of its rows — that is what
- * `docs/data-model.md` says of those columns, and it is why the screen writes a
- * toggled option to every row of a service. A fresh blank row here would answer
- * «I do these five things, in three days, for 500» with silence, because a
- * subject chip was tapped off.
+ * One row can carry both axes — a school picked first and a subject after it
+ * fill the same row — and it appears in both chip lists. Removing the subject
+ * there leaves the school, rather than taking a school the person never touched.
+ *
+ * And a service whose last axis goes keeps its row, because the person ticked
+ * the service: one with no axis is a service search cannot reach yet, not one
+ * they withdrew. The row keeps everything else it held — the checklist, the
+ * note and the turnaround belong to the service type and not to one of its
+ * rows, which is what `docs/data-model.md` says of those columns and why the
+ * screen writes a toggled option to every row of a service. A fresh blank row
+ * here would answer «I do these five things, in three days, for 500» with
+ * silence, because a chip was tapped off.
  */
-export function dropRow(rows: Draft[], row: Draft): Draft[] {
-  const left = rows.filter((other) => other.key !== row.key);
-  if (left.some((other) => other.service_type_id === row.service_type_id)) return left;
-  return [
-    ...left,
-    {
-      ...row,
-      // The key a fresh row of this service would have: nothing else of this
-      // service is left to collide with it, and the chip that carried the old
-      // one is gone.
-      key: `${row.service_type_id}:new`,
-      subject_id: null,
-      subject_name: null,
-      institution_id: null,
-      institution_name: null,
-    },
-  ];
+export function dropRow(rows: Draft[], row: Draft, axis: Axis): Draft[] {
+  const left = without(row, axis);
+  const others = rows.filter((other) => other.key !== row.key);
+  const bare = left.subject_id === null && left.institution_id === null;
+  if (bare && others.some((other) => other.service_type_id === row.service_type_id)) {
+    return others;
+  }
+  // In place, so the row keeps its position among its neighbours. The key it
+  // takes when nothing is left to name it is the one a fresh row of this
+  // service would have, and nothing of this service is left to collide with it.
+  return rows.map((other) =>
+    other.key === row.key
+      ? { ...left, key: bare ? `${row.service_type_id}:new` : other.key }
+      : other,
+  );
 }

--- a/apps/web/src/lib/offerRows.ts
+++ b/apps/web/src/lib/offerRows.ts
@@ -41,8 +41,8 @@ export interface Draft {
 export function serviceAnswers(rows: Draft[], serviceTypeId: number): Partial<Draft> {
   const sibling = rows.find((row) => row.service_type_id === serviceTypeId);
   if (!sibling) return {};
-  const { price, option_ids, note, turnaround_days } = sibling;
-  return { price, option_ids, note, turnaround_days };
+  const { price, unit, option_ids, note, turnaround_days } = sibling;
+  return { price, unit, option_ids, note, turnaround_days };
 }
 
 /** The two axes a row can carry. `offers` is unique on both of them. */
@@ -75,26 +75,28 @@ const without = (row: Draft, axis: Axis): Draft =>
 export function dropRow(rows: Draft[], row: Draft, axis: Axis): Draft[] {
   const left = without(row, axis);
   const others = rows.filter((other) => other.key !== row.key);
+  const siblings = others.filter(
+    (other) => other.service_type_id === row.service_type_id,
+  );
   const bare = left.subject_id === null && left.institution_id === null;
-  if (bare && others.some((other) => other.service_type_id === row.service_type_id)) {
-    return others;
-  }
-  // In place, so the row keeps its position among its neighbours, and re-keyed
-  // from what it now holds. Keeping the old key would leave a row named after
-  // an axis it no longer has, which `addAxis` could then mint a second time.
+  // Gone, in the two cases where keeping it would say nothing new: a row with
+  // no axis left beside a row that has one, and a row whose remaining axis
+  // another row of the service already names — that pair is one offer, and the
+  // server's unique index says so.
+  if (siblings.some((other) => bare || keyOf(other) === keyOf(left))) return others;
+  // Otherwise in place, so the row keeps its position among its neighbours, and
+  // re-keyed from what it now holds: a key naming an axis the row no longer has
+  // is one `addAxis` could mint a second time.
   return rows.map((other) =>
     other.key === row.key ? { ...left, key: keyOf(left) } : other,
   );
 }
 
 /**
- * A row's key, from its axes.
- *
- * Unique by construction: `offers` is unique on the same four columns, so two
- * rows of one service cannot hold the same pair. The other places that mint a
- * key — a row read from the server, a row a picker just added — name the same
- * pair, and a row with no axis left is the one blank row its service is
- * allowed.
+ * A row's key, from its axes — the same pair `offers` is unique on, so two rows
+ * of one service that agree on it are one offer. `dropRow` is what keeps that
+ * true: a clearing that would produce a key another row already has drops the
+ * row instead of minting a twin.
  */
 function keyOf(row: Draft): string {
   return `${row.service_type_id}:${row.subject_id}:${row.institution_id}`;

--- a/apps/web/src/lib/offerRows.ts
+++ b/apps/web/src/lib/offerRows.ts
@@ -118,18 +118,30 @@ export function keyOf(row: Draft): string {
  * That first row is filled rather than left behind, which would otherwise save
  * as "this service, no subject" beside the real ones. A row that is added
  * instead starts from `serviceAnswers`.
+ *
+ * The axis is named rather than read off the fields being set, so a caller
+ * that names neither is a type error instead of a row filled with nothing.
  */
-export function addAxis(rows: Draft[], blank: Draft, axis: Partial<Draft>): Draft[] {
+export function addAxis(
+  rows: Draft[],
+  blank: Draft,
+  axis: Axis,
+  picked: { id: number; name: string },
+): Draft[] {
   const service = blank.service_type_id;
-  const naming: keyof Draft = 'subject_id' in axis ? 'subject_id' : 'institution_id';
+  const named: Partial<Draft> =
+    axis === 'subject'
+      ? { subject_id: picked.id, subject_name: picked.name }
+      : { institution_id: picked.id, institution_name: picked.name };
+  const holds: keyof Draft = axis === 'subject' ? 'subject_id' : 'institution_id';
   const empty = rows.find(
-    (row) => row.service_type_id === service && row[naming] === null,
+    (row) => row.service_type_id === service && row[holds] === null,
   );
   if (empty) {
     return rows.map((row) =>
-      row === empty ? { ...row, ...axis, key: keyOf({ ...row, ...axis }) } : row,
+      row === empty ? { ...row, ...named, key: keyOf({ ...row, ...named }) } : row,
     );
   }
-  const added = { ...blank, ...serviceAnswers(rows, service), ...axis };
+  const added = { ...blank, ...serviceAnswers(rows, service), ...named };
   return [...rows, { ...added, key: keyOf(added) }];
 }

--- a/apps/web/src/lib/offerRows.ts
+++ b/apps/web/src/lib/offerRows.ts
@@ -94,10 +94,42 @@ export function dropRow(rows: Draft[], row: Draft, axis: Axis): Draft[] {
 
 /**
  * A row's key, from its axes — the same pair `offers` is unique on, so two rows
- * of one service that agree on it are one offer. `dropRow` is what keeps that
- * true: a clearing that would produce a key another row already has drops the
- * row instead of minting a twin.
+ * of one service that agree on it are one offer.
+ *
+ * Every row that exists is keyed through here, which is what makes the key
+ * readable as the row's identity: a key minted once and left alone while the
+ * row's axes change is a key that can be minted again for a different row, and
+ * two rows sharing one would share a price field and save as a duplicate.
+ * `dropRow` keeps the other half of it — a clearing that would produce a key
+ * the service already has drops the row instead of minting a twin.
  */
-function keyOf(row: Draft): string {
+export function keyOf(row: Draft): string {
   return `${row.service_type_id}:${row.subject_id}:${row.institution_id}`;
+}
+
+/**
+ * Attach a subject or a school to a service.
+ *
+ * One function for both, because they are the same move: `offers` is unique on
+ * its axes, so calculus and physics — or ČVUT and VŠE — are two rows of the
+ * same service, and the first row of a service that takes an axis starts
+ * without one.
+ *
+ * That first row is filled rather than left behind, which would otherwise save
+ * as "this service, no subject" beside the real ones. A row that is added
+ * instead starts from `serviceAnswers`.
+ */
+export function addAxis(rows: Draft[], blank: Draft, axis: Partial<Draft>): Draft[] {
+  const service = blank.service_type_id;
+  const naming: keyof Draft = 'subject_id' in axis ? 'subject_id' : 'institution_id';
+  const empty = rows.find(
+    (row) => row.service_type_id === service && row[naming] === null,
+  );
+  if (empty) {
+    return rows.map((row) =>
+      row === empty ? { ...row, ...axis, key: keyOf({ ...row, ...axis }) } : row,
+    );
+  }
+  const added = { ...blank, ...serviceAnswers(rows, service), ...axis };
+  return [...rows, { ...added, key: keyOf(added) }];
 }

--- a/apps/web/src/lib/offerRows.ts
+++ b/apps/web/src/lib/offerRows.ts
@@ -1,0 +1,80 @@
+/**
+ * The rows behind the prices screen, and the one rule that is not obvious.
+ *
+ * Here rather than in the page because it is behaviour and not layout: what
+ * survives when a row goes is a decision about somebody's saved answers, and a
+ * decision like that should be provable without rendering a screen.
+ */
+
+import type { PriceUnit } from './types';
+
+/**
+ * One offer while it is being edited. The price is a string: an input
+ * mid-typing legitimately holds "" and "4", and parsing on every keystroke
+ * turns both into something the field then has to render back.
+ */
+export interface Draft {
+  key: string;
+  service_type_id: number;
+  subject_id: number | null;
+  subject_name: string | null;
+  institution_id: number | null;
+  institution_name: string | null;
+  option_ids: number[];
+  note: string;
+  // `null` is «договоримся», which is an answer, so the field is never absent.
+  turnaround_days: number | null;
+  price: string;
+  unit: PriceUnit;
+  langs: string[];
+}
+
+/**
+ * What a new row of a service starts from.
+ *
+ * A second subject added to a service inherits what the person already said
+ * about that service, for the reason the screen writes a toggled option to
+ * every row: asking the same price four times is asking three times too many,
+ * and a row added after the ticks were set would otherwise save an empty
+ * checklist. Empty when the service has no row yet.
+ */
+export function serviceAnswers(rows: Draft[], serviceTypeId: number): Partial<Draft> {
+  const sibling = rows.find((row) => row.service_type_id === serviceTypeId);
+  if (!sibling) return {};
+  const { price, option_ids, note, turnaround_days } = sibling;
+  return { price, option_ids, note, turnaround_days };
+}
+
+/**
+ * The rows left after one axis chip is removed.
+ *
+ * Removing the last subject — or the last school — must not remove the
+ * service: the person ticked it, and a service with no axis is one search
+ * cannot reach yet, not one they withdrew. So the last row of a service stays,
+ * and only its axes are cleared.
+ *
+ * It keeps everything else it held. The checklist, the note and the turnaround
+ * belong to the service type and not to one of its rows — that is what
+ * `docs/data-model.md` says of those columns, and it is why the screen writes a
+ * toggled option to every row of a service. A fresh blank row here would answer
+ * «I do these five things, in three days, for 500» with silence, because a
+ * subject chip was tapped off.
+ */
+export function dropRow(rows: Draft[], row: Draft): Draft[] {
+  const left = rows.filter((other) => other.key !== row.key);
+  if (left.some((other) => other.service_type_id === row.service_type_id)) return left;
+  return [
+    ...left,
+    {
+      ...row,
+      // The key a fresh row of this service would have: nothing else of this
+      // service is left to collide with it, and the chip that carried the old
+      // one is gone.
+      key: `${row.service_type_id}:new`,
+      subject_id: null,
+      subject_name: null,
+      institution_id: null,
+      institution_name: null,
+    },
+  ];
+}

--- a/apps/web/src/lib/offerRows.ts
+++ b/apps/web/src/lib/offerRows.ts
@@ -83,7 +83,11 @@ export function dropRow(rows: Draft[], row: Draft, axis: Axis): Draft[] {
   // no axis left beside a row that has one, and a row whose remaining axis
   // another row of the service already names — that pair is one offer, and the
   // server's unique index says so.
-  if (siblings.some((other) => bare || keyOf(other) === keyOf(left))) return others;
+  if (
+    bare ? siblings.length > 0 : siblings.some((other) => keyOf(other) === keyOf(left))
+  ) {
+    return others;
+  }
   // Otherwise in place, so the row keeps its position among its neighbours, and
   // re-keyed from what it now holds: a key naming an axis the row no longer has
   // is one `addAxis` could mint a second time.

--- a/apps/web/src/pages/OfferPrices.tsx
+++ b/apps/web/src/pages/OfferPrices.tsx
@@ -636,8 +636,7 @@ function PriceRow({
  * The rows of one service that already carry an axis, as removable chips.
  *
  * One component for subjects and schools: the two blocks were byte-identical
- * apart from the field they read, down to the closure that puts the service
- * back when its last axis goes.
+ * apart from the field they read and the axis they name when a chip goes.
  */
 function AxisChips({
   rows,

--- a/apps/web/src/pages/OfferPrices.tsx
+++ b/apps/web/src/pages/OfferPrices.tsx
@@ -25,6 +25,7 @@ import {
 import { hapticSelection, hapticSuccess, useMainButton } from '@/hooks/useTelegram';
 import { api } from '@/lib/api';
 import { groupRuns } from '@/lib/groups';
+import { type Draft, dropRow, serviceAnswers } from '@/lib/offerRows';
 import { TURNAROUNDS, TurnaroundLabel } from '@/lib/turnaround';
 import type {
   Institution,
@@ -174,16 +175,9 @@ export default function OfferPricesPage() {
   // Arrived here directly — a reload, or a link. There is nothing to price.
   if (!picked || picked.length === 0) return <Navigate to="/offer" replace />;
 
-  // Removing the last subject — or the last school — must not remove the
-  // service: the person ticked it, and a service with no axis is one search
-  // cannot reach yet, not one they withdrew.
-  const dropRow = (type: ServiceType, row: Draft) => {
-    setRows((current) => {
-      const left = current.filter((other) => other.key !== row.key);
-      return left.some((other) => other.service_type_id === type.id)
-        ? left
-        : [...left, blank(type)];
-    });
+  // What survives a removed chip is `dropRow`'s rule, and it is tested there.
+  const removeRow = (row: Draft) => {
+    setRows((current) => dropRow(current, row));
   };
 
   // The checklist belongs to the service, not to one of its rows: a person who
@@ -266,22 +260,11 @@ export default function OfferPricesPage() {
       if (empty) {
         return current.map((row) => (row === empty ? { ...row, ...axis } : row));
       }
+      // Inherits what the person already said about this service; see
+      // `serviceAnswers`, which is where that list is tested.
       return [
         ...current,
-        {
-          ...blank(type),
-          ...axis,
-          key,
-          // Inherits what the person already said about this service — the
-          // price, and the checklist the ticks above wrote to its other rows.
-          // Asking the same price four times is asking three times too many,
-          // and a row added after the ticks were set would otherwise save an
-          // empty checklist.
-          price: current.find((row) => row.service_type_id === type.id)?.price ?? '',
-          option_ids:
-            current.find((row) => row.service_type_id === type.id)?.option_ids ?? [],
-          note: current.find((row) => row.service_type_id === type.id)?.note ?? '',
-        },
+        { ...blank(type), ...serviceAnswers(current, type.id), ...axis, key },
       ];
     });
   };
@@ -360,7 +343,7 @@ export default function OfferPricesPage() {
                           <AxisChips
                             rows={mineHere.filter((row) => row.subject_id !== null)}
                             label={(row) => row.subject_name}
-                            onDrop={(row) => dropRow(type, row)}
+                            onDrop={(row) => removeRow(row)}
                             removeLabel={t`Убрать`}
                           />
                           <SubjectSearch
@@ -380,7 +363,7 @@ export default function OfferPricesPage() {
                           <AxisChips
                             rows={mineHere.filter((row) => row.institution_id !== null)}
                             label={(row) => row.institution_name}
-                            onDrop={(row) => dropRow(type, row)}
+                            onDrop={(row) => removeRow(row)}
                             removeLabel={t`Убрать`}
                           />
                           <InstitutionPicker
@@ -647,25 +630,6 @@ function PriceRow({
       </select>
     </div>
   );
-}
-
-/** One offer while it is being edited. The price is a string: an input mid-typing
- *  legitimately holds "" and "4", and parsing on every keystroke turns both into
- *  something the field then has to render back. */
-interface Draft {
-  key: string;
-  service_type_id: number;
-  subject_id: number | null;
-  subject_name: string | null;
-  institution_id: number | null;
-  institution_name: string | null;
-  option_ids: number[];
-  note: string;
-  // `null` is «договоримся», which is an answer, so the field is never absent.
-  turnaround_days: number | null;
-  price: string;
-  unit: PriceUnit;
-  langs: string[];
 }
 
 /**

--- a/apps/web/src/pages/OfferPrices.tsx
+++ b/apps/web/src/pages/OfferPrices.tsx
@@ -25,7 +25,7 @@ import {
 import { hapticSelection, hapticSuccess, useMainButton } from '@/hooks/useTelegram';
 import { api } from '@/lib/api';
 import { groupRuns } from '@/lib/groups';
-import { type Draft, dropRow, serviceAnswers } from '@/lib/offerRows';
+import { type Axis, type Draft, dropRow, serviceAnswers } from '@/lib/offerRows';
 import { TURNAROUNDS, TurnaroundLabel } from '@/lib/turnaround';
 import type {
   Institution,
@@ -176,8 +176,8 @@ export default function OfferPricesPage() {
   if (!picked || picked.length === 0) return <Navigate to="/offer" replace />;
 
   // What survives a removed chip is `dropRow`'s rule, and it is tested there.
-  const removeRow = (row: Draft) => {
-    setRows((current) => dropRow(current, row));
+  const removeAxis = (row: Draft, axis: Axis) => {
+    setRows((current) => dropRow(current, row, axis));
   };
 
   // The checklist belongs to the service, not to one of its rows: a person who
@@ -343,7 +343,7 @@ export default function OfferPricesPage() {
                           <AxisChips
                             rows={mineHere.filter((row) => row.subject_id !== null)}
                             label={(row) => row.subject_name}
-                            onDrop={(row) => removeRow(row)}
+                            onDrop={(row) => removeAxis(row, 'subject')}
                             removeLabel={t`Убрать`}
                           />
                           <SubjectSearch
@@ -363,7 +363,7 @@ export default function OfferPricesPage() {
                           <AxisChips
                             rows={mineHere.filter((row) => row.institution_id !== null)}
                             label={(row) => row.institution_name}
-                            onDrop={(row) => removeRow(row)}
+                            onDrop={(row) => removeAxis(row, 'institution')}
                             removeLabel={t`Убрать`}
                           />
                           <InstitutionPicker

--- a/apps/web/src/pages/OfferPrices.tsx
+++ b/apps/web/src/pages/OfferPrices.tsx
@@ -238,22 +238,23 @@ export default function OfferPricesPage() {
 
   // Which row it lands on, what it inherits and how it is keyed are
   // `addAxis`'s rules, and they are tested there.
-  const attach = (type: ServiceType, axis: Partial<Draft>) => {
+  const attach = (
+    type: ServiceType,
+    axis: Axis,
+    picked: { id: number; name: string },
+  ) => {
     hapticSelection();
-    setRows((current) => addAxis(current, blank(type), axis));
+    setRows((current) => addAxis(current, blank(type), axis, picked));
   };
 
   const addSubject = (type: ServiceType, subject: Subject) =>
-    attach(type, { subject_id: subject.id, subject_name: subject.name });
+    attach(type, 'subject', { id: subject.id, name: subject.name });
 
   const addInstitution = (type: ServiceType, institution: Institution) =>
-    attach(type, {
-      institution_id: institution.id,
-      // The server's own `institution_name`, not the short form: a chip that
-      // reads ČVUT until the screen reloads and then reads the full name is one
-      // school looking like two.
-      institution_name: institution.name,
-    });
+    // The server's own `institution.name`, not the short form: a chip that
+    // reads ČVUT until the screen reloads and then reads the full name is one
+    // school looking like two.
+    attach(type, 'institution', { id: institution.id, name: institution.name });
 
   return (
     <Screen>

--- a/apps/web/src/pages/OfferPrices.tsx
+++ b/apps/web/src/pages/OfferPrices.tsx
@@ -25,7 +25,7 @@ import {
 import { hapticSelection, hapticSuccess, useMainButton } from '@/hooks/useTelegram';
 import { api } from '@/lib/api';
 import { groupRuns } from '@/lib/groups';
-import { type Axis, type Draft, dropRow, serviceAnswers } from '@/lib/offerRows';
+import { type Axis, addAxis, type Draft, dropRow, keyOf } from '@/lib/offerRows';
 import { TURNAROUNDS, TurnaroundLabel } from '@/lib/turnaround';
 import type {
   Institution,
@@ -236,60 +236,24 @@ export default function OfferPricesPage() {
     );
   };
 
-  /**
-   * Attach a subject or a school to this service.
-   *
-   * One function for both, because they are the same move: `offers` is unique
-   * on its four axes, so calculus and physics — or ČVUT and VŠE — are two rows
-   * of the same service, and the first row of a service that takes an axis
-   * starts without one.
-   */
-  const addAxis = (
-    type: ServiceType,
-    key: string,
-    axis: Partial<Draft>,
-    hasNoAxis: (row: Draft) => boolean,
-  ) => {
+  // Which row it lands on, what it inherits and how it is keyed are
+  // `addAxis`'s rules, and they are tested there.
+  const attach = (type: ServiceType, axis: Partial<Draft>) => {
     hapticSelection();
-    setRows((current) => {
-      // Fill the empty first row rather than leaving it behind, which would
-      // save as "this service, no subject" alongside the real ones.
-      const empty = current.find(
-        (row) => row.service_type_id === type.id && hasNoAxis(row),
-      );
-      if (empty) {
-        return current.map((row) => (row === empty ? { ...row, ...axis } : row));
-      }
-      // Inherits what the person already said about this service; see
-      // `serviceAnswers`, which is where that list is tested.
-      return [
-        ...current,
-        { ...blank(type), ...serviceAnswers(current, type.id), ...axis, key },
-      ];
-    });
+    setRows((current) => addAxis(current, blank(type), axis));
   };
 
   const addSubject = (type: ServiceType, subject: Subject) =>
-    addAxis(
-      type,
-      `${type.id}:${subject.id}`,
-      { subject_id: subject.id, subject_name: subject.name },
-      (row) => row.subject_id === null,
-    );
+    attach(type, { subject_id: subject.id, subject_name: subject.name });
 
   const addInstitution = (type: ServiceType, institution: Institution) =>
-    addAxis(
-      type,
-      `${type.id}:inst:${institution.id}`,
-      {
-        institution_id: institution.id,
-        // The server's own `institution_name`, not the short form: a chip that
-        // reads ČVUT until the screen reloads and then reads the full name is
-        // one school looking like two.
-        institution_name: institution.name,
-      },
-      (row) => row.institution_id === null,
-    );
+    attach(type, {
+      institution_id: institution.id,
+      // The server's own `institution_name`, not the short form: a chip that
+      // reads ČVUT until the screen reloads and then reads the full name is one
+      // school looking like two.
+      institution_name: institution.name,
+    });
 
   return (
     <Screen>
@@ -667,8 +631,8 @@ function AxisChips({
 }
 
 function blank(type: ServiceType): Draft {
-  return {
-    key: `${type.id}:new`,
+  const row: Draft = {
+    key: '',
     service_type_id: type.id,
     subject_id: null,
     subject_name: null,
@@ -683,11 +647,13 @@ function blank(type: ServiceType): Draft {
     unit: type.default_price_unit ?? 'hour',
     langs: [],
   };
+  // Keyed like every other row, from its axes — see `keyOf`.
+  return { ...row, key: keyOf(row) };
 }
 
 function fromOffer(type: ServiceType, offer: MyOffer): Draft {
-  return {
-    key: `${offer.service_type_id}:${offer.subject_id}:${offer.institution_id}`,
+  const row: Draft = {
+    key: '',
     service_type_id: offer.service_type_id,
     subject_id: offer.subject_id,
     subject_name: offer.subject_name,
@@ -702,6 +668,7 @@ function fromOffer(type: ServiceType, offer: MyOffer): Draft {
     unit: offer.price_unit ?? type.default_price_unit ?? 'hour',
     langs: offer.langs,
   };
+  return { ...row, key: keyOf(row) };
 }
 
 /** An offer we are not editing, sent back exactly as it came. */

--- a/apps/web/tests/offerRows.test.ts
+++ b/apps/web/tests/offerRows.test.ts
@@ -93,7 +93,19 @@ test('a row with both axes goes only when both are gone', () => {
   // Two taps, the second on the row as it stands after the first — which is
   // what the chip the screen renders carries.
   const once = dropRow([both, other], both, 'subject');
-  const bare = once.find((candidate) => candidate.key === both.key);
-  assert.ok(bare);
-  assert.deepEqual(dropRow(once, bare, 'institution'), [other]);
+  const school = once.find((candidate) => candidate.institution_id === 4);
+  assert.ok(school);
+  assert.deepEqual(dropRow(once, school, 'institution'), [other]);
+});
+
+test('a cleared row is re-keyed from what it still holds', () => {
+  // The key names the row's axes, and `addAxis` mints keys the same way. A row
+  // still called `7:12` after subject 12 was cleared is one the picker can
+  // mint again — two rows, one key, and a duplicate the server refuses.
+  const both = row({ key: '7:12', institution_id: 4, institution_name: 'ČVUT' });
+  const [kept] = dropRow([both], both, 'subject');
+  assert.equal(kept?.key, '7:null:4');
+
+  const [bare] = dropRow([row()], row(), 'subject');
+  assert.equal(bare?.key, '7:null:null');
 });

--- a/apps/web/tests/offerRows.test.ts
+++ b/apps/web/tests/offerRows.test.ts
@@ -44,11 +44,11 @@ test('a service with other rows left simply loses the one removed', () => {
     subject_id: 13,
     subject_name: 'Линейная алгебра',
   });
-  assert.deepEqual(dropRow([row(), kept], row()), [kept]);
+  assert.deepEqual(dropRow([row(), kept], row(), 'subject'), [kept]);
 });
 
 test('the last row of a service stays, with its axes cleared', () => {
-  const [last, ...rest] = dropRow([row()], row());
+  const [last, ...rest] = dropRow([row()], row(), 'subject');
   assert.equal(rest.length, 0);
   assert.equal(last?.service_type_id, 7);
   assert.equal(last?.subject_id, null);
@@ -59,10 +59,41 @@ test('and keeps what the person said about the service itself', () => {
   // The checklist, the note, the turnaround and the price belong to the
   // service type, not to one of its rows — see docs/data-model.md. Tapping a
   // subject chip off is not an answer to any of those questions.
-  const [last] = dropRow([row()], row());
+  const [last] = dropRow([row()], row(), 'subject');
   assert.deepEqual(last?.option_ids, [3, 4]);
   assert.equal(last?.note, 'Разбираю задачи с прошлых экзаменов');
   assert.equal(last?.turnaround_days, 3);
   assert.equal(last?.price, '500');
   assert.deepEqual(last?.langs, ['ru']);
+});
+
+test('a row that also names a school keeps it when the subject goes', () => {
+  // One row can carry both axes — a school picked first and a subject after it
+  // fill the same row — and the chip that was tapped is the only answer being
+  // taken back.
+  const both = row({ institution_id: 4, institution_name: 'ČVUT' });
+  const [left, ...rest] = dropRow([both], both, 'subject');
+  assert.equal(rest.length, 0);
+  assert.equal(left?.subject_id, null);
+  assert.equal(left?.institution_id, 4);
+  assert.equal(left?.institution_name, 'ČVUT');
+});
+
+test('and keeps the subject when the school goes', () => {
+  const both = row({ institution_id: 4, institution_name: 'ČVUT' });
+  const [left] = dropRow([both], both, 'institution');
+  assert.equal(left?.institution_id, null);
+  assert.equal(left?.subject_id, 12);
+});
+
+test('a row with both axes goes only when both are gone', () => {
+  // The service has another row, so nothing has to be kept for its sake.
+  const both = row({ institution_id: 4, institution_name: 'ČVUT' });
+  const other = row({ key: '7:13:null', subject_id: 13, subject_name: 'Физика' });
+  // Two taps, the second on the row as it stands after the first — which is
+  // what the chip the screen renders carries.
+  const once = dropRow([both, other], both, 'subject');
+  const bare = once.find((candidate) => candidate.key === both.key);
+  assert.ok(bare);
+  assert.deepEqual(dropRow(once, bare, 'institution'), [other]);
 });

--- a/apps/web/tests/offerRows.test.ts
+++ b/apps/web/tests/offerRows.test.ts
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { type Draft, dropRow, serviceAnswers } from '../src/lib/offerRows.ts';
+import {
+  addAxis,
+  type Draft,
+  dropRow,
+  keyOf,
+  serviceAnswers,
+} from '../src/lib/offerRows.ts';
 
 /** A row of the service the tests use, with everything filled in. */
 function row(over: Partial<Draft> = {}): Draft {
@@ -130,4 +136,68 @@ test('a cleared row that duplicates another one goes instead', () => {
     ...shared,
   });
   assert.deepEqual(dropRow([cleared, second], second, 'subject'), [cleared]);
+});
+
+/** A row of a service nothing has been said about yet. */
+function blank(over: Partial<Draft> = {}): Draft {
+  const empty: Draft = {
+    key: '',
+    service_type_id: 7,
+    subject_id: null,
+    subject_name: null,
+    institution_id: null,
+    institution_name: null,
+    option_ids: [],
+    note: '',
+    turnaround_days: null,
+    price: '',
+    unit: 'hour',
+    langs: [],
+    ...over,
+  };
+  return { ...empty, key: keyOf(empty) };
+}
+
+test('the first axis of a service fills its empty row', () => {
+  const rows = addAxis([blank()], blank(), { subject_id: 12, subject_name: 'Матан' });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]?.subject_id, 12);
+});
+
+test('a filled row is re-keyed, or the next one can be minted onto it', () => {
+  // The defect this pins: filling a row without re-keying leaves the key
+  // naming axes the row no longer has, and `keyOf` can then mint it again for
+  // a different row — two rows, one key, one price field between them.
+  const rows = addAxis([blank()], blank(), {
+    institution_id: 4,
+    institution_name: 'ČVUT',
+  });
+  assert.equal(rows[0]?.key, keyOf(rows[0] as Draft));
+  assert.equal(new Set(rows.map((r) => r.key)).size, rows.length);
+});
+
+test('a second axis is added, and starts from what the service says', () => {
+  const rows = addAxis([row()], blank(), { subject_id: 13, subject_name: 'Физика' });
+  assert.equal(rows.length, 2);
+  assert.equal(rows[1]?.price, '500');
+  assert.deepEqual(rows[1]?.option_ids, [3, 4]);
+  assert.equal(rows[1]?.turnaround_days, 3);
+  assert.equal(rows[1]?.key, '7:13:null');
+});
+
+test('every row of a service keeps a key of its own through both moves', () => {
+  // The trace a review found: fill, clear, fill again, clear again.
+  let rows = [
+    row({ key: '7:12:5', institution_id: 5, institution_name: 'ČVUT' }),
+    row({ key: '7:12:9', institution_id: 9, institution_name: 'VŠE' }),
+  ];
+  const first = rows[0] as Draft;
+  rows = dropRow(rows, first, 'institution');
+  const emptied = rows.find((candidate) => candidate.institution_id === null) as Draft;
+  assert.ok(emptied);
+  rows = addAxis(rows, blank(), { institution_id: 7, institution_name: 'UK' });
+  const second = rows.find((candidate) => candidate.institution_id === 9) as Draft;
+  rows = dropRow(rows, second, 'institution');
+  assert.equal(new Set(rows.map((r) => r.key)).size, rows.length);
+  for (const candidate of rows) assert.equal(candidate.key, keyOf(candidate));
 });

--- a/apps/web/tests/offerRows.test.ts
+++ b/apps/web/tests/offerRows.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { type Draft, dropRow, serviceAnswers } from '../src/lib/offerRows.ts';
+
+/** A row of the service the tests use, with everything filled in. */
+function row(over: Partial<Draft> = {}): Draft {
+  return {
+    key: '7:12:null',
+    service_type_id: 7,
+    subject_id: 12,
+    subject_name: 'Математический анализ',
+    institution_id: null,
+    institution_name: null,
+    option_ids: [3, 4],
+    note: 'Разбираю задачи с прошлых экзаменов',
+    turnaround_days: 3,
+    price: '500',
+    unit: 'hour',
+    langs: ['ru'],
+    ...over,
+  };
+}
+
+test('a second subject starts from what the service already says', () => {
+  // Every answer that belongs to the service, the turnaround included: a
+  // person who set «за 3 дня» and then added a second subject would otherwise
+  // publish one row promising three days and one promising nothing.
+  assert.deepEqual(serviceAnswers([row()], 7), {
+    price: '500',
+    option_ids: [3, 4],
+    note: 'Разбираю задачи с прошлых экзаменов',
+    turnaround_days: 3,
+  });
+});
+
+test('a service with no row yet inherits nothing', () => {
+  assert.deepEqual(serviceAnswers([row()], 9), {});
+});
+
+test('a service with other rows left simply loses the one removed', () => {
+  const kept = row({
+    key: '7:13:null',
+    subject_id: 13,
+    subject_name: 'Линейная алгебра',
+  });
+  assert.deepEqual(dropRow([row(), kept], row()), [kept]);
+});
+
+test('the last row of a service stays, with its axes cleared', () => {
+  const [last, ...rest] = dropRow([row()], row());
+  assert.equal(rest.length, 0);
+  assert.equal(last?.service_type_id, 7);
+  assert.equal(last?.subject_id, null);
+  assert.equal(last?.subject_name, null);
+});
+
+test('and keeps what the person said about the service itself', () => {
+  // The checklist, the note, the turnaround and the price belong to the
+  // service type, not to one of its rows — see docs/data-model.md. Tapping a
+  // subject chip off is not an answer to any of those questions.
+  const [last] = dropRow([row()], row());
+  assert.deepEqual(last?.option_ids, [3, 4]);
+  assert.equal(last?.note, 'Разбираю задачи с прошлых экзаменов');
+  assert.equal(last?.turnaround_days, 3);
+  assert.equal(last?.price, '500');
+  assert.deepEqual(last?.langs, ['ru']);
+});

--- a/apps/web/tests/offerRows.test.ts
+++ b/apps/web/tests/offerRows.test.ts
@@ -159,7 +159,7 @@ function blank(over: Partial<Draft> = {}): Draft {
 }
 
 test('the first axis of a service fills its empty row', () => {
-  const rows = addAxis([blank()], blank(), { subject_id: 12, subject_name: 'Матан' });
+  const rows = addAxis([blank()], blank(), 'subject', { id: 12, name: 'Матан' });
   assert.equal(rows.length, 1);
   assert.equal(rows[0]?.subject_id, 12);
 });
@@ -168,16 +168,13 @@ test('a filled row is re-keyed, or the next one can be minted onto it', () => {
   // The defect this pins: filling a row without re-keying leaves the key
   // naming axes the row no longer has, and `keyOf` can then mint it again for
   // a different row — two rows, one key, one price field between them.
-  const rows = addAxis([blank()], blank(), {
-    institution_id: 4,
-    institution_name: 'ČVUT',
-  });
+  const rows = addAxis([blank()], blank(), 'institution', { id: 4, name: 'ČVUT' });
   assert.equal(rows[0]?.key, keyOf(rows[0] as Draft));
   assert.equal(new Set(rows.map((r) => r.key)).size, rows.length);
 });
 
 test('a second axis is added, and starts from what the service says', () => {
-  const rows = addAxis([row()], blank(), { subject_id: 13, subject_name: 'Физика' });
+  const rows = addAxis([row()], blank(), 'subject', { id: 13, name: 'Физика' });
   assert.equal(rows.length, 2);
   assert.equal(rows[1]?.price, '500');
   assert.deepEqual(rows[1]?.option_ids, [3, 4]);
@@ -195,7 +192,7 @@ test('every row of a service keeps a key of its own through both moves', () => {
   rows = dropRow(rows, first, 'institution');
   const emptied = rows.find((candidate) => candidate.institution_id === null) as Draft;
   assert.ok(emptied);
-  rows = addAxis(rows, blank(), { institution_id: 7, institution_name: 'UK' });
+  rows = addAxis(rows, blank(), 'institution', { id: 7, name: 'UK' });
   const second = rows.find((candidate) => candidate.institution_id === 9) as Draft;
   rows = dropRow(rows, second, 'institution');
   assert.equal(new Set(rows.map((r) => r.key)).size, rows.length);

--- a/apps/web/tests/offerRows.test.ts
+++ b/apps/web/tests/offerRows.test.ts
@@ -28,6 +28,7 @@ test('a second subject starts from what the service already says', () => {
   // publish one row promising three days and one promising nothing.
   assert.deepEqual(serviceAnswers([row()], 7), {
     price: '500',
+    unit: 'hour',
     option_ids: [3, 4],
     note: 'Разбираю задачи с прошлых экзаменов',
     turnaround_days: 3,
@@ -108,4 +109,25 @@ test('a cleared row is re-keyed from what it still holds', () => {
 
   const [bare] = dropRow([row()], row(), 'subject');
   assert.equal(bare?.key, '7:null:null');
+});
+
+test('a cleared row that duplicates another one goes instead', () => {
+  // Two rows of one service at the same school, the first already cleared of
+  // its subject. Clearing the second's would name the same pair, which
+  // `offers` is unique on: two rows for one offer, sharing a key and a price
+  // field, and a save the server refuses.
+  const shared = { institution_id: 4, institution_name: 'ČVUT' };
+  const cleared = row({
+    key: '7:null:4',
+    subject_id: null,
+    subject_name: null,
+    ...shared,
+  });
+  const second = row({
+    key: '7:13:4',
+    subject_id: 13,
+    subject_name: 'Физика',
+    ...shared,
+  });
+  assert.deepEqual(dropRow([cleared, second], second, 'subject'), [cleared]);
 });

--- a/apps/web/tsconfig.test.json
+++ b/apps/web/tsconfig.test.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    // node, not vite/client: these run in node's own test runner.
+    "types": ["node"],
+
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    // The tests import the module under test by path, extension and all,
+    // because node resolves what it is given.
+    "allowImportingTsExtensions": true,
+    "skipLibCheck": true,
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["tests"]
+}


### PR DESCRIPTION
Docs updated first: README.md, apps/web/README.md

Tap the last subject off a service on the prices screen and the row was
replaced by a fresh blank one — which threw away the checklist, the note, the
turnaround and the price. None of those belong to the row.
`docs/data-model.md` says so of the two columns, and the screen already writes
a toggled option to *every* row of a service; only this path disagreed.

## What changes

- **A removed chip takes back the chip and nothing else.** The row stays and
  loses the axis that was tapped. It goes only when it would say nothing new:
  no axis left beside a row that has one, or a remaining axis another row of
  the service already names — that pair is one offer, and `uq_offers_axes`
  says so.
- **A row can carry both axes** — a school picked first and a subject after it
  fill the same row — so removing the subject there leaves the school.
- **A new row inherits the turnaround** as well as the price, its unit and the
  checklist. It inherited three of the five, so a person who set «за 3 дня» and
  then added a second subject published one row promising three days and one
  promising nothing.
- **One place mints a row key**, from the row's axes. Two mints in one
  namespace produced twins: two rows sharing a key, one price field writing
  both, and a save the server refuses.

The rules live in `apps/web/src/lib/offerRows.ts`. What survives a removed chip
is a decision about somebody's saved answers, not a layout, and it should be
provable without rendering a screen.

## A test runner for the mini app

There was none, so a rule like this had nowhere to be pinned. Node's own runner
is enough: `pnpm test`, **no dependency added**, type-checked through
`tsconfig.test.json`, wired into `make check` and the CI web job. CI's node
moves to 24 — node strips TypeScript unflagged only from 22.18.

It goes through `scripts/test.mjs` rather than `node --test <glob>` because the
glob exits 0 reporting "tests 0" when it matches nothing: a renamed directory
would leave every check green with nothing executed. Same paranoia as the
contract check, same reason.

## Verification

`make check` green: 427 API tests, 14 new web tests, ruff, ty, biome, tsc,
lingui `--strict`, `make contract`. Every rule mutation-checked. In the running
app: the last school chip of «Přijímačky» removed keeps the row and its 700 Kč,
and putting a different school back fills that row rather than adding a second.

Independent review: approved with no findings, after six rounds that found
twelve defects between them — among them a README line this branch made false,
the silent zero-test glob, the key collision through the fill branch, a price
inherited without its unit, and an axis inferred from the payload instead of
named.

## Out of scope

- The turnaround and the checklist are still written to every row of a service
  rather than held once per service; the shape follows `offers`.
- No service type declares both axes today, so the dual-axis paths above are
  the rule the screen codes for rather than a state the catalog can reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL
