### PR TITLE
State the process keeps is a service, not an attribute

### DIFF
--- a/apps/api/src/students_cz/api/deps.py
+++ b/apps/api/src/students_cz/api/deps.py
@@ -10,6 +10,7 @@ from students_cz.db.models.enums import UiLang
 from students_cz.db.session import session_scope
 from students_cz.services.notify import Notifier
 from students_cz.services.people import remember
+from students_cz.services.telegram import BotHandle
 
 SettingsDep = Annotated[Settings, Depends(get_settings)]
 SessionDep = Annotated[AsyncSession, Depends(session_scope, scope="function")]
@@ -109,3 +110,22 @@ async def current_notifier(http: Request, settings: SettingsDep) -> Notifier:
 
 
 NotifierDep = Annotated[Notifier, Depends(current_notifier)]
+
+
+def current_handle(http: Request) -> BotHandle:
+    """The bot's own handle, as one object per process.
+
+    Built where the bot is built, and only found here — but built on demand as
+    well, because the lifespan does not run under the test client and an app
+    with a bot on its state and no handle beside it would otherwise have no
+    handle at all. Either way there is one, and it is the same one for every
+    request, which is what makes remembering the answer worth anything.
+    """
+    handle = getattr(http.app.state, "bot_handle", None)
+    if handle is None:
+        handle = BotHandle(getattr(http.app.state, "bot", None))
+        http.app.state.bot_handle = handle
+    return handle
+
+
+HandleDep = Annotated[BotHandle, Depends(current_handle)]

--- a/apps/api/src/students_cz/api/deps.py
+++ b/apps/api/src/students_cz/api/deps.py
@@ -115,11 +115,15 @@ NotifierDep = Annotated[Notifier, Depends(current_notifier)]
 def current_handle(http: Request) -> BotHandle:
     """The bot's own handle, as one object per process.
 
-    Built where the bot is built, and only found here — but built on demand as
-    well, because the lifespan does not run under the test client and an app
-    with a bot on its state and no handle beside it would otherwise have no
-    handle at all. Either way there is one, and it is the same one for every
-    request, which is what makes remembering the answer worth anything.
+    Built here rather than in the lifespan, and kept: what a handler needs is
+    composed from what the process was started with, which is this module's
+    job, and the lifespan does not run under the test client or under an app
+    built by a script. One construction site means the path production takes
+    is the path the tests take.
+
+    Built on the first request rather than at import, because that is when the
+    bot exists: the lifespan has already run by then, so a `None` cached here
+    means the process really has no token.
     """
     handle = getattr(http.app.state, "bot_handle", None)
     if handle is None:

--- a/apps/api/src/students_cz/api/deps.py
+++ b/apps/api/src/students_cz/api/deps.py
@@ -112,7 +112,7 @@ async def current_notifier(http: Request, settings: SettingsDep) -> Notifier:
 NotifierDep = Annotated[Notifier, Depends(current_notifier)]
 
 
-def current_handle(http: Request) -> BotHandle:
+async def current_handle(http: Request) -> BotHandle:
     """The bot's own handle, as one object per process.
 
     Built here rather than in the lifespan, and kept: what a handler needs is
@@ -124,6 +124,10 @@ def current_handle(http: Request) -> BotHandle:
     Built on the first request rather than at import, because that is when the
     bot exists: the lifespan has already run by then, so a `None` cached here
     means the process really has no token.
+
+    `async` like every other dependency here, and not only for symmetry: a
+    plain `def` would be dispatched to a worker thread, and two first requests
+    landing together would each build a handle and each ask Telegram.
     """
     handle = getattr(http.app.state, "bot_handle", None)
     if handle is None:

--- a/apps/api/src/students_cz/api/v1/public.py
+++ b/apps/api/src/students_cz/api/v1/public.py
@@ -5,44 +5,16 @@ request with, and no chat to be answered in. What they get is a redirect into
 the bot, derived from the bot's own token so the handle is never hardcoded.
 """
 
-import logging
-import time as clock
-
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, HTTPException, status
 from fastapi.responses import RedirectResponse
 
-log = logging.getLogger("students_cz")
+from students_cz.api.deps import HandleDep
 
 router = APIRouter()
 
 
-BOT_LOOKUP_COOLDOWN = 30.0
-
-
-async def _bot_username(app) -> str | None:
-    """The bot's public handle, asked for once and remembered."""
-    cached = getattr(app.state, "bot_username", None)
-    if cached:
-        return cached
-    bot = getattr(app.state, "bot", None)
-    if bot is None:
-        return None
-    quiet_until = getattr(app.state, "bot_lookup_quiet_until", 0.0)
-    now = clock.monotonic()
-    if now < quiet_until:
-        return None
-    try:
-        me = await bot.get_me()
-    except Exception:
-        app.state.bot_lookup_quiet_until = now + BOT_LOOKUP_COOLDOWN
-        log.warning("could not read the bot's own username", exc_info=True)
-        return None
-    app.state.bot_username = me.username
-    return me.username
-
-
 @router.get("/open", include_in_schema=False, tags=["public"])
-async def open_in_telegram(request: Request) -> RedirectResponse:
+async def open_in_telegram(handle: HandleDep) -> RedirectResponse:
     """Send a browser to the bot.
 
     Unauthenticated on purpose: this is what the landing page's button points
@@ -51,7 +23,7 @@ async def open_in_telegram(request: Request) -> RedirectResponse:
     in exactly one place — the token the API is already running with. Change
     the bot and nothing in the frontend or the build needs to know.
     """
-    username = await _bot_username(request.app)
+    username = await handle.username()
     if username is None:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "no bot is configured")
     # 302 rather than 301: a permanent redirect would be cached by the browser

--- a/apps/api/src/students_cz/main.py
+++ b/apps/api/src/students_cz/main.py
@@ -23,7 +23,6 @@ from students_cz.core.config import get_settings
 from students_cz.db.session import dispose_engine
 from students_cz.services import errors
 from students_cz.services.embedding import get_embedder
-from students_cz.services.telegram import BotHandle
 
 log = logging.getLogger("students_cz")
 
@@ -185,7 +184,6 @@ async def lifespan(app: FastAPI):
     settings = get_settings()
     app.state.settings = settings
     app.state.bot = None
-    app.state.bot_handle = BotHandle(None)
     app.state.dispatcher = None
     app.state.webhook_task = None
     # Why registration failed, if it did. Whether there *is* a webhook is
@@ -204,9 +202,6 @@ async def lifespan(app: FastAPI):
         # Injected into every handler, so handlers never reach for a global.
         dispatcher["settings"] = settings
         app.state.bot, app.state.dispatcher = bot, dispatcher
-        # Beside the bot, because it is the bot's own handle and the memory of
-        # having asked for it. `api/deps.py` is what hands it to a route.
-        app.state.bot_handle = BotHandle(bot)
 
         await dispatcher.emit_startup(bot=bot, dispatcher=dispatcher)
         if settings.public_base_url:

--- a/apps/api/src/students_cz/main.py
+++ b/apps/api/src/students_cz/main.py
@@ -23,6 +23,7 @@ from students_cz.core.config import get_settings
 from students_cz.db.session import dispose_engine
 from students_cz.services import errors
 from students_cz.services.embedding import get_embedder
+from students_cz.services.telegram import BotHandle
 
 log = logging.getLogger("students_cz")
 
@@ -184,6 +185,7 @@ async def lifespan(app: FastAPI):
     settings = get_settings()
     app.state.settings = settings
     app.state.bot = None
+    app.state.bot_handle = BotHandle(None)
     app.state.dispatcher = None
     app.state.webhook_task = None
     # Why registration failed, if it did. Whether there *is* a webhook is
@@ -202,6 +204,9 @@ async def lifespan(app: FastAPI):
         # Injected into every handler, so handlers never reach for a global.
         dispatcher["settings"] = settings
         app.state.bot, app.state.dispatcher = bot, dispatcher
+        # Beside the bot, because it is the bot's own handle and the memory of
+        # having asked for it. `api/deps.py` is what hands it to a route.
+        app.state.bot_handle = BotHandle(bot)
 
         await dispatcher.emit_startup(bot=bot, dispatcher=dispatcher)
         if settings.public_base_url:

--- a/apps/api/src/students_cz/services/telegram.py
+++ b/apps/api/src/students_cz/services/telegram.py
@@ -1,0 +1,73 @@
+"""What the process knows about its own bot.
+
+One thing so far: the handle. It is asked for rather than configured, because
+the token the API already runs with is the only place a bot's identity should
+live — change the bot and neither the frontend nor the build needs to know.
+
+A service and not three `getattr` defaults in a route. What is kept here is
+per-process state rather than a value — the answer, and the cooldown that stops
+a failing Telegram being asked again on every visit to the landing page — which
+is why it is an object built once beside the bot rather than something a
+handler assembles for itself. See docs/architecture.md.
+"""
+
+import logging
+import time as clock
+from collections.abc import Callable
+from typing import Protocol
+
+log = logging.getLogger("students_cz")
+
+# Long enough that a Telegram outage costs one call rather than one per visitor,
+# short enough that a bot that came back is usable within half a minute.
+LOOKUP_COOLDOWN = 30.0
+
+
+class SelfAware(Protocol):
+    """The one thing `BotHandle` needs of a bot, so a test can be that much."""
+
+    async def get_me(self): ...
+
+
+class BotHandle:
+    """The bot's public handle, asked for once and remembered.
+
+    A handle with no bot answers `None`, which is how the API runs locally,
+    under test, and in any deployment without a token. That is a working
+    handle that knows nothing, not an error — the same shape `Notifier` takes,
+    and for the same reason: the caller would otherwise have to decide what a
+    missing bot means, separately, every time.
+    """
+
+    def __init__(
+        self,
+        bot: SelfAware | None,
+        *,
+        cooldown: float = LOOKUP_COOLDOWN,
+        clock: Callable[[], float] = clock.monotonic,
+    ) -> None:
+        self._bot = bot
+        self._cooldown = cooldown
+        self._clock = clock
+        self._username: str | None = None
+        self._quiet_until = 0.0
+
+    async def username(self) -> str | None:
+        if self._username:
+            return self._username
+        if self._bot is None:
+            return None
+        now = self._clock()
+        if now < self._quiet_until:
+            return None
+        try:
+            me = await self._bot.get_me()
+        except Exception:
+            self._quiet_until = now + self._cooldown
+            log.warning("could not read the bot's own username", exc_info=True)
+            return None
+        self._username = me.username
+        return self._username
+
+
+__all__ = ["BotHandle", "SelfAware"]

--- a/apps/api/src/students_cz/services/telegram.py
+++ b/apps/api/src/students_cz/services/telegram.py
@@ -23,10 +23,16 @@ log = logging.getLogger("students_cz")
 LOOKUP_COOLDOWN = 30.0
 
 
+class BotUser(Protocol):
+    """What Telegram says when asked who the token belongs to."""
+
+    username: str | None
+
+
 class SelfAware(Protocol):
     """The one thing `BotHandle` needs of a bot, so a test can be that much."""
 
-    async def get_me(self): ...
+    async def get_me(self) -> BotUser: ...
 
 
 class BotHandle:
@@ -66,8 +72,15 @@ class BotHandle:
             self._quiet_until = now + self._cooldown
             log.warning("could not read the bot's own username", exc_info=True)
             return None
+        if not me.username:
+            # A bot without a public handle cannot be linked to at all. The
+            # cooldown applies here too: nothing is cached, so without it every
+            # visitor to the landing page would ask Telegram again.
+            self._quiet_until = now + self._cooldown
+            log.warning("the bot has no public username")
+            return None
         self._username = me.username
         return self._username
 
 
-__all__ = ["BotHandle", "SelfAware"]
+__all__ = ["BotHandle", "BotUser", "SelfAware"]

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -20,6 +20,7 @@ os.environ["BOT_TOKEN"] = ""
 os.environ["PUBLIC_BASE_URL"] = "https://tests.example"
 
 from collections.abc import AsyncIterator
+from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
@@ -205,3 +206,26 @@ async def helper_factory(session: AsyncSession):
         return user
 
     return make
+
+
+class StubBot:
+    """Enough of aiogram's `Bot` to answer "what is your username?"."""
+
+    def __init__(self, username: str | None = "student_cz_bot") -> None:
+        self.username = username
+        self.calls = 0
+
+    async def get_me(self):
+        self.calls += 1
+        return SimpleNamespace(username=self.username)
+
+
+class BrokenBot:
+    """A Telegram that is having a moment."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def get_me(self):
+        self.calls += 1
+        raise RuntimeError("Telegram is having a moment")

--- a/apps/api/tests/test_landing.py
+++ b/apps/api/tests/test_landing.py
@@ -6,34 +6,15 @@ build. That makes this the only unauthenticated route in the API, which is
 worth pinning down.
 """
 
-from types import SimpleNamespace
-
 import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .conftest import app_for
+from .conftest import BrokenBot, StubBot, app_for
 
 pytestmark = pytest.mark.asyncio
-
-
-class StubBot:
-    """Enough of aiogram's Bot to answer "what is your username?"."""
-
-    def __init__(self, username: str) -> None:
-        self.username = username
-        self.calls = 0
-
-    async def get_me(self):
-        self.calls += 1
-        return SimpleNamespace(username=self.username)
-
-
-class BrokenBot:
-    async def get_me(self):
-        raise RuntimeError("Telegram is having a moment")
 
 
 @pytest_asyncio.fixture
@@ -72,7 +53,7 @@ async def test_open_needs_no_init_data(app_with) -> None:
     assert "Authorization" not in response.request.headers
 
 
-async def test_the_handle_is_asked_for_once(app_with) -> None:
+async def test_the_landing_asks_telegram_once(app_with) -> None:
     """Every landing visit would otherwise be a round trip to Telegram."""
     bot = StubBot("student_cz_bot")
     app = await app_with(bot)

--- a/apps/api/tests/test_telegram_handle.py
+++ b/apps/api/tests/test_telegram_handle.py
@@ -1,0 +1,68 @@
+"""The bot's own handle, asked for once and remembered.
+
+Reachable without an app, which is the point of moving it off `app.state`: the
+cooldown after a failing Telegram used to be three `getattr` defaults in a
+route, and the only way to exercise it was two HTTP requests and a stub bot.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from students_cz.services.telegram import BotHandle
+
+pytestmark = pytest.mark.asyncio
+
+
+class StubBot:
+    def __init__(self, username: str) -> None:
+        self.username = username
+        self.calls = 0
+
+    async def get_me(self):
+        self.calls += 1
+        return SimpleNamespace(username=self.username)
+
+
+class BrokenBot:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def get_me(self):
+        self.calls += 1
+        raise RuntimeError("Telegram is having a moment")
+
+
+async def test_the_handle_is_asked_for_once() -> None:
+    bot = StubBot("student_cz_bot")
+    handle = BotHandle(bot)
+
+    assert await handle.username() == "student_cz_bot"
+    assert await handle.username() == "student_cz_bot"
+    assert bot.calls == 1
+
+
+async def test_no_bot_is_no_handle_rather_than_an_error() -> None:
+    """How the API runs locally, and under test."""
+    assert await BotHandle(None).username() is None
+
+
+async def test_a_failing_telegram_is_not_asked_again_immediately() -> None:
+    now = [1000.0]
+    bot = BrokenBot()
+    handle = BotHandle(bot, cooldown=30.0, clock=lambda: now[0])
+
+    assert await handle.username() is None
+    assert await handle.username() is None
+    assert bot.calls == 1, "every landing visit would otherwise call Telegram"
+
+
+async def test_and_is_asked_again_once_the_cooldown_passes() -> None:
+    now = [1000.0]
+    bot = BrokenBot()
+    handle = BotHandle(bot, cooldown=30.0, clock=lambda: now[0])
+
+    await handle.username()
+    now[0] += 31.0
+    assert await handle.username() is None
+    assert bot.calls == 2, "a bot that came back must be reachable again"

--- a/apps/api/tests/test_telegram_handle.py
+++ b/apps/api/tests/test_telegram_handle.py
@@ -5,35 +5,16 @@ cooldown after a failing Telegram used to be three `getattr` defaults in a
 route, and the only way to exercise it was two HTTP requests and a stub bot.
 """
 
-from types import SimpleNamespace
-
 import pytest
 
 from students_cz.services.telegram import BotHandle
 
+from .conftest import BrokenBot, StubBot
+
 pytestmark = pytest.mark.asyncio
 
 
-class StubBot:
-    def __init__(self, username: str) -> None:
-        self.username = username
-        self.calls = 0
-
-    async def get_me(self):
-        self.calls += 1
-        return SimpleNamespace(username=self.username)
-
-
-class BrokenBot:
-    def __init__(self) -> None:
-        self.calls = 0
-
-    async def get_me(self):
-        self.calls += 1
-        raise RuntimeError("Telegram is having a moment")
-
-
-async def test_the_handle_is_asked_for_once() -> None:
+async def test_telegram_is_asked_once_and_the_answer_kept() -> None:
     bot = StubBot("student_cz_bot")
     handle = BotHandle(bot)
 
@@ -66,3 +47,15 @@ async def test_and_is_asked_again_once_the_cooldown_passes() -> None:
     now[0] += 31.0
     assert await handle.username() is None
     assert bot.calls == 2, "a bot that came back must be reachable again"
+
+
+async def test_a_bot_with_no_public_handle_is_not_asked_again_either() -> None:
+    """Nothing is cached in that case, so the cooldown is what stops the loop."""
+
+    now = [1000.0]
+    bot = StubBot(username=None)
+    handle = BotHandle(bot, cooldown=30.0, clock=lambda: now[0])
+
+    assert await handle.username() is None
+    assert await handle.username() is None
+    assert bot.calls == 1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,11 +136,20 @@ runtimes rather than a handler.
 a bot and an address, decided once. `telegram.BotHandle` is the other, and it
 was the harder case — it holds the bot's own handle and the cooldown that
 stops a failing Telegram being asked again on every landing visit, which is
-per-process state rather than a value. It lives on `app.state` still, but as
-one object built where the bot is built, and `api/deps.py` is what reaches for
-it. A route asks for `HandleDep` and cannot tell whether there is a bot at
-all — a handle with no bot answers `None`, which the route already had to
-answer for anyway.
+per-process state rather than a value. `api/deps.py` builds it on the first
+request that needs it and keeps it on `app.state`; a route asks for
+`HandleDep` and cannot tell whether there is a bot at all, because a handle
+with no bot answers `None`.
+
+Built in `deps.py` and not in the lifespan, deliberately: the lifespan does
+not run under the test client, so a handle built there would leave the tested
+path and the production path as different code.
+
+The webhook watchdog's state — `webhook_observed`, `webhook_checked_at` and
+the lock beside them — is the exception, and it belongs to the same carve-out
+as `health.py` above: it exists so that `/healthz` can report on the process
+without asking Telegram on every probe, and it is read by the one route whose
+job is reporting on the process.
 
 **A schema** is a leaf. `students_cz/schemas.py` — the package root, not inside
 `api/` — describes what goes over the wire. A service may return one without

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,6 +132,16 @@ route in `main.py`, which is defined inside `create_app` and hands the update
 to the dispatcher the lifespan put there — it is the seam between the two
 runtimes rather than a handler.
 
+**State the process keeps is a service, not an attribute.** `Notifier` is one:
+a bot and an address, decided once. `telegram.BotHandle` is the other, and it
+was the harder case — it holds the bot's own handle and the cooldown that
+stops a failing Telegram being asked again on every landing visit, which is
+per-process state rather than a value. It lives on `app.state` still, but as
+one object built where the bot is built, and `api/deps.py` is what reaches for
+it. A route asks for `HandleDep` and cannot tell whether there is a bot at
+all — a handle with no bot answers `None`, which the route already had to
+answer for anyway.
+
 **A schema** is a leaf. `students_cz/schemas.py` — the package root, not inside
 `api/` — describes what goes over the wire. A service may return one without
 that pointing the domain layer at the HTTP layer, which is the whole reason it
@@ -326,10 +336,6 @@ finds, and a rule with silent exceptions is worse than no rule.
   arriving. The product decision it waits on is whether to narrow the feed
   first, since notifying every helper about every request is how a feed becomes
   something people mute.
-- **`public.py` still reaches into `app.state`** — for the bot, and for the
-  per-process cache of its username. The cache is genuinely app-scoped, so
-  this one needs somewhere for that state to live before it can become a
-  dependency; it is not simply an unconverted call site.
 
 Each of these is a separate change with its own tests. None of them is a
 reason to write new code the old way.


### PR DESCRIPTION
Docs updated first: docs/architecture.md

The last item on `docs/architecture.md`'s list of places the code does not
follow it. `public.py` reached into `app.state` three times — for the bot, for
the remembered handle, and for the cooldown that stops a failing Telegram being
asked again on every landing visit — and each reach decided separately what "it
is not there" means, with a `getattr` default.

`services/telegram.BotHandle` is that decision, once. A handle with no bot
answers `None`: a working handle that knows nothing, the same shape `Notifier`
takes and for the same reason. `api/deps.current_handle` builds it on the first
request that needs it and keeps it; the route asks for `HandleDep` and cannot
tell whether there is a bot at all.

**No behaviour changes**: `/api/v1/open` still 302s to the handle, still answers
503 with no bot or a failing one, still asks Telegram once. The OpenAPI document
is byte-identical.

## Why `deps.py` and not the lifespan

Building it beside the bot reads better and is worse: the lifespan does not run
under the test client, so everything that runs would be the fallback and
nothing would exercise what production takes. One construction site, in the
module whose job is composing what a handler needs out of what the process was
started with.

## What the doc says now

The bullet is gone, and the rule that made it an exception is written down —
along with its own exception, because a rule with silent ones is what that
section exists to prevent:

> **State the process keeps is a service, not an attribute.** … The webhook
> watchdog's state is the exception, and it belongs to the same carve-out as
> `health.py`: it exists so that `/healthz` can report on the process without
> asking Telegram on every probe.

That section now has one entry left — nothing tells a helper that a request
exists — and that one waits on a product decision, not on code.

## Verification

`make check` green: 445 API tests, five of them new. The cooldown had never
been exercised on both sides; it is now, with an injected clock, along with a
bot that has no public handle at all.

Independent review: approved with no findings, after two rounds that found six
defects — among them the handle being built in two places so that the tested
path and the production path were different code, a dependency declared `def`
and therefore dispatched to a worker thread, and a doc paragraph that claimed
the new rule had no exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL
