### PR TITLE
A write is a rule, even a one-line one

### DIFF
--- a/apps/api/src/students_cz/api/v1/browse.py
+++ b/apps/api/src/students_cz/api/v1/browse.py
@@ -37,8 +37,13 @@ async def helper_detail(
 async def start_contact(user_id: int, session: SessionDep, user: UserDep) -> ContactOut:
     """Record that someone is about to write, and hand back the link.
 
-    The rule is `catalog.start_contact`. This sentence stays here because it is
-    the operation's description in the OpenAPI document, which the client is
-    generated from.
+    The conversation itself happens in Telegram, where both people already are.
+    What we keep is that it started — which is the only honest basis for the
+    response times and deal counts shown on a card. Self-reported numbers would
+    be worth nothing.
     """
+    # Word for word what it was before the rule moved to `catalog.start_contact`:
+    # a route's docstring is the operation's description in the OpenAPI
+    # document, so rewriting it here would change the contract, and it is
+    # addressed to whoever reads /docs rather than to whoever reads this file.
     return await catalog.start_contact(session, viewer=user, helper_id=user_id)

--- a/apps/api/src/students_cz/api/v1/browse.py
+++ b/apps/api/src/students_cz/api/v1/browse.py
@@ -35,4 +35,10 @@ async def helper_detail(
     tags=["catalog"],
 )
 async def start_contact(user_id: int, session: SessionDep, user: UserDep) -> ContactOut:
+    """Record that someone is about to write, and hand back the link.
+
+    The rule is `catalog.start_contact`. This sentence stays here because it is
+    the operation's description in the OpenAPI document, which the client is
+    generated from.
+    """
     return await catalog.start_contact(session, viewer=user, helper_id=user_id)

--- a/apps/api/src/students_cz/api/v1/browse.py
+++ b/apps/api/src/students_cz/api/v1/browse.py
@@ -1,35 +1,21 @@
 """The catalog as a visitor sees it: the home screen, a person, a contact."""
 
 from fastapi import APIRouter, HTTPException, status
-from sqlalchemy import select
-from sqlalchemy.orm import selectinload
 
 from students_cz.api.deps import LangDep, SessionDep, UserDep
-from students_cz.db.models import (
-    Contact,
-    HelperProfile,
-)
-from students_cz.db.models.enums import (
-    PublishStatus,
-    UserEventKind,
-)
 from students_cz.schemas import (
     ContactOut,
     HelperDetailOut,
     HomeOut,
 )
 from students_cz.services import catalog
-from students_cz.services.people import log_event
 
 router = APIRouter()
 
 
 @router.get("/home", response_model=HomeOut, tags=["catalog"])
 async def home(session: SessionDep, lang: LangDep, user: UserDep) -> HomeOut:
-    people, things = await catalog.home_sections(session, lang)
-    # The first screen stands in for "opened the app". Logging every request
-    # would drown the signal in taxonomy fetches.
-    await log_event(session, user.id, UserEventKind.APP_OPEN, lang=lang.value)
+    people, things = await catalog.open_home(session, lang, viewer=user)
     return HomeOut(people=people, things=things)
 
 
@@ -37,10 +23,9 @@ async def home(session: SessionDep, lang: LangDep, user: UserDep) -> HomeOut:
 async def helper_detail(
     user_id: int, session: SessionDep, lang: LangDep, user: UserDep
 ) -> HelperDetailOut:
-    detail = await catalog.helper_detail(session, user_id, lang)
+    detail = await catalog.view_helper(session, user_id, lang, viewer=user)
     if detail is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "no such published profile")
-    await log_event(session, user.id, UserEventKind.HELPER_VIEW, helper_id=user_id)
     return detail
 
 
@@ -50,31 +35,6 @@ async def helper_detail(
     tags=["catalog"],
 )
 async def start_contact(
-    user_id: int, session: SessionDep, lang: LangDep, user: UserDep
+    user_id: int, session: SessionDep, user: UserDep
 ) -> ContactOut:
-    """Record that someone is about to write, and hand back the link.
-
-    The conversation itself happens in Telegram, where both people already are.
-    What we keep is that it started — which is the only honest basis for the
-    response times and deal counts shown on a card. Self-reported numbers would
-    be worth nothing.
-    """
-    if user_id == user.id:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "that is your own profile")
-
-    helper = await session.scalar(
-        select(HelperProfile)
-        .where(HelperProfile.user_id == user_id)
-        .options(selectinload(HelperProfile.user))
-    )
-    if helper is None or helper.status != PublishStatus.PUBLISHED:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "no such published profile")
-    if not helper.user.tg_username:
-        raise HTTPException(
-            status.HTTP_409_CONFLICT, "this person has no public username"
-        )
-
-    session.add(Contact(student_id=user.id, helper_id=user_id, intro_text=None))
-    await log_event(session, user.id, UserEventKind.CONTACT, helper_id=user_id)
-
-    return ContactOut(telegram_url=f"https://t.me/{helper.user.tg_username}")
+    return await catalog.start_contact(session, viewer=user, helper_id=user_id)

--- a/apps/api/src/students_cz/api/v1/browse.py
+++ b/apps/api/src/students_cz/api/v1/browse.py
@@ -34,7 +34,5 @@ async def helper_detail(
     response_model=ContactOut,
     tags=["catalog"],
 )
-async def start_contact(
-    user_id: int, session: SessionDep, user: UserDep
-) -> ContactOut:
+async def start_contact(user_id: int, session: SessionDep, user: UserDep) -> ContactOut:
     return await catalog.start_contact(session, viewer=user, helper_id=user_id)

--- a/apps/api/src/students_cz/api/v1/me.py
+++ b/apps/api/src/students_cz/api/v1/me.py
@@ -15,7 +15,7 @@ from students_cz.schemas import (
     MeUpdate,
 )
 from students_cz.services.catalog import avatar_for
-from students_cz.services.refs import require_row
+from students_cz.services.people import update_profile
 
 router = APIRouter()
 
@@ -52,15 +52,8 @@ async def read_me(user: UserDep, session: SessionDep, lang: LangDep) -> MeOut:
 async def update_me(
     payload: MeUpdate, user: UserDep, session: SessionDep, lang: LangDep
 ) -> MeOut:
-    if payload.ui_lang is not None:
-        user.ui_lang = payload.ui_lang
-    if payload.spoken_langs is not None:
-        user.spoken_langs = payload.spoken_langs
-    if payload.city is not None:
-        user.city = payload.city or None
-    if payload.institution_id is not None:
-        await require_row(
-            session, Institution, payload.institution_id or None, "institution_id"
-        )
-        user.institution_id = payload.institution_id or None
+    await update_profile(session, user, payload)
+    # The language the payload just set, not the one the request arrived with:
+    # `LangDep` was resolved before the change, so reading it back through the
+    # old one would answer the screen in the language it just left.
     return await read_me(user, session, payload.ui_lang or lang)

--- a/apps/api/src/students_cz/api/v1/search.py
+++ b/apps/api/src/students_cz/api/v1/search.py
@@ -1,7 +1,9 @@
 """One free-text field, and what the catalog makes of it.
 
 `parse` turns a sentence into editable chips and at most one clarifying
-question; `search` runs the axes those chips describe.
+question — the rule for that, and the two rows it records, live in
+`services/search.py`. `search` runs the axes those chips describe, and writes
+nothing.
 """
 
 from fastapi import APIRouter, Query
@@ -11,28 +13,18 @@ from sqlalchemy.orm import selectinload
 from students_cz.api.deps import LangDep, SessionDep, UserDep
 from students_cz.db.models import (
     Institution,
-    SearchQuery,
     ServiceType,
     Subject,
 )
-from students_cz.db.models.enums import (
-    UserEventKind,
-)
 from students_cz.schemas import (
-    AlsoSubject,
     Chip,
-    Clarify,
-    ClarifyOption,
     ParseOut,
     ParseRequest,
-    Phrase,
     SearchFilters,
     SearchOut,
 )
-from students_cz.services import catalog, parser
-from students_cz.services.lookup import VECTOR_ALSO_FLOOR
+from students_cz.services import catalog, search
 from students_cz.services.naming import short_form, translated
-from students_cz.services.people import log_event
 
 router = APIRouter()
 
@@ -41,162 +33,7 @@ router = APIRouter()
 async def parse_query(
     payload: ParseRequest, session: SessionDep, lang: LangDep, user: UserDep
 ) -> ParseOut:
-    """Read a sentence and show back what we made of it.
-
-    Every call is logged with its parse and result count. Queries that match
-    nothing are the ranked list of what the catalog is missing, and the raw
-    text next to the parse is what a better parser would be trained on.
-    """
-    parsed = await parser.parse(session, payload.text, lang.value)
-
-    chips: list[Chip] = []
-    if parsed.subject:
-        chips.append(
-            Chip(
-                kind="subject",
-                label=parsed.subject.label,
-                value=parsed.subject.id,
-                confidence=round(parsed.subject.score, 2),
-            )
-        )
-    if parsed.institution:
-        chips.append(
-            Chip(
-                kind="institution",
-                label=parsed.institution.label,
-                value=parsed.institution.id,
-                confidence=round(parsed.institution.score, 2),
-            )
-        )
-    service_type_id = None
-    if parsed.service_type:
-        service = await session.scalar(
-            select(ServiceType)
-            .where(ServiceType.code == parsed.service_type)
-            .options(selectinload(ServiceType.names))
-        )
-        if service:
-            service_type_id = service.id
-            chips.append(
-                Chip(
-                    kind="service_type",
-                    label=translated(service, lang) or service.code,
-                    value=service.id,
-                )
-            )
-    if parsed.deadline:
-        chips.append(
-            Chip(
-                kind="deadline",
-                label=parsed.deadline.isoformat(),
-                value=parsed.deadline.isoformat(),
-            )
-        )
-    if parsed.budget_max:
-        chips.append(
-            Chip(
-                kind="budget",
-                label=str(int(parsed.budget_max)),
-                value=int(parsed.budget_max),
-            )
-        )
-
-    # Every parsed filter the search can apply, the budget included. Leaving one
-    # out counts people this query does not reach, and writes that number into
-    # `search_queries`, where a result for a query nobody ran is worse than no
-    # row at all. The deadline is the exception that cannot be honoured: there is
-    # no date filter to pass it to, so a query saying nothing but a date counts
-    # the whole catalog — see docs/data-model.md.
-    total, _ = await catalog.search(
-        session,
-        lang,
-        viewer=user,
-        subject_id=parsed.subject.id if parsed.subject else None,
-        institution_id=parsed.institution.id if parsed.institution else None,
-        service_type_id=service_type_id,
-        max_price=parsed.budget_max,
-        limit=1,
-    )
-
-    await log_event(
-        session, user.id, UserEventKind.SEARCH, text=payload.text, results=total
-    )
-    session.add(
-        SearchQuery(
-            user_id=user.id,
-            raw_text=payload.text,
-            parsed={
-                "subject_id": parsed.subject.id if parsed.subject else None,
-                "institution_id": (parsed.institution.id if parsed.institution else None),
-                "service_type": parsed.service_type,
-                "deadline": parsed.deadline.isoformat() if parsed.deadline else None,
-                "budget_max": parsed.budget_max,
-                # What the embedder proposed, and whether it was believed.
-                # Logged even when refused: the two thresholds it is judged by
-                # were set by eye, and this is the only place the numbers to
-                # replace them can come from.
-                "vector": (
-                    {
-                        "subject_id": parsed.vector[0].id,
-                        "score": round(parsed.vector[0].score, 3),
-                        "lead": round(parsed.vector[1], 3),
-                        "used": parsed.subject is not None
-                        and parsed.subject.matched_on == "vector",
-                    }
-                    if parsed.vector
-                    else None
-                ),
-            },
-            results_count=total,
-            parser="rules.v1",
-        )
-    )
-
-    return ParseOut(
-        chips=chips,
-        clarify=_clarify_for(parsed),
-        matches=total,
-        note=Phrase(code="parse.nothing_recognised") if not chips else None,
-        also=_also(parsed),
-    )
-
-
-def _also(parsed: parser.ParsedQuery) -> AlsoSubject | None:
-    """The guess the parse would not search by, when it is worth reading.
-
-    Not when it was believed — then it is the subject, and repeating it would be
-    the same list twice. Not when it is noise. And not when it conflicts with
-    the kind of help, believed or not: a subject that cannot go with what was
-    asked for cannot go beside it either, and the list behind it would be empty
-    by construction.
-    """
-    if not parsed.vector or parsed.vector_conflicted:
-        return None
-    proposed, _ = parsed.vector
-    if parsed.subject and parsed.subject.id == proposed.id:
-        return None
-    if proposed.score < VECTOR_ALSO_FLOOR:
-        return None
-    return AlsoSubject(subject_id=proposed.id, label=proposed.label)
-
-
-def _clarify_for(parsed: parser.ParsedQuery) -> Clarify | None:
-    """Ask at most one question, and only when it narrows the result.
-
-    If the text already says which kind of help is wanted, there is nothing to
-    ask; if it says nothing at all, a question about exam timing would be
-    guessing at the wrong thing.
-    """
-    if parsed.service_type or parsed.unmatched:
-        return None
-    return Clarify(
-        code="clarify.when",
-        options=[
-            ClarifyOption(code="exam_prep", tone=0),
-            ClarifyOption(code="exam_live_help", tone=1),
-            ClarifyOption(code="both", tone=5),
-        ],
-    )
+    return await search.describe(session, lang, viewer=user, text=payload.text)
 
 
 @router.get("/search", response_model=SearchOut, tags=["search"])

--- a/apps/api/src/students_cz/api/v1/search.py
+++ b/apps/api/src/students_cz/api/v1/search.py
@@ -35,10 +35,13 @@ async def parse_query(
 ) -> ParseOut:
     """Read a sentence and show back what we made of it.
 
-    The rule is `services/search.describe`. This sentence stays here because it
-    is the operation's description in the OpenAPI document, which the client is
-    generated from.
+    Every call is logged with its parse and result count. Queries that match
+    nothing are the ranked list of what the catalog is missing, and the raw
+    text next to the parse is what a better parser would be trained on.
     """
+    # Unchanged for the reason `browse.start_contact` gives: the docstring is
+    # the operation's description in the OpenAPI document. The rule itself is
+    # `services/search.describe`.
     return await search.describe(session, lang, viewer=user, text=payload.text)
 
 

--- a/apps/api/src/students_cz/api/v1/search.py
+++ b/apps/api/src/students_cz/api/v1/search.py
@@ -33,6 +33,12 @@ router = APIRouter()
 async def parse_query(
     payload: ParseRequest, session: SessionDep, lang: LangDep, user: UserDep
 ) -> ParseOut:
+    """Read a sentence and show back what we made of it.
+
+    The rule is `services/search.describe`. This sentence stays here because it
+    is the operation's description in the OpenAPI document, which the client is
+    generated from.
+    """
     return await search.describe(session, lang, viewer=user, text=payload.text)
 
 

--- a/apps/api/src/students_cz/services/catalog.py
+++ b/apps/api/src/students_cz/services/catalog.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import selectinload
 
 from students_cz.db.models import (
     AvailabilitySlot,
+    Contact,
     HelperProfile,
     Institution,
     Offer,
@@ -18,9 +19,10 @@ from students_cz.db.models import (
     User,
     UserEducation,
 )
-from students_cz.db.models.enums import PublishStatus, UiLang
+from students_cz.db.models.enums import PublishStatus, UiLang, UserEventKind
 from students_cz.schemas import (
     Avatar,
+    ContactOut,
     HelperCardOut,
     HelperDetailOut,
     HomeSection,
@@ -29,7 +31,9 @@ from students_cz.schemas import (
     Price,
     Stat,
 )
+from students_cz.services import errors
 from students_cz.services.naming import rows_by_id, short_form, translated
+from students_cz.services.people import log_event
 
 SortKey = Literal["relevance", "price", "available"]
 
@@ -612,9 +616,75 @@ async def _offers_out(
     return out
 
 
+async def open_home(
+    session: AsyncSession, lang: UiLang, *, viewer: User
+) -> tuple[list[HomeSection], list[HomeSection]]:
+    """The home screen, and the fact that somebody opened the app.
+
+    Separate from `home_sections` rather than folded into it: the sections are
+    a read the bot may want without claiming anybody opened anything, and this
+    is the screen standing in for "opened the app". Logging every request would
+    drown that signal in taxonomy fetches.
+    """
+    sections = await home_sections(session, lang)
+    await log_event(session, viewer.id, UserEventKind.APP_OPEN, lang=lang.value)
+    return sections
+
+
+async def view_helper(
+    session: AsyncSession, user_id: int, lang: UiLang, *, viewer: User
+) -> HelperDetailOut | None:
+    """One person's page, and the fact that it was read.
+
+    Nothing is recorded when there is no such page: an event here would count
+    views of profiles that do not exist as views of profiles.
+    """
+    detail = await helper_detail(session, user_id, lang)
+    if detail is None:
+        return None
+    await log_event(session, viewer.id, UserEventKind.HELPER_VIEW, helper_id=user_id)
+    return detail
+
+
+async def start_contact(
+    session: AsyncSession, *, viewer: User, helper_id: int
+) -> ContactOut:
+    """Record that someone is about to write, and hand back the link.
+
+    The conversation itself happens in Telegram, where both people already are.
+    What we keep is that it started — which is the only honest basis for the
+    response times and deal counts shown on a card. Self-reported numbers would
+    be worth nothing.
+
+    `BadRequest` rather than `Invalid` for writing to yourself: it answered 400
+    before this moved out of the route, and a status code is not the thing this
+    change is allowed to alter.
+    """
+    if helper_id == viewer.id:
+        raise errors.BadRequest("that is your own profile")
+
+    helper = await session.scalar(
+        select(HelperProfile)
+        .where(HelperProfile.user_id == helper_id)
+        .options(selectinload(HelperProfile.user))
+    )
+    if helper is None or helper.status != PublishStatus.PUBLISHED:
+        raise errors.NotFound("no such published profile")
+    if not helper.user.tg_username:
+        raise errors.Conflict("this person has no public username")
+
+    session.add(Contact(student_id=viewer.id, helper_id=helper_id, intro_text=None))
+    await log_event(session, viewer.id, UserEventKind.CONTACT, helper_id=helper_id)
+
+    return ContactOut(telegram_url=f"https://t.me/{helper.user.tg_username}")
+
+
 __all__ = [
     "avatar_for",
     "helper_detail",
     "home_sections",
+    "open_home",
     "search",
+    "start_contact",
+    "view_helper",
 ]

--- a/apps/api/src/students_cz/services/errors.py
+++ b/apps/api/src/students_cz/services/errors.py
@@ -35,10 +35,10 @@ class Invalid(ServiceError):
 
 
 class BadRequest(ServiceError):
-    """Answers 400, and exists only because one endpoint already did.
+    """Answers 400, and exists only because two endpoints already did.
 
-    Not a category — `Invalid` is the category. This is here so that
-    "you cannot answer your own request", which answered 400 long before any
-    of this moved into services, still answers 400. Reach for `Invalid`
-    unless you are preserving an existing 400.
+    Not a category — `Invalid` is the category. This is here so that "you
+    cannot answer your own request" and "that is your own profile", which
+    answered 400 long before either moved into a service, still answer 400.
+    Reach for `Invalid` unless you are preserving an existing 400.
     """

--- a/apps/api/src/students_cz/services/people.py
+++ b/apps/api/src/students_cz/services/people.py
@@ -14,8 +14,10 @@ from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from students_cz.db.models import User, UserEvent
+from students_cz.db.models import Institution, User, UserEvent
 from students_cz.db.models.enums import UiLang, UserEventKind
+from students_cz.schemas import MeUpdate
+from students_cz.services.refs import require_row
 
 # Telegram sends a language tag that may carry a region ("en-US"), and may name
 # a language we do not ship.
@@ -170,3 +172,28 @@ def reachable(*, langs: list[str] | None = None, source: str | None = None):
     if source:
         stmt = stmt.where(User.source == source)
     return stmt
+
+
+async def update_profile(session: AsyncSession, user: User, spec: MeUpdate) -> None:
+    """Apply what the account screen sent, and nothing it did not send.
+
+    A field the payload leaves out — or leaves null — is a question the screen
+    did not ask, so it is not an answer to overwrite with. `institution_id: 0`
+    is the one exception and means "no school": it is how the picker says
+    cleared, since a null cannot be told from an omission here.
+
+    The institution is checked before it is written so an id nobody has ever
+    seen answers as the field it is, rather than as a foreign-key violation
+    from Postgres.
+    """
+    if spec.ui_lang is not None:
+        user.ui_lang = spec.ui_lang
+    if spec.spoken_langs is not None:
+        user.spoken_langs = spec.spoken_langs
+    if spec.city is not None:
+        user.city = spec.city or None
+    if spec.institution_id is not None:
+        await require_row(
+            session, Institution, spec.institution_id or None, "institution_id"
+        )
+        user.institution_id = spec.institution_id or None

--- a/apps/api/src/students_cz/services/search.py
+++ b/apps/api/src/students_cz/services/search.py
@@ -1,0 +1,186 @@
+"""What a sentence is understood to mean, and what that leaves behind.
+
+`parser` reads the words; this turns the reading into the screen — chips to
+correct, at most one question, a count — and records two things while it does:
+an event, and the query itself.
+
+Both rows are deliberate. Queries that match nothing are the ranked list of
+what the catalog is missing, and the raw text beside the parse is what a better
+parser would be trained on.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from students_cz.db.models import SearchQuery, ServiceType, User
+from students_cz.db.models.enums import UiLang, UserEventKind
+from students_cz.schemas import (
+    AlsoSubject,
+    Chip,
+    Clarify,
+    ClarifyOption,
+    ParseOut,
+    Phrase,
+)
+from students_cz.services import catalog, parser
+from students_cz.services.lookup import VECTOR_ALSO_FLOOR
+from students_cz.services.naming import translated
+from students_cz.services.people import log_event
+
+
+async def describe(
+    session: AsyncSession, lang: UiLang, *, viewer: User, text: str
+) -> ParseOut:
+    """Read a sentence and say back what was made of it."""
+    parsed = await parser.parse(session, text, lang.value)
+
+    chips: list[Chip] = []
+    if parsed.subject:
+        chips.append(
+            Chip(
+                kind="subject",
+                label=parsed.subject.label,
+                value=parsed.subject.id,
+                confidence=round(parsed.subject.score, 2),
+            )
+        )
+    if parsed.institution:
+        chips.append(
+            Chip(
+                kind="institution",
+                label=parsed.institution.label,
+                value=parsed.institution.id,
+                confidence=round(parsed.institution.score, 2),
+            )
+        )
+    service_type_id = None
+    if parsed.service_type:
+        service = await session.scalar(
+            select(ServiceType)
+            .where(ServiceType.code == parsed.service_type)
+            .options(selectinload(ServiceType.names))
+        )
+        if service:
+            service_type_id = service.id
+            chips.append(
+                Chip(
+                    kind="service_type",
+                    label=translated(service, lang) or service.code,
+                    value=service.id,
+                )
+            )
+    if parsed.deadline:
+        chips.append(
+            Chip(
+                kind="deadline",
+                label=parsed.deadline.isoformat(),
+                value=parsed.deadline.isoformat(),
+            )
+        )
+    if parsed.budget_max:
+        chips.append(
+            Chip(
+                kind="budget",
+                label=str(int(parsed.budget_max)),
+                value=int(parsed.budget_max),
+            )
+        )
+
+    # Every parsed filter the search can apply, the budget included. Leaving one
+    # out counts people this query does not reach, and writes that number into
+    # `search_queries`, where a result for a query nobody ran is worse than no
+    # row at all. The deadline is the exception that cannot be honoured: there is
+    # no date filter to pass it to, so a query saying nothing but a date counts
+    # the whole catalog — see docs/data-model.md.
+    total, _ = await catalog.search(
+        session,
+        lang,
+        viewer=viewer,
+        subject_id=parsed.subject.id if parsed.subject else None,
+        institution_id=parsed.institution.id if parsed.institution else None,
+        service_type_id=service_type_id,
+        max_price=parsed.budget_max,
+        limit=1,
+    )
+
+    await log_event(session, viewer.id, UserEventKind.SEARCH, text=text, results=total)
+    session.add(
+        SearchQuery(
+            user_id=viewer.id,
+            raw_text=text,
+            parsed={
+                "subject_id": parsed.subject.id if parsed.subject else None,
+                "institution_id": (parsed.institution.id if parsed.institution else None),
+                "service_type": parsed.service_type,
+                "deadline": parsed.deadline.isoformat() if parsed.deadline else None,
+                "budget_max": parsed.budget_max,
+                # What the embedder proposed, and whether it was believed.
+                # Logged even when refused: the two thresholds it is judged by
+                # were set by eye, and this is the only place the numbers to
+                # replace them can come from.
+                "vector": (
+                    {
+                        "subject_id": parsed.vector[0].id,
+                        "score": round(parsed.vector[0].score, 3),
+                        "lead": round(parsed.vector[1], 3),
+                        "used": parsed.subject is not None
+                        and parsed.subject.matched_on == "vector",
+                    }
+                    if parsed.vector
+                    else None
+                ),
+            },
+            results_count=total,
+            parser="rules.v1",
+        )
+    )
+
+    return ParseOut(
+        chips=chips,
+        clarify=_clarify_for(parsed),
+        matches=total,
+        note=Phrase(code="parse.nothing_recognised") if not chips else None,
+        also=_also(parsed),
+    )
+
+
+def _also(parsed: parser.ParsedQuery) -> AlsoSubject | None:
+    """The guess the parse would not search by, when it is worth reading.
+
+    Not when it was believed — then it is the subject, and repeating it would be
+    the same list twice. Not when it is noise. And not when it conflicts with
+    the kind of help, believed or not: a subject that cannot go with what was
+    asked for cannot go beside it either, and the list behind it would be empty
+    by construction.
+    """
+    if not parsed.vector or parsed.vector_conflicted:
+        return None
+    proposed, _ = parsed.vector
+    if parsed.subject and parsed.subject.id == proposed.id:
+        return None
+    if proposed.score < VECTOR_ALSO_FLOOR:
+        return None
+    return AlsoSubject(subject_id=proposed.id, label=proposed.label)
+
+
+def _clarify_for(parsed: parser.ParsedQuery) -> Clarify | None:
+    """Ask at most one question, and only when it narrows the result.
+
+    If the text already says which kind of help is wanted, there is nothing to
+    ask; if it says nothing at all, a question about exam timing would be
+    guessing at the wrong thing.
+    """
+    if parsed.service_type or parsed.unmatched:
+        return None
+    return Clarify(
+        code="clarify.when",
+        options=[
+            ClarifyOption(code="exam_prep", tone=0),
+            ClarifyOption(code="exam_live_help", tone=1),
+            ClarifyOption(code="both", tone=5),
+        ],
+    )
+
+
+__all__ = ["describe"]

--- a/apps/api/tests/test_catalog_service.py
+++ b/apps/api/tests/test_catalog_service.py
@@ -9,8 +9,8 @@ import pytest
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from students_cz.db.models import Contact, User, UserEvent
-from students_cz.db.models.enums import UiLang, UserEventKind
+from students_cz.db.models import Contact, HelperProfile, User, UserEvent
+from students_cz.db.models.enums import PublishStatus, UiLang, UserEventKind
 from students_cz.services import catalog, errors
 
 pytestmark = pytest.mark.asyncio
@@ -62,7 +62,7 @@ async def test_you_cannot_start_a_contact_with_yourself(
         await catalog.start_contact(session, viewer=helper, helper_id=helper.id)
 
 
-async def test_a_profile_that_is_not_published_cannot_be_written_to(
+async def test_somebody_who_is_not_a_helper_cannot_be_written_to(
     session: AsyncSession,
 ) -> None:
     student = await _person(session, 92104)
@@ -70,6 +70,22 @@ async def test_a_profile_that_is_not_published_cannot_be_written_to(
 
     with pytest.raises(errors.NotFound):
         await catalog.start_contact(session, viewer=student, helper_id=nobody.id)
+
+
+async def test_a_profile_that_is_not_published_cannot_be_written_to(
+    session: AsyncSession, helper_factory
+) -> None:
+    """A draft is not a listing. It exists, and to anyone outside it does not:
+    the same 404, so which of the two it is cannot be read off the answer."""
+    helper = await helper_factory(tg_id=92113)
+    profile = await session.get(HelperProfile, helper.id)
+    assert profile is not None
+    profile.status = PublishStatus.DRAFT
+    await session.flush()
+    student = await _person(session, 92114)
+
+    with pytest.raises(errors.NotFound):
+        await catalog.start_contact(session, viewer=student, helper_id=helper.id)
 
 
 async def test_a_helper_without_a_username_cannot_be_written_to(

--- a/apps/api/tests/test_catalog_service.py
+++ b/apps/api/tests/test_catalog_service.py
@@ -1,0 +1,119 @@
+"""The catalog's writes, reached without an HTTP client.
+
+Three of them: starting a contact, and the two events that say the app was
+opened and a person was read. They were route bodies until this file existed —
+which is why none of them had a test that did not need a signed request.
+"""
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from students_cz.db.models import Contact, User, UserEvent
+from students_cz.db.models.enums import UiLang, UserEventKind
+from students_cz.services import catalog, errors
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _person(session: AsyncSession, tg_id: int) -> User:
+    user = User(tg_id=tg_id, first_name="Nikol", ui_lang=UiLang.RU)
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def _events(session: AsyncSession, user_id: int, kind: UserEventKind) -> int:
+    return await session.scalar(
+        select(func.count())
+        .select_from(UserEvent)
+        .where(UserEvent.user_id == user_id, UserEvent.kind == kind)
+    )
+
+
+async def test_starting_a_contact_records_it_and_hands_back_the_link(
+    session: AsyncSession, helper_factory
+) -> None:
+    helper = await helper_factory(tg_id=92101, first_name="Dana")
+    helper.tg_username = "dana_teaches"
+    await session.flush()
+    student = await _person(session, 92102)
+
+    out = await catalog.start_contact(session, viewer=student, helper_id=helper.id)
+
+    assert out.telegram_url.endswith(helper.tg_username)
+    contacts = await session.scalar(
+        select(func.count())
+        .select_from(Contact)
+        .where(Contact.student_id == student.id, Contact.helper_id == helper.id)
+    )
+    assert contacts == 1
+    assert await _events(session, student.id, UserEventKind.CONTACT) == 1
+
+
+async def test_you_cannot_start_a_contact_with_yourself(
+    session: AsyncSession, helper_factory
+) -> None:
+    helper = await helper_factory(tg_id=92103)
+
+    with pytest.raises(errors.BadRequest):
+        await catalog.start_contact(session, viewer=helper, helper_id=helper.id)
+
+
+async def test_a_profile_that_is_not_published_cannot_be_written_to(
+    session: AsyncSession,
+) -> None:
+    student = await _person(session, 92104)
+    nobody = await _person(session, 92105)
+
+    with pytest.raises(errors.NotFound):
+        await catalog.start_contact(session, viewer=student, helper_id=nobody.id)
+
+
+async def test_a_helper_without_a_username_cannot_be_written_to(
+    session: AsyncSession, helper_factory
+) -> None:
+    helper = await helper_factory(tg_id=92106)
+    helper.tg_username = None
+    await session.flush()
+    student = await _person(session, 92107)
+
+    with pytest.raises(errors.Conflict):
+        await catalog.start_contact(session, viewer=student, helper_id=helper.id)
+
+
+async def test_opening_the_home_screen_is_recorded_once(
+    session: AsyncSession,
+) -> None:
+    viewer = await _person(session, 92108)
+
+    people, things = await catalog.open_home(session, UiLang.RU, viewer=viewer)
+
+    assert people or things
+    assert await _events(session, viewer.id, UserEventKind.APP_OPEN) == 1
+
+
+async def test_reading_a_person_is_recorded_once(
+    session: AsyncSession, helper_factory
+) -> None:
+    helper = await helper_factory(tg_id=92109)
+    viewer = await _person(session, 92110)
+
+    detail = await catalog.view_helper(session, helper.id, UiLang.RU, viewer=viewer)
+
+    assert detail is not None
+    assert await _events(session, viewer.id, UserEventKind.HELPER_VIEW) == 1
+
+
+async def test_a_person_who_is_not_there_is_not_recorded_as_read(
+    session: AsyncSession,
+) -> None:
+    # Nothing was read, so nothing happened. An event here would count views of
+    # profiles that do not exist as views of profiles.
+    viewer = await _person(session, 92111)
+    missing = await _person(session, 92112)
+
+    detail = await catalog.view_helper(session, missing.id, UiLang.RU, viewer=viewer)
+
+    assert detail is None
+    assert await _events(session, viewer.id, UserEventKind.HELPER_VIEW) == 0

--- a/apps/api/tests/test_catalog_service.py
+++ b/apps/api/tests/test_catalog_service.py
@@ -24,11 +24,13 @@ async def _person(session: AsyncSession, tg_id: int) -> User:
 
 
 async def _events(session: AsyncSession, user_id: int, kind: UserEventKind) -> int:
-    return await session.scalar(
-        select(func.count())
-        .select_from(UserEvent)
-        .where(UserEvent.user_id == user_id, UserEvent.kind == kind)
-    )
+    return (
+        await session.scalar(
+            select(func.count())
+            .select_from(UserEvent)
+            .where(UserEvent.user_id == user_id, UserEvent.kind == kind)
+        )
+    ) or 0
 
 
 async def test_starting_a_contact_records_it_and_hands_back_the_link(

--- a/apps/api/tests/test_people.py
+++ b/apps/api/tests/test_people.py
@@ -15,7 +15,7 @@ from aiogram.types import User as TgUser
 from students_cz.bot.middleware import RememberUserMiddleware
 from students_cz.core.config import get_settings
 from students_cz.db.models import User, UserEvent
-from students_cz.db.models.enums import UserEventKind
+from students_cz.db.models.enums import UiLang, UserEventKind
 from students_cz.services.people import mark_unreachable, reachable, remember
 
 pytestmark = pytest.mark.asyncio
@@ -192,3 +192,44 @@ async def test_starting_again_makes_someone_reachable_once_more(session):
     await run_middleware(session, update_from(700021, "/start"))
     user = await session.scalar(select(User).where(User.tg_id == 700021))
     assert user.bot_can_message is True
+
+
+async def test_an_unknown_institution_is_named_rather_than_a_foreign_key_error(
+    session,
+):
+    from students_cz.schemas import MeUpdate
+    from students_cz.services import errors
+    from students_cz.services.people import update_profile
+
+    user = User(tg_id=700030, first_name="Nina", ui_lang=UiLang.RU)
+    session.add(user)
+    await session.flush()
+
+    with pytest.raises(errors.Invalid):
+        await update_profile(session, user, MeUpdate(institution_id=10**9))
+
+
+async def test_a_field_the_payload_does_not_mention_is_left_alone(session):
+    """What the form did not ask about, the save does not answer.
+
+    The same rule as the helper profile: a screen that shows three fields must
+    not clear the fourth on its way out.
+    """
+    from students_cz.schemas import MeUpdate
+    from students_cz.services.people import update_profile
+
+    user = User(
+        tg_id=700031,
+        first_name="Oleg",
+        ui_lang=UiLang.RU,
+        spoken_langs=["ru", "cs"],
+        city="Praha",
+    )
+    session.add(user)
+    await session.flush()
+
+    await update_profile(session, user, MeUpdate(ui_lang=UiLang.CS))
+
+    assert user.ui_lang is UiLang.CS
+    assert user.city == "Praha"
+    assert user.spoken_langs == ["ru", "cs"]

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -1,0 +1,85 @@
+"""What a sentence is understood to mean, and the two rows that records.
+
+Reached without an HTTP client, which is the point: the parse writes — an
+event and a `search_queries` row — and until this file those writes could only
+be exercised through a signed request.
+"""
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from students_cz.db.models import SearchQuery, User, UserEvent
+from students_cz.db.models.enums import UiLang, UserEventKind
+from students_cz.services import search
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _person(session: AsyncSession, tg_id: int) -> User:
+    user = User(tg_id=tg_id, first_name="Sofia", ui_lang=UiLang.RU)
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def test_a_parse_is_logged_with_its_text_and_its_count(
+    session: AsyncSession, helper_factory
+) -> None:
+    await helper_factory(tg_id=93101)
+    viewer = await _person(session, 93102)
+
+    out = await search.describe(
+        session, UiLang.RU, viewer=viewer, text="матанализ репетитор"
+    )
+
+    assert out.matches >= 1
+    row = await session.scalar(
+        select(SearchQuery).where(SearchQuery.user_id == viewer.id)
+    )
+    assert row is not None
+    assert row.raw_text == "матанализ репетитор"
+    assert row.results_count == out.matches
+    assert row.parsed["subject_id"] is not None
+    events = await session.scalar(
+        select(func.count())
+        .select_from(UserEvent)
+        .where(UserEvent.user_id == viewer.id, UserEvent.kind == UserEventKind.SEARCH)
+    )
+    assert events == 1
+
+
+async def test_the_count_is_of_the_search_the_chips_describe(
+    session: AsyncSession, helper_factory
+) -> None:
+    """Including the budget. A count that ignores a filter counts people the
+    query does not reach, and writes that number into `search_queries`."""
+    await helper_factory(tg_id=93103, price=900)
+    viewer = await _person(session, 93104)
+
+    out = await search.describe(
+        session, UiLang.RU, viewer=viewer, text="матанализ до 300 крон"
+    )
+
+    assert out.matches == 0
+    row = await session.scalar(
+        select(SearchQuery).where(SearchQuery.user_id == viewer.id)
+    )
+    assert row is not None
+    assert row.parsed["budget_max"] == 300
+
+
+async def test_a_query_nobody_can_read_still_leaves_a_row(
+    session: AsyncSession,
+) -> None:
+    """Those rows are the ranked list of what the catalog is missing."""
+    viewer = await _person(session, 93105)
+
+    out = await search.describe(session, UiLang.RU, viewer=viewer, text="ыфва цукен")
+
+    assert out.chips == []
+    assert out.note is not None
+    row = await session.scalar(
+        select(SearchQuery).where(SearchQuery.user_id == viewer.id)
+    )
+    assert row is not None

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,7 +68,7 @@ neighbours about where it lives.
 | `public.py` | `/open` — the only route without init data |
 | `me.py` | the account behind the init data |
 | `taxonomy.py` | service types, subjects, institutions, languages |
-| `search.py` | free-text parse, and the search it feeds |
+| `search.py` | free-text parse — the rule is `services/search.py` — and the search it feeds |
 | `browse.py` | the home screen, a person's page, starting a contact |
 | `cabinet.py` | a helper's own profile: reading it and saving it |
 | `requests.py` | the catalog in reverse — post, answer, accept, close |
@@ -90,6 +90,14 @@ and renders a schema. If it contains a rule — a permission check beyond
 "logged in", a multi-step write, ranking, a state machine — that rule belongs
 in a service, where a test can reach it without an HTTP client and a live
 database.
+
+**A write is a rule**, even a one-line one. An endpoint does not add a row: a
+row added in a handler is a fact about the product that only an HTTP test can
+reach, and the bot cannot reach it at all. The two that read like exceptions
+are not: `catalog.open_home` and `catalog.view_helper` are the plain readers
+plus the event each records, kept apart from `home_sections` and
+`helper_detail` so that reading the sections is not itself a claim that
+somebody opened the app.
 
 **A service** takes a session and plain values, and returns DTOs. It does not
 raise `HTTPException`: an HTTP status is a fact about a protocol, and a
@@ -309,11 +317,6 @@ is visible if the licence ever matters.
 Written down because an agent greps this tree and builds against what it
 finds, and a rule with silent exceptions is worse than no rule.
 
-- **Some endpoints still write in the route body**: `browse.start_contact`,
-  `me.update_me`, and the event logging behind `browse.home`,
-  `browse.helper_detail` and `search.parse`. Named rather than counted — a
-  number here is one nobody remembers to correct, and the last three attempts
-  at one were all wrong.
 - **Nothing tells a helper that a request exists.** `requests.feed_for` filters
   on status, authorship, expiry and whether you already answered, and uses the
   subject only for *ranking*, so every helper profile sees every open request —


### PR DESCRIPTION
Docs updated first: docs/architecture.md

`docs/architecture.md` says an endpoint reads the request, checks who is
asking, calls one service and renders a schema — and then named five places
where the code did not. This closes that list. **No behaviour changes**: same
status codes, same bodies, same rows, and an OpenAPI document that dumps
byte-identical to `main`.

| was in the route body | is now |
| --- | --- |
| `browse.start_contact` — three refusals, the `Contact` row, the event | `catalog.start_contact` |
| the `APP_OPEN` event behind `browse.home` | `catalog.open_home` |
| the `HELPER_VIEW` event behind `browse.helper_detail` | `catalog.view_helper` |
| `me.update_me` — four assignments and the institution check | `people.update_profile` |
| `search.parse` — a parse, five kinds of chip, a count, two rows written | `services/search.describe` |

The plain readers stay: `home_sections` and `helper_detail` are reads the bot
could want, and reading the sections is not a claim that anybody opened the
app. `search_offers` stays in the route module because it writes nothing.

`start_contact` raises the service errors rather than `HTTPException`, which
is what the doc asks for and what would let the bot call it. `BadRequest`
keeps its 400: a status code is not what this change is allowed to alter.

## What the doc says now

The bullet is gone, and in its place is the rule that made those five
exceptions in the first place:

> **A write is a rule**, even a one-line one. An endpoint does not add a row: a
> row added in a handler is a fact about the product that only an HTTP test can
> reach, and the bot cannot reach it at all.

## Verification

`make check` green: 440 API tests — 18 of them new and none needing an HTTP
client — plus ruff, ty, biome, tsc, lingui `--strict` and `make contract`.

The contract was checked the way `make contract` cannot: the committed client
is generated with the typescript plugin alone and carries no operation
descriptions, so a docstring moved out of a route changes the document
silently. Both documents were dumped and compared, and the comparison was
itself checked by mutating a docstring and watching it fail.

Independent review: approved with no findings, after two rounds that found five
defects — among them exactly that dropped description, and a "before"
measurement of mine that had compared the working tree with itself.

## Out of scope

- `public.py` reaching into `app.state` — the doc's other bullet, and a
  different problem: the bot-username cache is genuinely app-scoped and needs
  somewhere to live before it can become a dependency.
- Notifying helpers that a request exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL
