### PR TITLE
The owner hears about the first profile and the first request

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -169,6 +169,8 @@ jobs:
           PUBLIC_PORT: ${{ vars.PUBLIC_PORT }}
           INIT_DATA_MAX_AGE_SECONDS: ${{ vars.INIT_DATA_MAX_AGE_SECONDS || '86400' }}
           LOG_LEVEL: ${{ vars.LOG_LEVEL || 'INFO' }}
+          # Optional, and empty is a working value: no ping.
+          OWNER_TG_ID: ${{ vars.OWNER_TG_ID }}
           BACKUP_HOUR_UTC: ${{ vars.BACKUP_HOUR_UTC || '3' }}
           BACKUP_RETENTION_DAYS: ${{ vars.BACKUP_RETENTION_DAYS || '14' }}
         run: |
@@ -187,6 +189,7 @@ jobs:
             echo "PUBLIC_PORT=$PUBLIC_PORT"
             echo "INIT_DATA_MAX_AGE_SECONDS=$INIT_DATA_MAX_AGE_SECONDS"
             echo "LOG_LEVEL=$LOG_LEVEL"
+            echo "OWNER_TG_ID=$OWNER_TG_ID"
             echo "BACKUP_HOUR_UTC=$BACKUP_HOUR_UTC"
             echo "BACKUP_RETENTION_DAYS=$BACKUP_RETENTION_DAYS"
           } > "$env_file"

--- a/apps/api/src/students_cz/api/deps.py
+++ b/apps/api/src/students_cz/api/deps.py
@@ -105,7 +105,9 @@ async def current_notifier(http: Request, settings: SettingsDep) -> Notifier:
     other places that reach for `app.state` are named in docs/architecture.md.
     """
     return Notifier(
-        getattr(http.app.state, "bot", None), settings.public_base_url or None
+        getattr(http.app.state, "bot", None),
+        settings.public_base_url or None,
+        owner_tg_id=settings.owner_tg_id,
     )
 
 

--- a/apps/api/src/students_cz/api/v1/cabinet.py
+++ b/apps/api/src/students_cz/api/v1/cabinet.py
@@ -16,7 +16,6 @@ from students_cz.db.models import (
     Offer,
     ServiceType,
     Subject,
-    User,
 )
 from students_cz.schemas import (
     HelperUpsert,
@@ -27,6 +26,7 @@ from students_cz.schemas import (
 from students_cz.services import helpers
 from students_cz.services.naming import names_by_id
 from students_cz.services.notify import quote
+from students_cz.services.people import full_name
 
 router = APIRouter()
 
@@ -121,12 +121,8 @@ async def upsert_helper(
         background.add_task(
             notifier.tell_owner,
             OWNER_NEW_HELPER.format(
-                name=quote(_display_name(user), 64),
+                name=quote(full_name(user), 64),
                 services=quote(", ".join(saved.services) or OWNER_NO_SERVICES, 200),
             ),
         )
     return await read_me(user, session, lang)
-
-
-def _display_name(user: User) -> str:
-    return " ".join(filter(None, (user.first_name, user.last_name))) or str(user.id)

--- a/apps/api/src/students_cz/api/v1/cabinet.py
+++ b/apps/api/src/students_cz/api/v1/cabinet.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 
 from students_cz.api.deps import LangDep, NotifierDep, SessionDep, UserDep
 from students_cz.api.v1.me import read_me
-from students_cz.bot.texts import OWNER_NEW_HELPER
+from students_cz.bot.texts import OWNER_NEW_HELPER, OWNER_NO_SERVICES
 from students_cz.db.models import (
     HelperProfile,
     Institution,
@@ -122,7 +122,7 @@ async def upsert_helper(
             notifier.tell_owner,
             OWNER_NEW_HELPER.format(
                 name=quote(_display_name(user), 64),
-                services=quote(", ".join(saved.services) or "без услуг", 200),
+                services=quote(", ".join(saved.services) or OWNER_NO_SERVICES, 200),
             ),
         )
     return await read_me(user, session, lang)

--- a/apps/api/src/students_cz/api/v1/cabinet.py
+++ b/apps/api/src/students_cz/api/v1/cabinet.py
@@ -4,17 +4,19 @@ The counterpart to `browse`: the same offers, seen from the side of the person
 who owns them.
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, BackgroundTasks
 from sqlalchemy import select
 
-from students_cz.api.deps import LangDep, SessionDep, UserDep
+from students_cz.api.deps import LangDep, NotifierDep, SessionDep, UserDep
 from students_cz.api.v1.me import read_me
+from students_cz.bot.texts import OWNER_NEW_HELPER
 from students_cz.db.models import (
     HelperProfile,
     Institution,
     Offer,
     ServiceType,
     Subject,
+    User,
 )
 from students_cz.schemas import (
     HelperUpsert,
@@ -24,6 +26,7 @@ from students_cz.schemas import (
 )
 from students_cz.services import helpers
 from students_cz.services.naming import names_by_id
+from students_cz.services.notify import quote
 
 router = APIRouter()
 
@@ -103,8 +106,27 @@ async def my_helper(session: SessionDep, lang: LangDep, user: UserDep) -> MyHelp
 
 @router.put("/helper", response_model=MeOut, tags=["helper"])
 async def upsert_helper(
-    payload: HelperUpsert, session: SessionDep, lang: LangDep, user: UserDep
+    payload: HelperUpsert,
+    background: BackgroundTasks,
+    notifier: NotifierDep,
+    session: SessionDep,
+    lang: LangDep,
+    user: UserDep,
 ) -> MeOut:
     """Create or replace the caller's helper profile and its offers."""
-    await helpers.save_profile(session, user=user, spec=payload, lang=lang)
+    saved = await helpers.save_profile(session, user=user, spec=payload, lang=lang)
+    if saved.published_now:
+        # After the response, like every other message here: Telegram is a
+        # third party in the middle of a request somebody is waiting on.
+        background.add_task(
+            notifier.tell_owner,
+            OWNER_NEW_HELPER.format(
+                name=quote(_display_name(user), 64),
+                services=quote(", ".join(saved.services) or "без услуг", 200),
+            ),
+        )
     return await read_me(user, session, lang)
+
+
+def _display_name(user: User) -> str:
+    return " ".join(filter(None, (user.first_name, user.last_name))) or str(user.id)

--- a/apps/api/src/students_cz/api/v1/me.py
+++ b/apps/api/src/students_cz/api/v1/me.py
@@ -15,7 +15,7 @@ from students_cz.schemas import (
     MeUpdate,
 )
 from students_cz.services.catalog import avatar_for
-from students_cz.services.people import update_profile
+from students_cz.services.people import full_name, update_profile
 
 router = APIRouter()
 
@@ -36,7 +36,7 @@ async def read_me(user: UserDep, session: SessionDep, lang: LangDep) -> MeOut:
     return MeOut(
         id=user.id,
         tg_id=user.tg_id,
-        name=" ".join(filter(None, (user.first_name, user.last_name))),
+        name=full_name(user),
         username=user.tg_username,
         avatar=avatar_for(user),
         ui_lang=user.ui_lang,

--- a/apps/api/src/students_cz/api/v1/requests.py
+++ b/apps/api/src/students_cz/api/v1/requests.py
@@ -43,6 +43,7 @@ from students_cz.services import requests as requests_service
 from students_cz.services.catalog import avatar_for
 from students_cz.services.naming import rows_by_id, short_form, translated
 from students_cz.services.notify import Recipient, quote
+from students_cz.services.people import full_name
 
 router = APIRouter()
 
@@ -363,7 +364,7 @@ async def _responses_out(
                 id=response.id,
                 request_id=response.request_id,
                 helper_id=response.helper_id,
-                name=" ".join(filter(None, (person.first_name, person.last_name))),
+                name=full_name(person),
                 avatar=avatar_for(person),
                 username=person.tg_username,
                 affiliation=profile.headline,

--- a/apps/api/src/students_cz/api/v1/requests.py
+++ b/apps/api/src/students_cz/api/v1/requests.py
@@ -12,6 +12,7 @@ from students_cz.bot.texts import (
     FOR_PRICE,
     NEW_RESPONSE,
     OWNER_NEW_REQUEST,
+    OWNER_NOTHING_PARSED,
     RESPONSE_ACCEPTED,
     WAIT_FOR_MESSAGE,
     WRITE_TO,
@@ -82,7 +83,7 @@ async def create_request(
     background.add_task(
         notifier.tell_owner,
         OWNER_NEW_REQUEST.format(
-            topic=quote(_axes_line(rendered), 120),
+            topic=quote(await _axes_line(session, request), 120),
             text=quote(request.raw_text),
         ),
     )
@@ -290,15 +291,39 @@ def _topic_of(*, rendered_request: HelpRequest) -> str:
     return rendered_request.raw_text
 
 
-def _axes_line(rendered: RequestOut) -> str:
+async def _axes_line(session, request: HelpRequest) -> str:
     """What the parse made of a request, for the one person watching the first
-    of them. Empty when it understood nothing, which is itself worth seeing."""
+    of them.
+
+    Slugs and codes rather than translated names, like the profile ping and for
+    the same reason: this message is framed in one language whoever posted the
+    request wrote in, and a Czech subject name inside a Russian sentence reads
+    as a bug. Says so plainly when the parse understood nothing, which is
+    itself the interesting case.
+    """
+    subject = (
+        await session.get(Subject, request.subject_id) if request.subject_id else None
+    )
+    institution = (
+        await session.get(Institution, request.institution_id)
+        if request.institution_id
+        else None
+    )
+    service = (
+        await session.get(ServiceType, request.service_type_id)
+        if request.service_type_id
+        else None
+    )
     named = [
         part
-        for part in (rendered.subject, rendered.institution, rendered.service_type)
+        for part in (
+            subject.slug if subject else None,
+            institution.code if institution else None,
+            service.code if service else None,
+        )
         if part
     ]
-    return " · ".join(named) if named else "ничего не разобрали"
+    return " · ".join(named) if named else OWNER_NOTHING_PARSED
 
 
 def _price_line(price: Price | None) -> str:

--- a/apps/api/src/students_cz/api/v1/requests.py
+++ b/apps/api/src/students_cz/api/v1/requests.py
@@ -11,6 +11,7 @@ from students_cz.api.deps import LangDep, NotifierDep, SessionDep, UserDep
 from students_cz.bot.texts import (
     FOR_PRICE,
     NEW_RESPONSE,
+    OWNER_NEW_REQUEST,
     RESPONSE_ACCEPTED,
     WAIT_FOR_MESSAGE,
     WRITE_TO,
@@ -52,7 +53,12 @@ router = APIRouter()
     tags=["requests"],
 )
 async def create_request(
-    payload: RequestCreate, session: SessionDep, lang: LangDep, user: UserDep
+    payload: RequestCreate,
+    background: BackgroundTasks,
+    notifier: NotifierDep,
+    session: SessionDep,
+    lang: LangDep,
+    user: UserDep,
 ) -> RequestOut:
     """Post "I need help with X" and let helpers answer."""
     request = await requests_service.create(
@@ -70,7 +76,17 @@ async def create_request(
         # as an explicit `null`, which means "any" and not "work it out".
         given=frozenset(payload.model_fields_set),
     )
-    return await _request_out(session, request, lang)
+    rendered = await _request_out(session, request, lang)
+    # Nobody else is told yet — see "Where the code does not follow this yet"
+    # in docs/architecture.md. This is what makes the first ones noticed.
+    background.add_task(
+        notifier.tell_owner,
+        OWNER_NEW_REQUEST.format(
+            topic=quote(_axes_line(rendered), 120),
+            text=quote(request.raw_text),
+        ),
+    )
+    return rendered
 
 
 @router.get("/requests", response_model=list[RequestOut], tags=["requests"])
@@ -272,6 +288,17 @@ def _topic_of(*, rendered_request: HelpRequest) -> str:
     words, and "Mathematical Analysis I · ČVUT" is our vocabulary, not theirs.
     """
     return rendered_request.raw_text
+
+
+def _axes_line(rendered: RequestOut) -> str:
+    """What the parse made of a request, for the one person watching the first
+    of them. Empty when it understood nothing, which is itself worth seeing."""
+    named = [
+        part
+        for part in (rendered.subject, rendered.institution, rendered.service_type)
+        if part
+    ]
+    return " · ".join(named) if named else "ничего не разобрали"
 
 
 def _price_line(price: Price | None) -> str:

--- a/apps/api/src/students_cz/bot/texts.py
+++ b/apps/api/src/students_cz/bot/texts.py
@@ -95,6 +95,14 @@ WAIT_FOR_MESSAGE: dict[UiLang, str] = {
 }
 
 
+# The two the owner is told about, and the only strings here with no table
+# behind them. Nobody reading these chose a language: they go to one address,
+# `OWNER_TG_ID`, and they report on the catalog rather than saying anything to
+# a person who is using it. See docs/architecture.md.
+OWNER_NEW_HELPER = "<b>Новая анкета</b>\n{name}\n{services}"
+OWNER_NEW_REQUEST = "<b>Новая заявка</b>\n{topic}\n«{text}»"
+
+
 def pick(table: dict[UiLang, str], lang: UiLang) -> str:
     """Read a string, falling back to Russian for a language we have not written.
 

--- a/apps/api/src/students_cz/bot/texts.py
+++ b/apps/api/src/students_cz/bot/texts.py
@@ -101,6 +101,8 @@ WAIT_FOR_MESSAGE: dict[UiLang, str] = {
 # a person who is using it. See docs/architecture.md.
 OWNER_NEW_HELPER = "<b>Новая анкета</b>\n{name}\n{services}"
 OWNER_NEW_REQUEST = "<b>Новая заявка</b>\n{topic}\n«{text}»"
+OWNER_NO_SERVICES = "без услуг"
+OWNER_NOTHING_PARSED = "ничего не разобрали"
 
 
 def pick(table: dict[UiLang, str], lang: UiLang) -> str:

--- a/apps/api/src/students_cz/core/config.py
+++ b/apps/api/src/students_cz/core/config.py
@@ -2,7 +2,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Literal
 
-from pydantic import Field, computed_field
+from pydantic import Field, computed_field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -89,6 +89,23 @@ class Settings(BaseSettings):
     # webhook call; anything else is not Telegram.
     webhook_secret: str = ""
     webhook_path: str = "/tg/webhook"
+    # Told when a profile or a request appears, and nothing else. Unset — which
+    # is how it runs everywhere but production — means no ping. A numeric
+    # Telegram id and not a handle: the bot needs a chat it can open, and it
+    # can only open one with somebody who has started it.
+    owner_tg_id: int | None = None
+
+    @field_validator("owner_tg_id", mode="before")
+    @classmethod
+    def _blank_is_nobody(cls, value: object) -> object:
+        """An unset variable reaches us as an empty string, not as absent.
+
+        Compose writes `OWNER_TG_ID=` whether or not anybody set it, and an
+        empty string is not an integer — so without this the API refuses to
+        start in exactly the configuration that means "no ping".
+        """
+        return None if value == "" else value
+
     # Public HTTPS origin. Since 20 July 2026 Telegram only allows Mini App API
     # calls from the app's own origin, so a preview deployment on a different
     # domain will not work.

--- a/apps/api/src/students_cz/services/helpers.py
+++ b/apps/api/src/students_cz/services/helpers.py
@@ -36,14 +36,15 @@ from students_cz.services.refs import require_row
 
 @dataclass(frozen=True)
 class Saved:
-    """The profile, and whether this save is the one that published it.
+    """What a save leaves behind that the row cannot answer afterwards.
 
-    The second half is not readable from the row afterwards — a profile that
-    was already published looks exactly like one that just was — and it is
-    what the owner ping is about. Answered where the transition happens.
+    A profile that was already published looks exactly like one that just went
+    out, so whether this save is the one that published it has to be said
+    where the transition happens. That is what the owner ping is about, and
+    the whole of what anything asks of this return value — the profile itself
+    is the caller's own `user`'s, and readable from the session.
     """
 
-    profile: HelperProfile
     published_now: bool
     # Only when it published just now, and only then worth a query: the codes
     # of what this person offers, for the line the owner is pinged with.
@@ -89,7 +90,6 @@ async def save_profile(
     if "offers" in spec.model_fields_set:
         await _apply_offers(session, user=user, helper=helper, spec=spec)
     return Saved(
-        profile=helper,
         published_now=published_now,
         services=await _service_codes(session, helper) if published_now else (),
     )

--- a/apps/api/src/students_cz/services/helpers.py
+++ b/apps/api/src/students_cz/services/helpers.py
@@ -6,6 +6,7 @@ about HTTP, so the bot could offer the same thing tomorrow without any of it
 being reimplemented.
 """
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from sqlalchemy import delete, select
@@ -33,9 +34,25 @@ from students_cz.services.people import log_event
 from students_cz.services.refs import require_row
 
 
+@dataclass(frozen=True)
+class Saved:
+    """The profile, and whether this save is the one that published it.
+
+    The second half is not readable from the row afterwards — a profile that
+    was already published looks exactly like one that just was — and it is
+    what the owner ping is about. Answered where the transition happens.
+    """
+
+    profile: HelperProfile
+    published_now: bool
+    # Only when it published just now, and only then worth a query: the codes
+    # of what this person offers, for the line the owner is pinged with.
+    services: tuple[str, ...] = ()
+
+
 async def save_profile(
     session: AsyncSession, *, user: User, spec: HelperUpsert, lang: UiLang
-) -> HelperProfile:
+) -> Saved:
     """Create or replace the caller's helper profile and its offers.
 
     The set of offers is authoritative — whatever the caller did not send is
@@ -63,7 +80,7 @@ async def save_profile(
         raise Forbidden("this profile is blocked")
 
     _apply_text(helper, spec, lang)
-    await _apply_status(session, helper, user, publish=spec.publish)
+    published_now = await _apply_status(session, helper, user, publish=spec.publish)
     await session.flush()
     # Same rule as the text fields, and for the same reason. `offers` defaults
     # to an empty list, so an unconditional call here deletes everything the
@@ -71,7 +88,30 @@ async def save_profile(
     # is the promise the docstring above already makes.
     if "offers" in spec.model_fields_set:
         await _apply_offers(session, user=user, helper=helper, spec=spec)
-    return helper
+    return Saved(
+        profile=helper,
+        published_now=published_now,
+        services=await _service_codes(session, helper) if published_now else (),
+    )
+
+
+async def _service_codes(session: AsyncSession, helper: HelperProfile) -> tuple[str, ...]:
+    """What this profile offers, by code.
+
+    Read here rather than off `helper.offers` in the caller: the relationship
+    is not loaded, and a lazy load after the response is a `MissingGreenlet`
+    rather than a query. Codes and not translated names — the one person who
+    reads this knows them, and resolving names in three tables to report a
+    profile is a query nobody is waiting for.
+    """
+    rows = await session.scalars(
+        select(ServiceType.code)
+        .join(Offer, Offer.service_type_id == ServiceType.id)
+        .where(Offer.helper_id == helper.user_id)
+        .distinct()
+        .order_by(ServiceType.code)
+    )
+    return tuple(rows)
 
 
 def _apply_text(helper: HelperProfile, spec: HelperUpsert, lang: UiLang) -> None:
@@ -103,19 +143,21 @@ def _apply_text(helper: HelperProfile, spec: HelperUpsert, lang: UiLang) -> None
 
 async def _apply_status(
     session: AsyncSession, helper: HelperProfile, user: User, *, publish: bool
-) -> None:
+) -> bool:
+    """Apply the publish flag. Returns whether this is the moment it went out."""
     if publish:
         was_published = helper.status == PublishStatus.PUBLISHED
         helper.status = PublishStatus.PUBLISHED
         helper.published_at = helper.published_at or datetime.now(UTC)
         if not was_published:
             await log_event(session, user.id, UserEventKind.PROFILE_PUBLISHED)
-        return
+        return not was_published
 
     # HIDDEN, not DRAFT, once it has been out: "hide me" has to actually take
     # the profile out of the catalog, and the distinction preserves whether
     # anyone has ever seen it.
     helper.status = PublishStatus.HIDDEN if helper.published_at else PublishStatus.DRAFT
+    return False
 
 
 async def _apply_offers(

--- a/apps/api/src/students_cz/services/helpers.py
+++ b/apps/api/src/students_cz/services/helpers.py
@@ -144,14 +144,18 @@ def _apply_text(helper: HelperProfile, spec: HelperUpsert, lang: UiLang) -> None
 async def _apply_status(
     session: AsyncSession, helper: HelperProfile, user: User, *, publish: bool
 ) -> bool:
-    """Apply the publish flag. Returns whether this is the moment it went out."""
+    """Apply the publish flag. Returns whether it went out for the first time."""
     if publish:
         was_published = helper.status == PublishStatus.PUBLISHED
+        # Ever, not since the last save: hiding a profile and listing it again
+        # is the same profile coming back, and the owner has already been told
+        # about it once.
+        first_time = helper.published_at is None
         helper.status = PublishStatus.PUBLISHED
         helper.published_at = helper.published_at or datetime.now(UTC)
         if not was_published:
             await log_event(session, user.id, UserEventKind.PROFILE_PUBLISHED)
-        return not was_published
+        return first_time
 
     # HIDDEN, not DRAFT, once it has been out: "hide me" has to actually take
     # the profile out of the catalog, and the distinction preserves whether

--- a/apps/api/src/students_cz/services/helpers.py
+++ b/apps/api/src/students_cz/services/helpers.py
@@ -107,7 +107,7 @@ async def _service_codes(session: AsyncSession, helper: HelperProfile) -> tuple[
     rows = await session.scalars(
         select(ServiceType.code)
         .join(Offer, Offer.service_type_id == ServiceType.id)
-        .where(Offer.helper_id == helper.user_id)
+        .where(Offer.helper_id == helper.user_id, Offer.is_active.is_(True))
         .distinct()
         .order_by(ServiceType.code)
     )

--- a/apps/api/src/students_cz/services/notify.py
+++ b/apps/api/src/students_cz/services/notify.py
@@ -112,9 +112,16 @@ class Notifier:
     caller remembers separately.
     """
 
-    def __init__(self, bot: Bot | None, app_url: str | None = None) -> None:
+    def __init__(
+        self,
+        bot: Bot | None,
+        app_url: str | None = None,
+        *,
+        owner_tg_id: int | None = None,
+    ) -> None:
         self._bot = bot
         self._app_url = app_url
+        self._owner_tg_id = owner_tg_id
 
     async def tell(self, recipient: Recipient, text: str) -> bool:
         """Send, if this person can be sent to. Returns whether it arrived.
@@ -131,6 +138,30 @@ class Notifier:
             text=text,
             lang=recipient.lang,
             app_url=self._app_url,
+        )
+
+    async def tell_owner(self, text: str) -> bool:
+        """Say that something happened, to whoever runs this. Once.
+
+        A different kind of message from the two above and kept apart from
+        them: those answer something the recipient set in motion, this one
+        reports on the catalog to one address that no screen chose. There is
+        nobody to consult about language, nothing to opt out of, and no button
+        — see docs/architecture.md.
+
+        Off unless `OWNER_TG_ID` names somebody, which is how it runs
+        everywhere but production. Like every notification here it cannot fail
+        the action it follows: the send is already guarded, and no owner is
+        `False` rather than a raise.
+        """
+        if self._owner_tg_id is None:
+            return False
+        return await tell(
+            self._bot,
+            tg_id=self._owner_tg_id,
+            text=text,
+            lang=UiLang.RU,
+            app_url=None,
         )
 
 

--- a/apps/api/src/students_cz/services/people.py
+++ b/apps/api/src/students_cz/services/people.py
@@ -197,3 +197,19 @@ async def update_profile(session: AsyncSession, user: User, spec: MeUpdate) -> N
             session, Institution, spec.institution_id or None, "institution_id"
         )
         user.institution_id = spec.institution_id or None
+
+
+def full_name(user: User) -> str:
+    """Someone's name as they gave it to Telegram.
+
+    Three screens want this and each had written it out: your own account, the
+    name beside an answer to your request, and the owner ping. Not the same
+    rule as a catalog card, which shows a first name and an initial — full
+    surnames are neither needed to choose somebody nor ours to publish. This
+    one is used where the reader is either the person themselves or somebody
+    already talking to them.
+
+    The id is the fallback for a row with no first name, which Telegram does
+    not allow and a seeded fixture might.
+    """
+    return " ".join(filter(None, (user.first_name, user.last_name))) or str(user.id)

--- a/apps/api/tests/test_notify.py
+++ b/apps/api/tests/test_notify.py
@@ -186,3 +186,33 @@ async def test_a_reachable_person_is_written_to() -> None:
     assert await Notifier(cast(Bot, bot)).tell(Recipient.of(_person()), "привет") is True
     assert bot.sent[0]["chat_id"] == 42
     assert bot.sent[0]["text"] == "привет"
+
+
+@pytest.mark.asyncio
+async def test_the_owner_is_told_when_somebody_is_watching() -> None:
+    bot = _Bot()
+    notifier = Notifier(cast(Bot, bot), None, owner_tg_id=777)
+
+    assert await notifier.tell_owner("новая анкета") is True
+    assert bot.sent[0]["chat_id"] == 777
+    assert bot.sent[0]["text"] == "новая анкета"
+
+
+@pytest.mark.asyncio
+async def test_no_owner_means_no_ping_rather_than_an_error() -> None:
+    """How it runs until somebody sets `OWNER_TG_ID`, which is most of the time."""
+    bot = _Bot()
+
+    assert await Notifier(cast(Bot, bot), None).tell_owner("новая анкета") is False
+    assert bot.sent == []
+
+
+@pytest.mark.asyncio
+async def test_the_owner_ping_carries_no_button() -> None:
+    """It is a line in a log, not an invitation to open a screen."""
+    bot = _Bot()
+    notifier = Notifier(cast(Bot, bot), "https://tests.example", owner_tg_id=777)
+
+    await notifier.tell_owner("новая заявка")
+
+    assert bot.sent[0]["reply_markup"] is None

--- a/apps/api/tests/test_owner_ping.py
+++ b/apps/api/tests/test_owner_ping.py
@@ -1,0 +1,137 @@
+"""What the owner is told, and what it costs when it fails.
+
+The catalog is empty and the fan-out question — who among the helpers hears
+about a request — cannot be answered from data that does not exist. This is
+the part that can be built now: the first profile and the first request are
+noticed without anybody reading the database. See docs/architecture.md.
+"""
+
+from typing import cast
+
+import pytest
+from aiogram import Bot
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from students_cz.api.deps import current_notifier
+from students_cz.services.notify import Notifier
+
+from .conftest import app_for, auth_header
+
+pytestmark = pytest.mark.asyncio
+
+
+class Watching(Notifier):
+    """A notifier that records the pings instead of sending them."""
+
+    def __init__(self) -> None:
+        super().__init__(None)
+        self.pings: list[str] = []
+
+    async def tell_owner(self, text: str) -> bool:
+        self.pings.append(text)
+        return True
+
+
+class BrokenTelegram:
+    """A bot whose send blows up, which `notify.tell` is supposed to absorb."""
+
+    async def send_message(self, **kwargs):
+        raise RuntimeError("Telegram is having a moment")
+
+
+async def _client(session: AsyncSession, notifier: Notifier) -> AsyncClient:
+    app = app_for(session)
+    app.dependency_overrides[current_notifier] = lambda: notifier
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def test_a_posted_request_is_reported(session: AsyncSession) -> None:
+    watcher = Watching()
+
+    async with await _client(session, watcher) as http:
+        response = await http.post(
+            "/api/v1/requests",
+            json={"text": "нужен матан на ČVUT к 14 февраля"},
+            headers=auth_header(94101),
+        )
+
+    assert response.status_code == 201
+    assert len(watcher.pings) == 1
+    assert "матан" in watcher.pings[0]
+
+
+async def test_a_published_profile_is_reported_once(session: AsyncSession) -> None:
+    """Once, on the way out of draft. Editing a price is not news."""
+    watcher = Watching()
+    profile = {
+        "raw_intro": "Веду матан на ČVUT, 500 Kč в час",
+        "publish": True,
+    }
+
+    async with await _client(session, watcher) as http:
+        first = await http.put("/api/v1/helper", json=profile, headers=auth_header(94102))
+        second = await http.put(
+            "/api/v1/helper", json=profile, headers=auth_header(94102)
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert len(watcher.pings) == 1
+
+
+async def test_a_profile_that_stays_a_draft_is_not_reported(
+    session: AsyncSession,
+) -> None:
+    watcher = Watching()
+
+    async with await _client(session, watcher) as http:
+        response = await http.put(
+            "/api/v1/helper",
+            json={"raw_intro": "ещё думаю", "publish": False},
+            headers=auth_header(94103),
+        )
+
+    assert response.status_code == 200
+    assert watcher.pings == []
+
+
+async def test_a_ping_that_fails_does_not_fail_the_request(
+    session: AsyncSession,
+) -> None:
+    """The request is committed before anything is sent. It stays committed.
+
+    A real notifier over a bot that raises, not a double that refuses to send:
+    the guarantee being tested is `notify.tell` swallowing whatever Telegram
+    does, and a double would be testing the double.
+    """
+    notifier = Notifier(cast(Bot, BrokenTelegram()), None, owner_tg_id=777)
+
+    async with await _client(session, notifier) as http:
+        response = await http.post(
+            "/api/v1/requests",
+            json={"text": "нужна нострификация аттестата"},
+            headers=auth_header(94104),
+        )
+
+    assert response.status_code == 201
+
+
+async def test_an_empty_owner_id_is_nobody_rather_than_a_crash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """What the compose file passes when the variable is unset.
+
+    Docker writes `OWNER_TG_ID=` into the environment either way, and an empty
+    string is not an integer — so without this the API would refuse to start
+    in exactly the configuration that is supposed to mean "no ping".
+    """
+    from students_cz.core.config import Settings
+
+    # Through the environment, which is the path that breaks: a keyword goes by
+    # field name and would be ignored as an unknown extra.
+    monkeypatch.setenv("OWNER_TG_ID", "")
+    assert Settings(_env_file=None).owner_tg_id is None
+
+    monkeypatch.setenv("OWNER_TG_ID", "777")
+    assert Settings(_env_file=None).owner_tg_id == 777

--- a/apps/api/tests/test_owner_ping.py
+++ b/apps/api/tests/test_owner_ping.py
@@ -135,3 +135,25 @@ async def test_an_empty_owner_id_is_nobody_rather_than_a_crash(
 
     monkeypatch.setenv("OWNER_TG_ID", "777")
     assert Settings(_env_file=None).owner_tg_id == 777
+
+
+async def test_hiding_and_listing_again_is_not_a_new_profile(
+    session: AsyncSession,
+) -> None:
+    """The same profile coming back, and the owner was told about it once."""
+    watcher = Watching()
+
+    async with await _client(session, watcher) as http:
+        await http.put(
+            "/api/v1/helper",
+            json={"raw_intro": "веду матан", "publish": True},
+            headers=auth_header(94105),
+        )
+        await http.put(
+            "/api/v1/helper", json={"publish": False}, headers=auth_header(94105)
+        )
+        await http.put(
+            "/api/v1/helper", json={"publish": True}, headers=auth_header(94105)
+        )
+
+    assert len(watcher.pings) == 1

--- a/apps/api/tests/test_owner_ping.py
+++ b/apps/api/tests/test_owner_ping.py
@@ -58,7 +58,12 @@ async def test_a_posted_request_is_reported(session: AsyncSession) -> None:
 
     assert response.status_code == 201
     assert len(watcher.pings) == 1
-    assert "матан" in watcher.pings[0]
+    # The person's own words, and what the parse made of them — by slug and
+    # code, which no language owns. A translated name here would land inside a
+    # sentence written in another language.
+    assert "нужен матан" in watcher.pings[0]
+    assert "matematicka-analyza" in watcher.pings[0]
+    assert "cvut" in watcher.pings[0].lower()
 
 
 async def test_a_published_profile_is_reported_once(session: AsyncSession) -> None:
@@ -157,3 +162,74 @@ async def test_hiding_and_listing_again_is_not_a_new_profile(
         )
 
     assert len(watcher.pings) == 1
+
+
+async def test_a_request_nobody_could_parse_says_so(session: AsyncSession) -> None:
+    """The interesting case: the catalog has no word for what somebody wants."""
+    watcher = Watching()
+
+    async with await _client(session, watcher) as http:
+        await http.post(
+            "/api/v1/requests",
+            json={"text": "ыфва цукен"},
+            headers=auth_header(94106),
+        )
+
+    assert "ничего не разобрали" in watcher.pings[0]
+
+
+async def test_the_profile_ping_names_what_the_person_offers(
+    session: AsyncSession,
+) -> None:
+    watcher = Watching()
+
+    async with await _client(session, watcher) as http:
+        await http.put(
+            "/api/v1/helper",
+            json={"raw_intro": "веду матан", "publish": True},
+            headers=auth_header(94107),
+        )
+        with_offer = await http.put(
+            "/api/v1/helper",
+            json={"publish": True, "offers": [{"service_type_id": 1}]},
+            headers=auth_header(94108),
+        )
+
+    assert with_offer.status_code == 200
+    assert "без услуг" in watcher.pings[0]
+    assert "без услуг" not in watcher.pings[1]
+
+
+async def test_a_withdrawn_offer_is_not_named(session: AsyncSession) -> None:
+    """`is_active` is what every other query on this table respects.
+
+    Nothing deactivates an offer today — the cabinet deletes what it drops —
+    but the column exists and the ping has no business being the one query
+    that ignores it.
+    """
+    from sqlalchemy import select
+
+    from students_cz.db.models import Offer, User
+
+    watcher = Watching()
+
+    async with await _client(session, watcher) as http:
+        await http.put(
+            "/api/v1/helper",
+            json={"publish": False, "offers": [{"service_type_id": 1}]},
+            headers=auth_header(94109),
+        )
+        # This person's own row: the database is seeded, and somebody else's
+        # tutoring offer would be the one found by service type alone.
+        mine = await session.scalar(select(User).where(User.tg_id == 94109))
+        assert mine is not None
+        offer = await session.scalar(select(Offer).where(Offer.helper_id == mine.id))
+        assert offer is not None
+        offer.is_active = False
+        await session.flush()
+
+        await http.put(
+            "/api/v1/helper", json={"publish": True}, headers=auth_header(94109)
+        )
+
+    assert "без услуг" in watcher.pings[0]

--- a/apps/api/tests/test_people.py
+++ b/apps/api/tests/test_people.py
@@ -235,7 +235,7 @@ async def test_a_field_the_payload_does_not_mention_is_left_alone(session):
     assert user.spoken_langs == ["ru", "cs"]
 
 
-async def test_a_full_name_is_both_parts_and_falls_back_to_the_id():
+async def test_a_full_name_is_both_parts_and_falls_back_to_the_id(session):
     """Not the catalog's rule — a card shows a first name and an initial."""
     from students_cz.services.people import full_name
 
@@ -244,3 +244,8 @@ async def test_a_full_name_is_both_parts_and_falls_back_to_the_id():
         == "Нина К"
     )
     assert full_name(User(tg_id=2, first_name="Нина", ui_lang=UiLang.RU)) == "Нина"
+    # Telegram does not allow this; a fixture can.
+    nameless = User(tg_id=3, first_name="", ui_lang=UiLang.RU)
+    session.add(nameless)
+    await session.flush()
+    assert full_name(nameless) == str(nameless.id)

--- a/apps/api/tests/test_people.py
+++ b/apps/api/tests/test_people.py
@@ -233,3 +233,14 @@ async def test_a_field_the_payload_does_not_mention_is_left_alone(session):
     assert user.ui_lang is UiLang.CS
     assert user.city == "Praha"
     assert user.spoken_langs == ["ru", "cs"]
+
+
+async def test_a_full_name_is_both_parts_and_falls_back_to_the_id():
+    """Not the catalog's rule — a card shows a first name and an initial."""
+    from students_cz.services.people import full_name
+
+    assert (
+        full_name(User(tg_id=1, first_name="Нина", last_name="К", ui_lang=UiLang.RU))
+        == "Нина К"
+    )
+    assert full_name(User(tg_id=2, first_name="Нина", ui_lang=UiLang.RU)) == "Нина"

--- a/deploy/students-cz/.env.example
+++ b/deploy/students-cz/.env.example
@@ -21,5 +21,8 @@ PUBLIC_PORT=
 
 INIT_DATA_MAX_AGE_SECONDS=86400
 LOG_LEVEL=INFO
+# Who is told when a profile or a request appears. Empty means nobody, which
+# is a working configuration — see docs/architecture.md.
+OWNER_TG_ID=
 BACKUP_HOUR_UTC=3
 BACKUP_RETENTION_DAYS=14

--- a/deploy/students-cz/docker-compose.yml
+++ b/deploy/students-cz/docker-compose.yml
@@ -72,6 +72,9 @@ services:
       PUBLIC_BASE_URL: ${PUBLIC_HOST}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       INIT_DATA_MAX_AGE_SECONDS: ${INIT_DATA_MAX_AGE_SECONDS:-86400}
+      # Empty means nobody is told when a profile or a request appears, which
+      # is a working configuration and the default everywhere else.
+      OWNER_TG_ID: ${OWNER_TG_ID:-}
       # Never true here. It would let anyone claim to be anyone.
       ALLOW_UNSIGNED_INIT_DATA: "false"
       CORS_ORIGINS: '["${PUBLIC_HOST}"]'

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -356,8 +356,9 @@ finds, and a rule with silent exceptions is worse than no rule.
   arriving. The product decision it waits on is whether to narrow the feed
   first, since notifying every helper about every request is how a feed becomes
   something people mute — and that decision cannot be made from data yet: the
-  catalog holds no profiles and no requests. The owner ping below exists so
-  that the first ones are noticed without anybody reading the database.
+  catalog holds no profiles and no requests. `Notifier.tell_owner`, described
+  under "What belongs where", exists so that the first ones are noticed without
+  anybody reading the database.
 
 Each of these is a separate change with its own tests. None of them is a
 reason to write new code the old way.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,6 +132,17 @@ route in `main.py`, which is defined inside `create_app` and hands the update
 to the dispatcher the lifespan put there — it is the seam between the two
 runtimes rather than a handler.
 
+**Two notifications and one ping.** `services/notify.py` writes to people
+about something they set in motion — an answer to their request, an acceptance
+of their answer. `Notifier.tell_owner` is the other kind and is kept apart from
+it: one message to one address, `OWNER_TG_ID`, about a profile or a request
+appearing. It is not product copy — nobody reading it chose a language, and it
+is addressed to whoever runs this — so it lives in `bot/texts.py` as a plain
+string rather than a table per language, and it is off unless that setting
+names somebody. A ping that cannot be sent, like a notification that cannot,
+costs the action nothing: both are queued after the response and neither may
+raise.
+
 **State the process keeps is a service, not an attribute.** `Notifier` is one:
 a bot and an address, decided once. `telegram.BotHandle` is the other, and it
 was the harder case — it holds the bot's own handle and the cooldown that
@@ -340,11 +351,13 @@ finds, and a rule with silent exceptions is worse than no rule.
   on status, authorship, expiry and whether you already answered, and uses the
   subject only for *ranking*, so every helper profile sees every open request —
   which the screens now say, rather than promising the subject narrows it. What
-  is still missing is the push: the two notifications that exist are about a
+  is still missing is the push: the notifications that exist are about a
   response and an acceptance, so a request waits to be found rather than
   arriving. The product decision it waits on is whether to narrow the feed
   first, since notifying every helper about every request is how a feed becomes
-  something people mute.
+  something people mute — and that decision cannot be made from data yet: the
+  catalog holds no profiles and no requests. The owner ping below exists so
+  that the first ones are noticed without anybody reading the database.
 
 Each of these is a separate change with its own tests. None of them is a
 reason to write new code the old way.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -144,6 +144,7 @@ ssh-keyscan -t ed25519 <host>          # for DEPLOY_KNOWN_HOSTS
 | `INIT_DATA_MAX_AGE_SECONDS` | Optional; defaults to 86400. |
 | `LOG_LEVEL` | Optional; defaults to `INFO`. One of DEBUG, INFO, WARNING, ERROR, CRITICAL. |
 | `BACKUP_HOUR_UTC`, `BACKUP_RETENTION_DAYS` | Optional; default 3 and 14. |
+| `OWNER_TG_ID` | Optional. Telegram id of whoever runs this, to be told when a profile or a request appears. Unset means no ping. A numeric id, not a handle — the bot needs a chat it can open, and it can only open one with somebody who has started it. |
 
 ### 5. In @BotFather
 


### PR DESCRIPTION
Docs updated first: docs/architecture.md, docs/deploy.md

Production holds **no profiles, no requests and one account**. Which helpers
should be told about a new request cannot be decided from data that does not
exist — and notifying everyone about everything is how a feed becomes something
people mute. So that decision stays deferred, and this builds the part that can
be built: the first profile and the first request are noticed without anybody
reading the database.

## One message, one address

`Notifier.tell_owner` is a different kind of message from the two that exist,
and deliberately kept apart from them. Those answer something the recipient set
in motion; this one reports on the catalog to an address no screen chose. There
is nobody to consult about language, nothing to opt out of and no button — so
its strings are plain rather than a table per language, and they live in
`bot/texts.py` with the rest of what the bot says.

Off unless `OWNER_TG_ID` names somebody, which is how it runs everywhere but
production. A ping costs the action nothing: it is queued after the response
and `notify.tell` swallows whatever Telegram does.

**What it says.** A profile: the person's name and the services they offer, by
code. A request: what the parse understood — by slug and code — and the words
the person actually typed. Codes and not translated names, because the message
is framed in one language and the poster may have written in another.

**When.** A profile the first time it is published, ever — hiding and listing
again is the same profile coming back, and editing a price is not news.

## The trap this nearly shipped with

`OWNER_TG_ID` is optional, and compose writes `OWNER_TG_ID=` into the
environment whether or not anyone set it. An empty string is not an integer, so
pydantic would have refused to start the API in exactly the configuration that
means "no ping". Measured before it shipped, and the validator that fixes it is
pinned by a test that fails when it is removed.

## Verification

`make check` green: 458 API tests, ten of them new — the two events, the two
suppressions, the empty setting, and what the messages actually say. Every rule
mutation-checked. `docker compose config` resolves the compose file from the
documented variables alone, with `OWNER_TG_ID` empty.

Independent review: approved with no findings, after four rounds that found ten
defects — among them a second ping when a hidden profile was re-listed, axes
named in the poster's language inside a Russian sentence, a query that ignored
`Offer.is_active` where every sibling respects it, and a test whose only
content assertion was satisfied by the person's own words.

## Out of scope

- Telling helpers. Still the open decision, and the doc says why it waits.
- Any digest, batching or rate limit: one owner, and today zero events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL
