### PR TITLE
The chat stops offering what the old bot offered

### DIFF
--- a/apps/api/src/students_cz/bot/__init__.py
+++ b/apps/api/src/students_cz/bot/__init__.py
@@ -11,10 +11,12 @@ from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
 from aiogram.filters import Command, CommandStart
 from aiogram.types import (
+    BotCommand,
     InlineKeyboardButton,
     InlineKeyboardMarkup,
     MenuButtonWebApp,
     Message,
+    ReplyKeyboardRemove,
     WebAppInfo,
 )
 
@@ -90,12 +92,32 @@ async def on_start(message: Message, settings: Settings) -> None:
     )
 
 
-async def configure(bot: Bot, settings: Settings) -> None:
-    """Point the persistent menu button at the mini app.
+# The two that exist. Telegram keeps whatever list it was last given, and this
+# token answered to a command-driven bot before this one — so a bot that sets
+# none is still offering `/language`, which nothing here handles. Two of them,
+# and both are ways out rather than ways around the app.
+COMMANDS = [
+    BotCommand(command="start", description="Открыть каталог"),
+    BotCommand(command="stop", description="Не писать мне"),
+]
 
-    This is what makes the app reachable without anyone typing a command —
-    the whole point of moving off a command-driven interface.
+# What a message gets when it is not one of those. Short on purpose: the reply
+# exists to carry `ReplyKeyboardRemove`, and the menu button beside the field
+# is where the app actually is.
+NOT_A_CONVERSATION = (
+    "Всё происходит в приложении — открой его кнопкой рядом с полем ввода."
+)
+
+
+async def configure(bot: Bot, settings: Settings) -> None:
+    """Say what this bot offers, in the two places Telegram remembers it.
+
+    The menu button is what makes the app reachable without anyone typing a
+    command — the whole point of moving off a command-driven interface. The
+    command list is the other half, and it is set here rather than left alone
+    because "left alone" means the previous bot's list.
     """
+    await bot.set_my_commands(COMMANDS)
     if not settings.public_base_url:
         return
     await bot.set_chat_menu_button(
@@ -122,3 +144,15 @@ async def on_stop(message: Message) -> None:
             await session.commit()
 
     await message.answer(UNSUBSCRIBED)
+
+
+@router.message()
+async def on_anything_else(message: Message) -> None:
+    """Anything that is not one of the two commands.
+
+    Which, for anybody who used the bot this token belonged to, is most often
+    a tap on a button still sitting in their chat: Telegram keeps a reply
+    keyboard until a message removes it, and those send their own label as
+    ordinary text. The reply is one line and its job is the removal.
+    """
+    await message.answer(NOT_A_CONVERSATION, reply_markup=ReplyKeyboardRemove())

--- a/apps/api/src/students_cz/bot/__init__.py
+++ b/apps/api/src/students_cz/bot/__init__.py
@@ -98,7 +98,11 @@ async def on_start(message: Message, settings: Settings) -> None:
 # and both are ways out rather than ways around the app.
 COMMANDS = [
     BotCommand(command="start", description="Открыть каталог"),
-    BotCommand(command="stop", description="Не писать мне"),
+    # Not "не писать мне", which is the promise `UNSUBSCRIBED` below exists to
+    # take back: answers to your own requests keep arriving, because you asked
+    # for them. The line before the command has to say the same as the line
+    # after it.
+    BotCommand(command="stop", description="Не присылать рассылки"),
 ]
 
 # What a message gets when it is not one of those. Short on purpose: the reply
@@ -117,6 +121,9 @@ async def configure(bot: Bot, settings: Settings) -> None:
     command list is the other half, and it is set here rather than left alone
     because "left alone" means the previous bot's list.
     """
+    # The default scope, which is where the previous bot's list is: measured on
+    # 2026-08-04 against production, every narrower scope and every language
+    # variant is empty, and Telegram falls back to this one.
     await bot.set_my_commands(COMMANDS)
     if not settings.public_base_url:
         return
@@ -143,7 +150,9 @@ async def on_stop(message: Message) -> None:
         if await unsubscribe(session, message.from_user.id):
             await session.commit()
 
-    await message.answer(UNSUBSCRIBED)
+    # Carries the removal too: somebody typing /stop is as likely to have the
+    # old keyboard in front of them as anybody else.
+    await message.answer(UNSUBSCRIBED, reply_markup=ReplyKeyboardRemove())
 
 
 @router.message()
@@ -154,5 +163,10 @@ async def on_anything_else(message: Message) -> None:
     a tap on a button still sitting in their chat: Telegram keeps a reply
     keyboard until a message removes it, and those send their own label as
     ordinary text. The reply is one line and its job is the removal.
+
+    Nothing is said to an update with no sender — a channel post — for the
+    same reason `on_stop` returns: there is nobody there to have asked.
     """
+    if message.from_user is None:
+        return
     await message.answer(NOT_A_CONVERSATION, reply_markup=ReplyKeyboardRemove())

--- a/apps/api/src/students_cz/main.py
+++ b/apps/api/src/students_cz/main.py
@@ -164,7 +164,6 @@ async def _set_webhook(
                 allowed_updates=dispatcher.resolve_used_update_types(),
                 drop_pending_updates=drop_pending,
             )
-            await configure(bot, settings)
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -176,7 +175,26 @@ async def _set_webhook(
         else:
             app.state.webhook_error = None
             log.info("webhook set to %s", url)
+            await _describe_bot(bot, settings)
             return
+
+
+async def _describe_bot(bot, settings) -> None:
+    """The menu button and the command list — never at the webhook's cost.
+
+    Beside registration these are cosmetic: if Telegram refuses them, updates
+    still arrive. Inside the retry above they were not cosmetic at all — one
+    429 on a command list re-registered the webhook in a tight loop, with
+    `drop_pending_updates` on the boot path throwing away everything that
+    queued between attempts, and the watch that heals a cleared webhook never
+    started.
+    """
+    try:
+        await configure(bot, settings)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        log.warning("could not set the bot's menu or command list: %s", exc)
 
 
 @asynccontextmanager

--- a/apps/api/src/students_cz/main.py
+++ b/apps/api/src/students_cz/main.py
@@ -88,6 +88,9 @@ async def keep_webhook_registered(
     # Dropping what queued before the process existed is right at boot, and
     # wrong on a heal — see below.
     await _set_webhook(app, bot, dispatcher, settings, drop_pending=True)
+    # Once, here: what the bot offers does not change when a webhook is healed,
+    # and a call made on that path would delay the healing it follows.
+    await _describe_bot(bot, settings)
 
     while True:
         await asyncio.sleep(recheck_seconds)
@@ -175,26 +178,33 @@ async def _set_webhook(
         else:
             app.state.webhook_error = None
             log.info("webhook set to %s", url)
-            await _describe_bot(bot, settings)
             return
 
 
-async def _describe_bot(bot, settings) -> None:
+async def _describe_bot(
+    bot, settings, *, timeout: float = WEBHOOK_RECHECK_TIMEOUT
+) -> None:
     """The menu button and the command list — never at the webhook's cost.
 
     Beside registration these are cosmetic: if Telegram refuses them, updates
-    still arrive. Inside the retry above they were not cosmetic at all — one
-    429 on a command list re-registered the webhook in a tight loop, with
-    `drop_pending_updates` on the boot path throwing away everything that
-    queued between attempts, and the watch that heals a cleared webhook never
-    started.
+    still arrive. Inside the retry they were not cosmetic at all — one 429 on a
+    command list re-registered the webhook in a tight loop, throwing away
+    everything that queued between attempts, and the watch that heals a cleared
+    webhook never started.
+
+    Bounded, because refusing is not the only way a call fails: aiogram waits a
+    minute by default, and a minute spent here is a minute before the watch
+    starts. The same guard, and the same number, as the recheck above.
     """
     try:
-        await configure(bot, settings)
+        await asyncio.wait_for(configure(bot, settings), timeout=timeout)
     except asyncio.CancelledError:
         raise
     except Exception as exc:
-        log.warning("could not set the bot's menu or command list: %s", exc)
+        log.warning(
+            "could not set the bot's menu or command list: %s",
+            str(exc) or type(exc).__name__,
+        )
 
 
 @asynccontextmanager

--- a/apps/api/tests/test_bot.py
+++ b/apps/api/tests/test_bot.py
@@ -165,9 +165,11 @@ class _Message:
     def __init__(self, tg_id: int | None) -> None:
         self.from_user = SimpleNamespace(id=tg_id) if tg_id is not None else None
         self.answers: list[str] = []
+        self.markups: list[object] = []
 
-    async def answer(self, text: str, **_: object) -> None:
+    async def answer(self, text: str, reply_markup: object = None, **_: object) -> None:
         self.answers.append(text)
+        self.markups.append(reply_markup)
 
 
 def _lend(session: AsyncSession):
@@ -212,3 +214,81 @@ async def test_an_update_without_a_sender_is_ignored(
     await students_cz_bot.on_stop(message)
 
     assert message.answers == []
+
+
+class _Bot:
+    """Records what the bot would have told Telegram about itself."""
+
+    def __init__(self) -> None:
+        self.commands: list[dict] = []
+        self.menu_buttons: list[object] = []
+
+    async def set_my_commands(self, commands, **kwargs) -> None:
+        self.commands.append({"commands": commands, **kwargs})
+
+    async def set_chat_menu_button(self, **kwargs) -> None:
+        self.menu_buttons.append(kwargs)
+
+
+async def test_the_command_list_is_the_commands_that_exist() -> None:
+    """This token belonged to a command-driven bot first.
+
+    Telegram keeps the list until somebody replaces it, so a bot that sets none
+    is still offering the old one — `/language`, which nothing here handles.
+    """
+    from students_cz.core.config import Settings
+
+    bot = _Bot()
+    await students_cz_bot.configure(
+        bot, Settings(_env_file=None, public_base_url="https://tests.example")
+    )
+
+    assert bot.commands, "nothing replaced the list the previous bot left"
+    offered = {command.command for call in bot.commands for command in call["commands"]}
+    assert offered == {"start", "stop"}
+
+
+async def test_the_menu_is_still_pointed_at_the_app() -> None:
+    from students_cz.core.config import Settings
+
+    bot = _Bot()
+    await students_cz_bot.configure(
+        bot, Settings(_env_file=None, public_base_url="https://tests.example")
+    )
+
+    assert bot.menu_buttons
+
+
+async def test_answering_anything_else_clears_the_old_keyboard(
+    session: AsyncSession,
+) -> None:
+    """The buttons of the previous bot are still in every chat it ever had.
+
+    Nothing but a reply carrying `ReplyKeyboardRemove` takes them away, and
+    tapping one is exactly what somebody with a stale keyboard does.
+    """
+    from aiogram.types import ReplyKeyboardRemove
+
+    message = _Message(91004)
+
+    await students_cz_bot.on_anything_else(message)
+
+    assert message.answers
+    assert isinstance(message.markups[-1], ReplyKeyboardRemove)
+
+
+async def test_the_catch_all_answers_last_and_only_then() -> None:
+    """Order is the whole safety of a handler with no filter.
+
+    Registered before `/start`, it would answer "everything happens in the
+    app" to somebody opening the bot for the first time — and the greeting,
+    which is the one thing this bot exists to say, would never be sent.
+    """
+    handlers = students_cz_bot.router.message.handlers
+
+    assert handlers[-1].callback is students_cz_bot.on_anything_else
+    assert not handlers[-1].filters, "a catch-all with a filter is not a catch-all"
+    assert [handler.callback for handler in handlers[:-1]] == [
+        students_cz_bot.on_start,
+        students_cz_bot.on_stop,
+    ]

--- a/apps/api/tests/test_bot.py
+++ b/apps/api/tests/test_bot.py
@@ -13,11 +13,13 @@ from typing import cast
 
 import pytest
 from aiogram import Bot
+from aiogram.types import ReplyKeyboardRemove
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from students_cz import bot as students_cz_bot
-from students_cz.bot import GREETING, UNSUBSCRIBED
+from students_cz.bot import COMMANDS, GREETING, NOT_A_CONVERSATION, UNSUBSCRIBED
+from students_cz.core.config import Settings
 from students_cz.db.models import HelperProfile, HelpRequest, RequestResponse, User
 from students_cz.db.models.enums import UiLang
 from students_cz.services.people import unsubscribe
@@ -238,8 +240,6 @@ async def test_the_command_list_is_the_commands_that_exist() -> None:
     Telegram keeps the list until somebody replaces it, so a bot that sets none
     is still offering the old one — `/language`, which nothing here handles.
     """
-    from students_cz.core.config import Settings
-
     bot = _Bot()
     await students_cz_bot.configure(
         cast(Bot, bot), Settings(_env_file=None, public_base_url="https://tests.example")
@@ -250,9 +250,26 @@ async def test_the_command_list_is_the_commands_that_exist() -> None:
     assert offered == {"start", "stop"}
 
 
-async def test_the_menu_is_still_pointed_at_the_app() -> None:
-    from students_cz.core.config import Settings
+async def test_the_opt_out_command_promises_what_the_reply_delivers() -> None:
+    """«Не писать мне» is the sentence `UNSUBSCRIBED` exists to take back.
 
+    Answers to your own requests keep arriving — `notify.Recipient.of` ignores
+    `unsubscribed_at` on purpose — so the description a person reads before
+    tapping has to say the same as the line they read after.
+    """
+    [described] = [c.description for c in COMMANDS if c.command == "stop"]
+
+    assert "не писать" not in described.lower()
+    assert "рассылк" in described.lower()
+
+
+async def test_the_line_that_carries_the_removal_says_where_the_app_is() -> None:
+    """It is the only thing a stale-keyboard tap gets back."""
+    assert "приложении" in NOT_A_CONVERSATION
+    assert COMMAND.search(NOT_A_CONVERSATION) is None
+
+
+async def test_the_menu_is_still_pointed_at_the_app() -> None:
     bot = _Bot()
     await students_cz_bot.configure(
         cast(Bot, bot), Settings(_env_file=None, public_base_url="https://tests.example")
@@ -270,8 +287,6 @@ async def test_answering_anything_else_clears_the_old_keyboard() -> None:
     Nothing but a reply carrying `ReplyKeyboardRemove` takes them away, and
     tapping one is exactly what somebody with a stale keyboard does.
     """
-    from aiogram.types import ReplyKeyboardRemove
-
     message = _Message(91004)
 
     await students_cz_bot.on_anything_else(message)
@@ -292,8 +307,6 @@ async def test_a_channel_post_is_not_answered() -> None:
 async def test_the_opt_out_reply_clears_the_old_keyboard_too(
     session: AsyncSession, monkeypatch
 ) -> None:
-    from aiogram.types import ReplyKeyboardRemove
-
     monkeypatch.setattr(students_cz_bot, "get_sessionmaker", lambda: _lend(session))
     user = await _person(session, tg_id=91005)
     message = _Message(user.tg_id)

--- a/apps/api/tests/test_bot.py
+++ b/apps/api/tests/test_bot.py
@@ -223,7 +223,7 @@ class _Bot:
 
     def __init__(self) -> None:
         self.commands: list[dict] = []
-        self.menu_buttons: list[object] = []
+        self.menu_buttons: list[dict] = []
 
     async def set_my_commands(self, commands, **kwargs) -> None:
         self.commands.append({"commands": commands, **kwargs})

--- a/apps/api/tests/test_bot.py
+++ b/apps/api/tests/test_bot.py
@@ -258,12 +258,13 @@ async def test_the_menu_is_still_pointed_at_the_app() -> None:
         cast(Bot, bot), Settings(_env_file=None, public_base_url="https://tests.example")
     )
 
-    assert bot.menu_buttons
+    [call] = bot.menu_buttons
+    button = call["menu_button"]
+    assert button.web_app.url == "https://tests.example"
+    assert button.text
 
 
-async def test_answering_anything_else_clears_the_old_keyboard(
-    session: AsyncSession,
-) -> None:
+async def test_answering_anything_else_clears_the_old_keyboard() -> None:
     """The buttons of the previous bot are still in every chat it ever had.
 
     Nothing but a reply carrying `ReplyKeyboardRemove` takes them away, and
@@ -276,6 +277,29 @@ async def test_answering_anything_else_clears_the_old_keyboard(
     await students_cz_bot.on_anything_else(message)
 
     assert message.answers
+    assert isinstance(message.markups[-1], ReplyKeyboardRemove)
+
+
+async def test_a_channel_post_is_not_answered() -> None:
+    """No sender, nobody to have asked — the rule `on_stop` already follows."""
+    message = _Message(None)
+
+    await students_cz_bot.on_anything_else(message)
+
+    assert message.answers == []
+
+
+async def test_the_opt_out_reply_clears_the_old_keyboard_too(
+    session: AsyncSession, monkeypatch
+) -> None:
+    from aiogram.types import ReplyKeyboardRemove
+
+    monkeypatch.setattr(students_cz_bot, "get_sessionmaker", lambda: _lend(session))
+    user = await _person(session, tg_id=91005)
+    message = _Message(user.tg_id)
+
+    await students_cz_bot.on_stop(message)
+
     assert isinstance(message.markups[-1], ReplyKeyboardRemove)
 
 

--- a/apps/api/tests/test_bot.py
+++ b/apps/api/tests/test_bot.py
@@ -9,8 +9,10 @@ import re
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
+from aiogram import Bot
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -240,7 +242,7 @@ async def test_the_command_list_is_the_commands_that_exist() -> None:
 
     bot = _Bot()
     await students_cz_bot.configure(
-        bot, Settings(_env_file=None, public_base_url="https://tests.example")
+        cast(Bot, bot), Settings(_env_file=None, public_base_url="https://tests.example")
     )
 
     assert bot.commands, "nothing replaced the list the previous bot left"
@@ -253,7 +255,7 @@ async def test_the_menu_is_still_pointed_at_the_app() -> None:
 
     bot = _Bot()
     await students_cz_bot.configure(
-        bot, Settings(_env_file=None, public_base_url="https://tests.example")
+        cast(Bot, bot), Settings(_env_file=None, public_base_url="https://tests.example")
     )
 
     assert bot.menu_buttons

--- a/apps/api/tests/test_webhook_watchdog.py
+++ b/apps/api/tests/test_webhook_watchdog.py
@@ -216,3 +216,31 @@ async def test_the_watch_reports_a_missing_webhook_in_the_endpoint_s_words(
         "", expected=settings.webhook_url, registration_error="Bad Request: bad webhook"
     )
     assert "Bad Request: bad webhook" in app.state.webhook_observed
+
+
+class Fussy(Telegram):
+    """A Telegram that registers webhooks and refuses command lists.
+
+    A 429 on `setMyCommands` is the realistic version, and it used to be
+    indistinguishable from a webhook that would not register.
+    """
+
+    async def set_my_commands(self, *_: object, **__: object) -> None:
+        raise RuntimeError("Too Many Requests: retry after 30")
+
+
+async def test_a_refused_command_list_does_not_re_register_the_webhook(
+    settings,
+) -> None:
+    from students_cz.main import keep_webhook_registered
+
+    bot = Fussy()
+    app = _app()
+
+    await _run_briefly(
+        keep_webhook_registered(app, bot, _dispatcher(), settings, recheck_seconds=0.05)
+    )
+
+    assert bot.sets == 1, "a cosmetic call must not retry the registration"
+    assert bot.reads > 0, "the watch never started"
+    assert app.state.webhook_error is None

--- a/apps/api/tests/test_webhook_watchdog.py
+++ b/apps/api/tests/test_webhook_watchdog.py
@@ -34,6 +34,9 @@ class Telegram:
     async def set_chat_menu_button(self, **_: object) -> None:
         """Called right after registration, to point the menu at the app."""
 
+    async def set_my_commands(self, *_: object, **__: object) -> None:
+        """And the command list beside it — see `bot.configure`."""
+
     async def get_webhook_info(self):
         self.reads += 1
         if self.clear_after is not None and self.reads >= self.clear_after:

--- a/apps/api/tests/test_webhook_watchdog.py
+++ b/apps/api/tests/test_webhook_watchdog.py
@@ -25,6 +25,7 @@ class Telegram:
         self.reads = 0
         self.clear_after = clear_after
         self.dropped: list[bool] = []
+        self.command_lists: list[object] = []
 
     async def set_webhook(self, url: str, **kwargs: object) -> None:
         self.sets += 1
@@ -34,8 +35,9 @@ class Telegram:
     async def set_chat_menu_button(self, **_: object) -> None:
         """Called right after registration, to point the menu at the app."""
 
-    async def set_my_commands(self, *_: object, **__: object) -> None:
+    async def set_my_commands(self, commands, **_: object) -> None:
         """And the command list beside it — see `bot.configure`."""
+        self.command_lists.append(commands)
 
     async def get_webhook_info(self):
         self.reads += 1
@@ -76,6 +78,27 @@ async def test_a_webhook_cleared_by_someone_else_is_set_again(settings) -> None:
 
     assert bot.sets > 1, "the webhook was set once and never restored"
     assert bot.url == settings.webhook_url
+
+
+async def test_the_bot_says_what_it_offers_once_it_can_be_reached(
+    settings,
+) -> None:
+    """Or production keeps serving the previous bot's command list.
+
+    Once, and after the webhook: the list does not change when a webhook is
+    healed, and a call on that path would delay the healing.
+    """
+    from students_cz.main import keep_webhook_registered
+
+    bot = Telegram(clear_after=1)
+    app = _app()
+
+    await _run_briefly(
+        keep_webhook_registered(app, bot, _dispatcher(), settings, recheck_seconds=0.05)
+    )
+
+    assert len(bot.command_lists) == 1
+    assert bot.sets > 1, "the fixture is meant to lose its webhook and heal"
 
 
 async def test_a_webhook_that_stays_put_is_not_set_again(settings) -> None:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,9 +19,18 @@ writes to the bot and a person who opens the app are recorded the same way.
 command list and a chat's reply keyboard until somebody replaces them, and this
 token belonged to a command-driven bot before it belonged to this one — so a
 list nobody sets is the old one, still offering `/language` to a bot that has
-no such command. `bot.configure` sets the two that exist, and any message the
-bot answers clears whatever keyboard is left over from before. Both are the
-same rule as the copy above: what a person is offered has to exist.
+no such command. `bot.configure` sets the two that exist. The old keyboard goes
+the same way: a reply is the only thing that removes one, so `/stop` and every
+message that is neither command carry `ReplyKeyboardRemove` — which is what a
+person with a stale keyboard triggers, because tapping one of its buttons sends
+its label as ordinary text. The greeting is the exception and cannot carry it:
+`reply_markup` holds one thing, and there it is the button that opens the app.
+
+Both are the same rule as the copy above: what a person is offered has to
+exist. And neither is worth a failed registration — `main._describe_bot` sets
+them after the webhook is registered and swallows what Telegram says, because
+a command list that will not set is cosmetic while a webhook that will not set
+is a deaf bot.
 
 **What we say is part of what we do.** A sentence telling somebody how to undo
 something, or who can see their request, or how fast an answer comes, is a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,14 @@ bot handler and an endpoint both have to get right belongs in `services/`, and
 `services/people.remember` is the pattern: both doors call it, so a person who
 writes to the bot and a person who opens the app are recorded the same way.
 
+**What the chat offers is part of what we say.** Telegram remembers a bot's
+command list and a chat's reply keyboard until somebody replaces them, and this
+token belonged to a command-driven bot before it belonged to this one — so a
+list nobody sets is the old one, still offering `/language` to a bot that has
+no such command. `bot.configure` sets the two that exist, and any message the
+bot answers clears whatever keyboard is left over from before. Both are the
+same rule as the copy above: what a person is offered has to exist.
+
 **What we say is part of what we do.** A sentence telling somebody how to undo
 something, or who can see their request, or how fast an answer comes, is a
 claim about the code — and it is the kind that rots quietly, because nobody


### PR DESCRIPTION
Docs updated first: docs/architecture.md

Measured on production today: **Telegram is still serving the previous bot's
menu.** This token answered to a command-driven bot before it answered to this
one, and Telegram keeps a command list until somebody replaces it — so
`/start — 🕹 Обновить меню` and `/language — 🌍 Изменить язык` are what a person
sees, and `/language` is a command nothing in this codebase handles.

The same is true of that bot's reply keyboard: it is still sitting in every
chat it ever had, and only a reply can take it away. Tapping one of its buttons
sends its label as ordinary text — which is exactly what happened today: the
account that pressed one shows a message and no start.

## What changes

- `bot.configure` sets the two commands that exist. The default scope, because
  that is the one holding the old list — checked against production, every
  narrower scope and every language variant is empty.
- Anything that is neither command gets one line back, and that line carries
  `ReplyKeyboardRemove`. A stale-keyboard tap is what triggers it, which is the
  point. `/stop`'s reply carries it too.
- The greeting is the exception and the doc says so: `reply_markup` holds one
  thing, and there it is the button that opens the app.
- `/stop` is described as «Не присылать рассылки» rather than «Не писать мне» —
  the second is the promise `UNSUBSCRIBED` exists to take back, since answers to
  your own requests keep arriving.

## The bug this was sitting on

`configure` ran inside the webhook registration's retry loop — it did before
this branch, but a command list is far likelier to be refused than a menu
button. A reviewer measured it: with `setMyCommands` failing, `set_webhook` was
re-issued **10 377 times** with `drop_pending_updates=True`, throwing away
everything queued between attempts, and `get_webhook_info` was never called
once — the watchdog that heals a cleared webhook never started. On this
deployment, where something outside clears the webhook every few minutes, that
is the difference between a bot that recovers and one that does not.

It runs once on the boot path now, after registration, bounded by the same
timeout as the recheck, and what Telegram says about it is logged and
swallowed: a command list that will not set is cosmetic, a webhook that will
not set is a deaf bot.

## Verification

`make check` green: 468 API tests. Six of them are new and each was checked by
removing what it covers — including deleting the describe call, which the
previous round proved was invisible to CI.

Independent review: approved with no findings, after two rounds that found
eleven defects, two of them blocking: that retry loop, and the `/stop`
description contradicting its own reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiBQbrZrnNrSjgd5ELv9kL
